### PR TITLE
fix(biome): correct config keys for Biome 1.9.4

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "assist": {"actions": {"source": {"organizeImports": "on"}}},
+  "organizeImports": { "enabled": true },
   "linter": {
     "enabled": true,
     "rules": {
@@ -25,6 +25,6 @@
     }
   },
   "files": {
-    "includes": ["**", "!**/dist", "!**/node_modules", "!**/.changeset"]
+    "ignore": ["dist", "node_modules", ".changeset"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE",
-    "CHANGELOG.md"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "keywords": [
     "opencode",
     "opencode-plugin",


### PR DESCRIPTION
Fixes three schema errors in `biome.json` that caused `bun run lint` to fail.

- `assist` → top-level `organizeImports: {enabled: true}`
- `files.includes` → `files.ignore` with plain directory names
- Auto-applied formatter drift via `biome check --write`

Verified: `bun run lint` and `bun run fix` both clean (16 files).