### PR TITLE
chore(ci): add Fro Bot agent workflow with single-issue autohealing

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -1,0 +1,234 @@
+---
+name: Fro Bot
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  discussion_comment:
+    types: [created]
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, review_requested]
+  schedule:
+    - cron: '0 16 * * *' # Daily at 16:00 UTC
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Custom prompt for the Fro Bot agent
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    fro-bot-${{
+      github.event.issue.number ||
+      github.event.pull_request.number ||
+      github.event.discussion.number ||
+      github.run_id
+    }}
+  cancel-in-progress: false
+
+env:
+  PR_REVIEW_PROMPT: |
+    Review this OpenCode plugin PR focusing on:
+    - TypeScript type safety: no `any`, no `@ts-ignore`/`@ts-expect-error`, proper discriminated unions, satisfies over type annotations where appropriate
+    - OpenCode plugin API contracts: tool schema correctness (`.string()`, `.number()`, etc.), ToolResult shape (`string | { output: string }`), peerDependency compatibility with `@opencode-ai/plugin` and `@opencode-ai/sdk`
+    - Subprocess safety: process spawn correctness, stdin/stdout buffering, signal propagation, process-tree kill, no zombie processes
+    - Tool output safety: no secrets, PATs, tokens, or PII in tool return values or log output
+    - Changeset hygiene: breaking public API changes require a `major` bump, new features require `minor`, bug fixes use `patch`; verify a `.changeset/*.md` is present for user-visible changes
+    Skip style nits — Biome handles formatting and lint.
+
+    Do NOT push commits, modify code, or create branches. Review only.
+    Use inline comments for file-specific issues. Reserve the review body
+    for the structured summary below.
+
+    You MUST structure your review using exactly these headings:
+    ## Verdict: [PASS | CONDITIONAL | REJECT]
+    CONDITIONAL = can merge after addressing the listed blocking issues.
+    ### Blocking issues
+    ### Non-blocking concerns
+    ### Missing tests
+    ### Risk assessment (LOW/MED/HIGH) + rationale
+    Evaluate likelihood of regression, security exposure, or blast radius.
+    Consider impact on parent OpenCode sessions when the plugin crashes or hangs.
+    If a section has no items, write "None" under the heading.
+    Do not omit any heading.
+
+  SCHEDULE_PROMPT: |
+    Perform daily repository autohealing for the opencode-copilot-delegate TypeScript plugin.
+    Work through each category in order, making commits and pushing fixes directly where possible.
+    Prefer minimal diffs. Avoid destructive changes.
+
+    1. ERRORED PRs
+       Find open PRs with failing CI checks. For each failing PR:
+       a. Check out the PR branch.
+       b. Read the failing check logs to diagnose the root cause.
+       c. Fix the issue (type errors, lint failures, build breaks).
+          - `bun run typecheck` — TypeScript strict mode via tsc --noEmit
+          - `bun run lint` — Biome check
+          - `bun run build` — bun build + tsc --emitDeclarationOnly
+       d. Commit with a clear message and push to the PR branch.
+       e. Comment on the PR explaining what failed and what was fixed.
+
+    2. SECURITY
+       Review Dependabot/Renovate alerts and open PRs for vulnerable deps.
+       - If a security update PR exists but has conflicts or failures, fix and push.
+       - For unaddressed critical/high advisories with no existing PR, create one.
+       - Do NOT bulk-update unrelated deps in a security PR.
+
+    3. HEALTH & MAINTENANCE
+       Check for outdated dependencies in package.json:
+       - Verify peerDependency version constraints for `@opencode-ai/plugin` and
+         `@opencode-ai/sdk` are still accurate against latest published versions.
+         If the minimum required version has changed, open a PR updating the constraint.
+       - Check for major version bumps in devDependencies (typescript, @biomejs/biome,
+         @types/bun, @types/node, rimraf). Create one PR per major bump.
+       - Pin any unpinned GitHub Actions in .github/workflows/ to full commit SHAs.
+       Check changeset hygiene:
+       - Verify no unreleased changeset entries have drifted out of sync with package.json version.
+       - Flag any PR that introduces user-visible changes without a corresponding changeset.
+
+    4. DEVELOPER EXPERIENCE
+       Ensure consistent linting, formatting, and static analysis:
+       - Run `bun run lint` (Biome). Fix auto-fixable issues, commit safe formatting fixes
+         directly to the default branch; open a PR for logic-level lint changes.
+       - Run `bun run typecheck`. Fix any type errors introduced since last run.
+       - Run `bun run build`. Fix any build failures.
+       - Verify `bun install` produces no errors or unexpected peer dependency warnings.
+
+    ## SINGLE ISSUE MANAGEMENT
+
+    Manage a SINGLE perpetual issue titled "Daily Autohealing Report".
+
+    ### Finding the Perpetual Issue
+    1. Search for an open issue titled "Daily Autohealing Report" (exact match)
+    2. If found, use that issue for all updates
+    3. If not found, create a new issue with that exact title
+
+    ### Updating the Issue
+    After completing all work, ADD a dated update section to the TOP of the issue body:
+
+    ```markdown
+    ## Update — YYYY-MM-DD
+
+    ### Summary
+    | Category | Status | Actions |
+    |----------|--------|---------|
+    | ERRORED PRs | ✅ / ⚠️ / ❌ | description |
+    | SECURITY | ✅ / ⚠️ / ❌ | description |
+    | HEALTH & MAINTENANCE | ✅ / ⚠️ / ❌ | description |
+    | DEVELOPER EXPERIENCE | ✅ / ⚠️ / ❌ | description |
+
+    ### Tasks for Fro Bot
+    - [ ] Task description (PAT-powered, multi-step work)
+
+    ### Tasks for Copilot
+    - [ ] Task description (assigned task → single PR)
+
+    ### Items Needing Human Attention
+    - Description of blockers or decisions needed
+
+    ---
+    ```
+
+    ### Rules
+    - DO NOT create new daily issues
+    - DO NOT close the perpetual issue
+    - ALWAYS prepend new updates to existing content (newest at top)
+    - Use the Task structure above for delegation to Fro Bot and Copilot agents
+
+    Do NOT comment on individual issues. Update the single perpetual issue only.
+
+jobs:
+  fro-bot:
+    name: Fro Bot
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+    if: >-
+      (
+        github.event.pull_request == null ||
+        (
+          !github.event.pull_request.head.repo.fork &&
+          !endsWith(github.event.pull_request.user.login || '', '[bot]')
+        )
+      ) && (
+        (
+          github.event_name == 'issues' &&
+          !endsWith(github.event.issue.user.login || '', '[bot]') &&
+          (github.event.issue.user.login || '') != 'fro-bot'
+        ) ||
+        (
+          github.event_name == 'pull_request' &&
+          !endsWith(github.event.pull_request.user.login || '', '[bot]') &&
+          (github.event.pull_request.user.login || '') != 'fro-bot'
+        ) ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          (github.event_name == 'issue_comment' ||
+           github.event_name == 'pull_request_review_comment' ||
+           github.event_name == 'discussion_comment') &&
+          contains(github.event.comment.body || '', '@fro-bot') &&
+          (github.event.comment.user.login || '') != 'fro-bot' &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || '')
+        )
+      )
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: >-
+            ${{
+              (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number))
+              || github.event.pull_request.head.sha
+              || ''
+            }}
+          token: >-
+            ${{
+              github.event_name == 'workflow_dispatch'
+              && secrets.GITHUB_TOKEN
+              || secrets.FRO_BOT_PAT
+            }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Fro Bot
+        uses: fro-bot/agent@fc1387ec5c25afed73b11b8b26c482b90b3ad9cd # v0.41.0
+        env:
+          OPENCODE_PROMPT_ARTIFACT: 'true'
+          PROMPT: >-
+            ${{
+              (github.event_name == 'workflow_dispatch' && (github.event.inputs.prompt || ''))
+              || (github.event_name == 'schedule' && env.SCHEDULE_PROMPT)
+              || (github.event_name == 'pull_request' && env.PR_REVIEW_PROMPT)
+              || ''
+            }}
+        with:
+          github-token: >-
+            ${{
+              github.event_name == 'workflow_dispatch'
+              && secrets.GITHUB_TOKEN
+              || secrets.FRO_BOT_PAT
+            }}
+          auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
+          model: ${{ vars.FRO_BOT_MODEL }}
+          prompt: ${{ env.PROMPT }}
+          omo-providers: ${{ secrets.OMO_PROVIDERS }}
+          opencode-config: ${{ secrets.OPENCODE_CONFIG }}

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -148,12 +148,6 @@ jobs:
   fro-bot:
     name: Fro Bot
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: write
-      discussions: write
-      issues: write
-      pull-requests: write
     if: >-
       (
         github.event.pull_request == null ||
@@ -194,12 +188,7 @@ jobs:
               || github.event.pull_request.head.sha
               || ''
             }}
-          token: >-
-            ${{
-              github.event_name == 'workflow_dispatch'
-              && secrets.GITHUB_TOKEN
-              || secrets.FRO_BOT_PAT
-            }}
+          token: ${{ secrets.FRO_BOT_PAT }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -221,13 +210,8 @@ jobs:
               || ''
             }}
         with:
-          github-token: >-
-            ${{
-              github.event_name == 'workflow_dispatch'
-              && secrets.GITHUB_TOKEN
-              || secrets.FRO_BOT_PAT
-            }}
           auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
           model: ${{ vars.FRO_BOT_MODEL }}
           prompt: ${{ env.PROMPT }}
           omo-providers: ${{ secrets.OMO_PROVIDERS }}

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -8,6 +8,8 @@ on:
     types: [created]
   discussion_comment:
     types: [created]
+  issues:
+    types: [opened, edited]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, review_requested]
   schedule:
@@ -159,6 +161,12 @@ jobs:
           !endsWith(github.event.pull_request.user.login || '', '[bot]') &&
           (github.event.pull_request.user.login || '') != 'fro-bot'
         ) ||
+        (
+          github.event_name == 'issues' &&
+          !endsWith(github.event.issue.user.login || '', '[bot]') &&
+          (github.event.issue.user.login || '') != 'fro-bot' &&
+          contains(github.event.issue.body || '', '@fro-bot')
+        ) ||
         github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch' ||
         (
@@ -200,6 +208,7 @@ jobs:
               (github.event_name == 'workflow_dispatch' && (github.event.inputs.prompt || ''))
               || (github.event_name == 'schedule' && env.SCHEDULE_PROMPT)
               || (github.event_name == 'pull_request' && env.PR_REVIEW_PROMPT)
+              || (github.event_name == 'issues' && github.event.issue.body)
               || ''
             }}
         with:

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -208,7 +208,6 @@ jobs:
               (github.event_name == 'workflow_dispatch' && (github.event.inputs.prompt || ''))
               || (github.event_name == 'schedule' && env.SCHEDULE_PROMPT)
               || (github.event_name == 'pull_request' && env.PR_REVIEW_PROMPT)
-              || (github.event_name == 'issues' && github.event.issue.body)
               || ''
             }}
         with:

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -8,8 +8,6 @@ on:
     types: [created]
   discussion_comment:
     types: [created]
-  issues:
-    types: [opened, edited]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, review_requested]
   schedule:
@@ -157,11 +155,6 @@ jobs:
         )
       ) && (
         (
-          github.event_name == 'issues' &&
-          !endsWith(github.event.issue.user.login || '', '[bot]') &&
-          (github.event.issue.user.login || '') != 'fro-bot'
-        ) ||
-        (
           github.event_name == 'pull_request' &&
           !endsWith(github.event.pull_request.user.login || '', '[bot]') &&
           (github.event.pull_request.user.login || '') != 'fro-bot'
@@ -191,7 +184,7 @@ jobs:
           token: ${{ secrets.FRO_BOT_PAT }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/fro-bot.yaml` — the Fro Bot agent workflow, adapted from the canonical `fro-bot/agent` example and the single-issue autohealing strategy used in `marcusrbrown/containers`.

## What's included

**PR review** (`pull_request` trigger):
- Structured `PASS / CONDITIONAL / REJECT` verdict with required headings
- Plugin-specific focus: TypeScript type safety, OpenCode API contracts (`ToolResult` shape, peerDep compatibility), subprocess safety, tool output safety (no secrets/PII), changeset hygiene

**Daily autohealing** (`schedule` trigger — 16:00 UTC):
- Adapted from the containers perpetual single-issue strategy
- Covers: errored PRs (diagnose + fix + push), security alerts, health & maintenance (peerDep version drift, major dep bumps, SHA-pinning of unpinned actions), developer experience (`bun run typecheck`, `bun run lint`, `bun run build`)
- Manages a single perpetual "Daily Autohealing Report" issue — prepends newest section to top, never creates daily issues

**Mention-based** (`issue_comment`, `pull_request_review_comment`, `discussion_comment`):
- `@fro-bot` in any comment by OWNER/MEMBER/COLLABORATOR triggers the agent

**Manual dispatch** (`workflow_dispatch`):
- Free-form prompt via GitHub UI, runs with `GITHUB_TOKEN` (not `FRO_BOT_PAT`)

## Security

- `actions/checkout` pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- `fro-bot/agent` pinned to `fc1387ec5c25afed73b11b8b26c482b90b3ad9cd` (v0.41.0)
- `oven-sh/setup-bun@v2` — needs SHA pin (see next steps)
- Workflow-level permissions: `contents: read` baseline; job grants `contents: write`, `issues: write`, `pull-requests: write`, `discussions: write`

## Required secrets / vars

| Name | Where | Notes |
|------|-------|-------|
| `FRO_BOT_PAT` | Repo secret | PAT for the `fro-bot` user |
| `OPENCODE_AUTH_JSON` | Repo secret | `{"anthropic":{"apiKey":"..."}}` |
| `OMO_PROVIDERS` | Repo secret | OMO provider config |
| `OPENCODE_CONFIG` | Repo secret | OpenCode config JSON |
| `FRO_BOT_MODEL` | Repo variable | Model ID (e.g. `anthropic/claude-opus-4-5`) |

## Next steps

- [ ] Pin `oven-sh/setup-bun@v2` to a full commit SHA
- [ ] Add repo secrets: `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`, `OPENCODE_CONFIG`
- [ ] Add repo variable: `FRO_BOT_MODEL`
- [ ] After T11 (CI) lands, revisit autohealing category 1 (errored PRs) to reference the actual check names