### PR TITLE
chore(settings): add repo settings and update-repo-settings workflow

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,7 +12,7 @@ branches:
     protection:
       required_status_checks:
         strict: true
-        # T11 will expand this list once CI workflows exist (Build, Typecheck, Lint, Test, etc.)
+        # Expand this list once CI workflows exist (Build, Typecheck, Lint, Test, etc.)
         contexts:
           - Fro Bot
       enforce_admins: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,21 @@
+---
+_extends: .github:common-settings.yaml
+
+repository:
+  name: opencode-copilot-delegate
+  description: OpenCode plugin that spawns GitHub Copilot CLI (copilot -p) as a background subprocess
+  homepage: https://www.npmjs.com/package/opencode-copilot-delegate
+  topics: opencode, plugin, copilot, github-copilot, typescript, bun
+
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        # T11 will expand this list once CI workflows exist (Build, Typecheck, Lint, Test, etc.)
+        contexts:
+          - Fro Bot
+      enforce_admins: true
+      required_pull_request_reviews: null
+      restrictions: null
+      required_linear_history: true

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -1,0 +1,25 @@
+---
+name: Update Repo Settings
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/settings.yml'
+      - '.github/workflows/update-repo-settings.yaml'
+  schedule:
+    - cron: '55 2 * * *'
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  update-repo-settings:
+    name: Update Repository Settings
+    uses: bfra-me/.github/.github/workflows/update-repo-settings.yaml@f6a7976c5cc48af150f7de3df331362262f15a18
+    secrets:
+      APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+      APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}


### PR DESCRIPTION
Adds declarative repo settings via the `bfra-me/.github` reusable workflow pattern used across `systematic`, `containers`, and dotfiles.

## What

- `.github/settings.yml` — extends `bfra-me/.github:common-settings.yaml` (squash-only, auto-merge, delete-on-merge, no wiki/projects), sets repo description + topics, enforces linear history + `enforce_admins` on `main`, requires `Fro Bot` as the lone status check until CI workflows land
- `.github/workflows/update-repo-settings.yaml` — calls the SHA-pinned reusable workflow from `bfra-me/.github` on push to settings files, daily at 02:55 UTC, and `workflow_dispatch`

## Prerequisites

Requires `APPLICATION_ID` and `APPLICATION_PRIVATE_KEY` repo secrets (GitHub App credentials for `bfra-me/.github`). The Fro Bot and Renovate secrets added previously are separate from these.

## Follow-up

When CI workflows land, expand `required_status_checks.contexts` in `.github/settings.yml` to include Build, Typecheck, Lint, Test, and any CodeQL/Renovate checks.