### PR TITLE
docs(readme): fix Copilot CLI install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ When the subprocess completes, a `<system-reminder>` notification is injected in
 Requires the `copilot` CLI to be on `PATH`. Install via:
 
 ```sh
-gh extension install github/gh-copilot
+# npm (recommended)
+npm install -g @github/copilot
+
+# Homebrew
+brew install copilot-cli
+
+# Install script (CI-friendly)
+curl -fsSL https://gh.io/copilot-install | bash
 ```
 
 ## Authentication


### PR DESCRIPTION
Replaces `gh extension install github/gh-copilot` with the correct install methods for the standalone `copilot` binary. The extension command installs the legacy `gh copilot` chat helper — a different product that is not the binary this plugin invokes.

Correct options per the official Copilot CLI docs:
- `npm install -g @github/copilot` (recommended)
- `brew install copilot-cli`
- `curl -fsSL https://gh.io/copilot-install | bash` (CI-friendly)