### PR TITLE
fix(settings): remove concurrency block causing deadlock with reusable workflow

### DIFF
--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - '.github/settings.yml'
+      - '.github/workflows/update-repo-settings.yaml'
   schedule:
     - cron: '55 2 * * *'
   workflow_dispatch:

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -1,4 +1,5 @@
 ---
+# Update repository settings to match the definitions in .github/settings.yml.
 name: Update Repo Settings
 
 on:
@@ -6,12 +7,9 @@ on:
     branches: [main]
     paths:
       - '.github/settings.yml'
-      - '.github/workflows/update-repo-settings.yaml'
   schedule:
     - cron: '55 2 * * *'
   workflow_dispatch:
-
-concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: read
@@ -19,7 +17,7 @@ permissions:
 jobs:
   update-repo-settings:
     name: Update Repository Settings
-    uses: bfra-me/.github/.github/workflows/update-repo-settings.yaml@f6a7976c5cc48af150f7de3df331362262f15a18
     secrets:
       APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
       APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+    uses: bfra-me/.github/.github/workflows/update-repo-settings.yaml@f6a7976c5cc48af150f7de3df331362262f15a18


### PR DESCRIPTION
The `concurrency:` key on the caller workflow conflicted with the same key inside `bfra-me/.github`'s reusable workflow — both resolved to the same group name, producing a deadlock on the first push to `main`.

Fix: remove `concurrency:` from the caller entirely, matching the pattern in `systematic` and other repos that use this reusable. Also removes the workflow file itself from push `paths:` (only `.github/settings.yml` changes should trigger the job).