### PR TITLE
Add subprocess wrapper, notification injection, and agent discovery

### DIFF
--- a/.changeset/subprocess-agents-notify.md
+++ b/.changeset/subprocess-agents-notify.md
@@ -1,0 +1,11 @@
+---
+"opencode-copilot-delegate": minor
+---
+
+Add subprocess wrapper, task registry, notification injection, and agent discovery
+
+- Subprocess spawning with line-buffered JSONL parsing, auth token env precedence, and abort-based cancellation via fkill process group kills
+- In-memory task registry with cleanup-all lifecycle
+- Notification injection using noReply semantics with per-session in-flight counters
+- Agent discovery scanning builtin, user, and repo directories with override semantics
+- ANSI escape sequence stripping for clean error/message text

--- a/.context/systematic/ce-review/20260423-154842-9db4dc23/adversarial-reviewer.json
+++ b/.context/systematic/ce-review/20260423-154842-9db4dc23/adversarial-reviewer.json
@@ -1,0 +1,189 @@
+{
+  "reviewer": "adversarial",
+  "findings": [
+    {
+      "title": "Cascade: fire-and-forget killProcessTree in abort handler becomes unhandled rejection",
+      "technique": "cascade construction",
+      "confidence": 0.85,
+      "severity": "high",
+      "description": "The abort handler in subprocess.ts calls `void killProcessTree(task.pid)`, discarding the returned promise. If fkill throws (process already dead, permission denied, timeout), the rejection is unhandled. In Node.js strict mode this crashes the parent process.",
+      "evidence": [
+        "subprocess.ts line 141: `void killProcessTree(task.pid)`",
+        "kill-tree.ts uses fkill with 5s timeout; fkill throws on timeout",
+        "No try/catch or .catch() around the voided promise",
+        "Node.js treats unhandled promise rejections as fatal in modern configurations"
+      ],
+      "affected_files": ["src/runtime/subprocess.ts", "src/lib/kill-tree.ts"],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Composition failure: cleanupAll and abort handler race to kill the same PID",
+      "technique": "composition failure",
+      "confidence": 0.9,
+      "severity": "high",
+      "description": "cleanupAll calls abortController.abort() then checks task.status === 'running' and awaits killProcessTree. The abort event listener is scheduled on the next tick. If it hasn't executed yet, cleanupAll sees status 'running' and starts killing. Then the abort listener runs, sees status is still 'running' (on its own desynchronized object), and calls killProcessTree again. Both calls target the same PID concurrently.",
+      "evidence": [
+        "task-registry.ts lines 55-60: abort() followed by status check and killProcessTree",
+        "subprocess.ts lines 133-144: abort listener checks status and calls killProcessTree",
+        "The abort listener modifies SpawnCopilotResult.status while cleanupAll inspects TaskState.status — they are independent primitives due to createTask spreading input",
+        "Result: fkill invoked twice on same PID; second call may throw or kill a reused PID"
+      ],
+      "affected_files": [
+        "src/runtime/task-registry.ts",
+        "src/runtime/subprocess.ts"
+      ],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Assumption violation: parseJsonlLine throwing crashes the Node.js process",
+      "technique": "assumption violation",
+      "confidence": 0.8,
+      "severity": "high",
+      "description": "The stdout 'data' handler and flushBufferedStdout both call parseJsonlLine without try/catch. If parseJsonlLine throws on malformed JSONL, the exception propagates out of an EventEmitter handler. Node.js emits an 'error' event on the stream; if unhandled, the process terminates.",
+      "evidence": [
+        "subprocess.ts line 124: `const event = parseJsonlLine(line)` inside data handler",
+        "subprocess.ts line 32: `task.events.push(parseJsonlLine(task.stdoutLineBuffer))` inside flushBufferedStdout",
+        "No try/catch around either call",
+        "Node.js stream documentation: uncaught exceptions in data handlers crash the process"
+      ],
+      "affected_files": ["src/runtime/subprocess.ts"],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Resource exhaustion: unbounded stdout, stderr, and event accumulation",
+      "technique": "abuse case",
+      "confidence": 0.95,
+      "severity": "medium",
+      "description": "The events array, stderrText string, and stdoutLineBuffer all grow without limits. A misbehaving or adversarial copilot subprocess can emit massive output without newlines or a high volume of JSONL events, causing unbounded memory growth in the parent process. No backpressure or size caps are applied.",
+      "evidence": [
+        "subprocess.ts line 124: `events.push(event)` in an unbounded array",
+        "subprocess.ts line 113: `task.stdoutLineBuffer += chunk` with no max size",
+        "subprocess.ts line 130: `stderrText += chunk` with no max size",
+        "If child outputs a multi-gigabyte line without \\n, stdoutLineBuffer retains it all"
+      ],
+      "affected_files": ["src/runtime/subprocess.ts"],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Abuse case: orphaned in-flight counters leak memory and permanently break noReply semantics",
+      "technique": "abuse case",
+      "confidence": 0.9,
+      "severity": "medium",
+      "description": "If incrementInFlight is called but notifyCompletion is never reached (e.g., subprocess crashes before close event, or orchestrator forgets), the counter stays elevated forever. Additionally, when a counter reaches zero, the Map entry is retained instead of deleted. Over a long-lived process with many sessions, this leaks memory and permanently breaks noReply semantics.",
+      "evidence": [
+        "notify.ts lines 49-52: incrementInFlight adds to Map but never removes entry",
+        "notify.ts lines 105-107: decrement computes Math.max(0, current-1) and sets value 0, keeping the key",
+        "No cleanup or TTL for zero-value entries",
+        "A caller spawning tasks without corresponding notification calls breaks the counter permanently"
+      ],
+      "affected_files": ["src/runtime/notify.ts"],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Composition failure: registry task state is permanently desynchronized from subprocess",
+      "technique": "composition failure",
+      "confidence": 0.9,
+      "severity": "high",
+      "description": "spawnCopilot creates a SpawnCopilotResult with mutable fields (status, exitCode, events, stdoutLineBuffer). createTask copies initial values into an independent TaskState. As the subprocess runs, spawnCopilot mutates its own object. The registry copy never receives these updates. Code querying the registry sees stale data (status still 'running', empty events, no exitCode).",
+      "evidence": [
+        "subprocess.ts lines 97-107: spawnCopilot creates local task object and mutates it in event handlers",
+        "task-registry.ts lines 31-39: createTask spreads input into a new object with a new taskId",
+        "spawnCopilot generates taskId independently; createTask generates another",
+        "No mechanism syncs subprocess mutations back to the registry entry"
+      ],
+      "affected_files": [
+        "src/runtime/subprocess.ts",
+        "src/runtime/task-registry.ts"
+      ],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Assumption violation: PID reuse can cause killProcessTree to kill an unrelated process",
+      "technique": "assumption violation",
+      "confidence": 0.7,
+      "severity": "medium",
+      "description": "task.pid retains the child PID even after the process exits. Under high process churn, the OS can reuse that PID for a new unrelated process. If a delayed abort, retry, or second cleanup call invokes killProcessTree(task.pid) after natural exit, it may terminate the wrong process. cleanupAll checks task.status, but other call sites (not visible in diff) might not.",
+      "evidence": [
+        "subprocess.ts line 99: `pid: child.pid ?? -1` stored once and never cleared",
+        "kill-tree.ts line 14: `await fkill(-pid, options)` kills by raw PID",
+        "No verification that the PID still belongs to the expected process",
+        "OS PID reuse is a documented behavior on all platforms"
+      ],
+      "affected_files": ["src/runtime/subprocess.ts", "src/lib/kill-tree.ts"],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Abuse case: notifyCompletion without matching incrementInFlight forces parent turn",
+      "technique": "abuse case",
+      "confidence": 0.85,
+      "severity": "medium",
+      "description": "notifyCompletion decrements the counter for the given parentSessionID. If incrementInFlight was never called for that session, the counter is 0, decrement clamps to 0, and noReply is set to false. This forces a parent turn. Any component with access to notifyCompletion can inject notifications that demand parent attention, regardless of actual in-flight state.",
+      "evidence": [
+        "notify.ts lines 105-107: `const remaining = Math.max(0, current - 1)`",
+        "notify.ts lines 110-113: noReply is false when remaining === 0 and status is not failed/cancelled",
+        "No validation that the session ID was ever registered or that the task is known",
+        "Public export of notifyCompletion allows arbitrary callers"
+      ],
+      "affected_files": ["src/runtime/notify.ts"],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Cascade: cleanupAll can orphan tasks added during its async window",
+      "technique": "cascade construction",
+      "confidence": 0.85,
+      "severity": "medium",
+      "description": "cleanupAll snapshots the task list, awaits kills, then clears the map. A task added after the snapshot but before tasks.clear() is removed from the registry without being aborted or killed. The subprocess runs as an orphan, untracked and unreachable through getTask.",
+      "evidence": [
+        "task-registry.ts lines 51-63: snapshot `[...tasks.values()]`, await Promise.allSettled, then `tasks.clear()`",
+        "No lock prevents createTask from running during the async gap",
+        "The new task's abortController is never triggered, and killProcessTree is never called",
+        "Child process continues running with no registry reference"
+      ],
+      "affected_files": ["src/runtime/task-registry.ts"],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "title": "Assumption violation: negative PID to fkill assumes Unix process group semantics",
+      "technique": "assumption violation",
+      "confidence": 0.65,
+      "severity": "medium",
+      "description": "killProcessTree passes `-pid` to fkill, relying on Unix behavior where a negative PID targets a process group. On Windows, `detached: true` in spawn() does not create a POSIX process group. fkill's behavior with negative PIDs on Windows is undefined in this context, and grandchild processes may survive the kill. This breaks the process-tree kill guarantee on Windows.",
+      "evidence": [
+        "src/lib/kill-tree.ts line 14: `await fkill(-pid, options)`",
+        "src/runtime/subprocess.ts line 90: `detached: true`",
+        "Node.js docs: detached behavior differs significantly between Unix and Windows",
+        "No platform-specific handling or fallback"
+      ],
+      "affected_files": ["src/lib/kill-tree.ts", "src/runtime/subprocess.ts"],
+      "autofix_class": "advisory",
+      "owner": "human"
+    }
+  ],
+  "residual_risks": [
+    "fkill dependency may have additional platform-specific edge cases not visible in this diff (e.g., EPERM on macOS for root-owned processes)",
+    "parseJsonlLine implementation is not in diff; if it performs recursive parsing or regex on large input, it could be a DoS vector",
+    "Orchestrator code that links spawnCopilot, createTask, and notifyCompletion is not in diff; any bugs in that glue multiply the risks above",
+    "No signal handling for SIGTERM/SIGINT of the parent process itself; orphaned children may outlive the parent"
+  ],
+  "testing_gaps": [
+    "Malformed JSONL output from child: no test verifies behavior when parseJsonlLine throws",
+    "Memory pressure scenario: no test for massive single-line stdout or high-volume event streams",
+    "Double-kill race: no test simulates cleanupAll running concurrently with a natural child exit",
+    "PID reuse: no test verifies behavior when a task's PID is reused after exit",
+    "Counter leak: no test for incrementInFlight without matching notifyCompletion",
+    "Unauthorized notification: no test for notifyCompletion with an unregistered parentSessionID",
+    "Registry staleness: no test verifies that registry task state reflects subprocess completion",
+    "Windows process group kill: no cross-platform test for grandchild cleanup",
+    "Parent process signal handling: no test for SIGTERM during active subprocesses",
+    "fkill timeout failure: no test for killProcessTree when process ignores SIGTERM and survives past waitForExit"
+  ]
+}

--- a/.context/systematic/ce-review/20260423-154842-9db4dc23/correctness-reviewer.json
+++ b/.context/systematic/ce-review/20260423-154842-9db4dc23/correctness-reviewer.json
@@ -1,0 +1,140 @@
+{
+  "reviewer": "correctness",
+  "findings": [
+    {
+      "title": "stdout data handler crashes on malformed JSONL and corrupts buffer state",
+      "severity": "P0",
+      "file": "src/runtime/subprocess.ts",
+      "line": 123,
+      "confidence": 0.88,
+      "autofix_class": "safe_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "Wrap `parseJsonlLine(line)` in a try/catch inside the `child.stdout.on('data')` handler. On parse failure, push a synthetic `{ type: 'error', data: { message: ... } }` event (or skip the line), and ensure `task.stdoutLineBuffer` is still cleared so the bad line is not re-parsed on every subsequent chunk."
+    },
+    {
+      "title": "assignFinalMessage crashes when message event lacks `data` property",
+      "severity": "P1",
+      "file": "src/runtime/subprocess.ts",
+      "line": 40,
+      "confidence": 0.92,
+      "autofix_class": "safe_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "Change `const content = lastMessage?.data.content` to `const content = lastMessage?.data?.content` to guard against `data` being undefined or null."
+    },
+    {
+      "title": "Spawn error status and errorText overwritten by close handler",
+      "severity": "P1",
+      "file": "src/runtime/subprocess.ts",
+      "line": 147,
+      "confidence": 0.85,
+      "autofix_class": "safe_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "In `finalizeTask`, add an early return or guard `if (task.status === 'failed') return;` before overwriting `task.status` and `task.errorText`, so that spawn errors (set in the `child.once('error')` handler) are not lost when the `close` event fires."
+    },
+    {
+      "title": "User/repo agents can collide with built-in names",
+      "severity": "P2",
+      "file": "src/discovery/agents.ts",
+      "line": 52,
+      "confidence": 0.85,
+      "autofix_class": "gated_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "Add `const builtinNames = new Set(BUILTIN_AGENTS)` and filter `userAgents` and `repoAgents` against it before concatenation, so the invariant 'built-ins are not overridden' is actually enforced. Also add a fixture named `default.md` to the collision test so it exercises the real case."
+    },
+    {
+      "title": "Task registry leaks completed tasks forever",
+      "severity": "P2",
+      "file": "src/runtime/task-registry.ts",
+      "line": 29,
+      "confidence": 0.8,
+      "autofix_class": "gated_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "Provide a `removeTask(taskId: string)` function and call it from the subprocess completion path (or from `finalizeTask`) so the global `tasks` Map does not grow unbounded. Alternatively, wire `spawnCopilot` into `createTask` so the registry is actually used, and clean up on completion."
+    },
+    {
+      "title": "inFlightCounters Map leaks finished sessions",
+      "severity": "P2",
+      "file": "src/runtime/notify.ts",
+      "line": 105,
+      "confidence": 0.8,
+      "autofix_class": "safe_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "After decrementing, delete the entry when it reaches zero: `if (remaining === 0) { inFlightCounters.delete(task.parentSessionID); }`."
+    },
+    {
+      "title": "Duplicate notifyCompletion calls drain counter prematurely",
+      "severity": "P2",
+      "file": "src/runtime/notify.ts",
+      "line": 105,
+      "confidence": 0.75,
+      "autofix_class": "gated_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "Add a `Set<string>` of already-notified `taskId`s. At the top of `notifyCompletion`, return early if the task was already processed."
+    },
+    {
+      "title": "Unhandled rejection from fire-and-forget killProcessTree",
+      "severity": "P2",
+      "file": "src/runtime/subprocess.ts",
+      "line": 141,
+      "confidence": 0.7,
+      "autofix_class": "safe_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "Change `void killProcessTree(task.pid)` to `killProcessTree(task.pid).catch((err) => { /* log or ignore */ })` to prevent unhandled promise rejections if `fkill` fails for any reason other than invalid PID."
+    },
+    {
+      "title": "Missing `crypto` import relies on global",
+      "severity": "P2",
+      "file": "src/runtime/subprocess.ts",
+      "line": 98,
+      "confidence": 0.7,
+      "autofix_class": "safe_auto",
+      "owner": "review-fixer",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "Add `import { randomUUID } from 'node:crypto'` and replace `crypto.randomUUID()` with `randomUUID()`. Apply the same fix in `src/runtime/task-registry.ts` line 32."
+    },
+    {
+      "title": "Cancelled tasks force parent turn even when other tasks are in flight",
+      "severity": "P3",
+      "file": "src/runtime/notify.ts",
+      "line": 111,
+      "confidence": 0.6,
+      "autofix_class": "advisory",
+      "owner": "human",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "Clarify whether cancelled tasks should force a parent turn. If only failures should force a turn, change the condition to `task.status === 'failed' ? false : remaining > 0`. Otherwise, update the comment to explicitly include 'cancelled'."
+    }
+  ],
+  "residual_risks": [
+    "`parseJsonlLine` implementation was not in the diff. If it throws on malformed input (likely), the uncaught-exception finding above is critical. If it already swallows errors and returns a safe object, the severity drops — verify its contract.",
+    "`fkill` with a negative PID relies on Unix process-group semantics. On Windows, behavior may differ and `killProcessTree` might not terminate grandchildren. Cross-platform correctness depends on `fkill` internals.",
+    "`stripAnsi` regex is heuristic. Exotic terminal sequences may slip through and corrupt the `finalMessage` or `errorText`, but this is cosmetic and low-risk.",
+    "`spawnCopilot` does not register the spawned task in `task-registry`. If production code expects the registry to contain all tasks, the two modules are effectively disconnected, which may indicate an incomplete integration rather than a standalone bug."
+  ],
+  "testing_gaps": [
+    "No test for malformed/non-JSONL stdout lines in `subprocess.test.ts`. Add a case where the fake copilot emits garbage on stdout to verify the parser does not crash the host.",
+    "No test for `lastMessage` event missing the `data` property. Add a parsed event `{ type: 'message' }` without `data` to verify `assignFinalMessage` does not throw.",
+    "No test for simultaneous spawn error + non-zero exit. Verify that `task.status` remains 'failed' and the original spawn error message is preserved in `task.errorText`.",
+    "The test 'should not override built-in agents with user or repo agents of the same name' does not actually create a name collision. Add a `default.md` fixture or temporarily create one to test the real merge behavior.",
+    "No test for duplicate `notifyCompletion` calls. Verify that calling it twice for the same task does not decrement the counter twice.",
+    "No test for `notifyCompletion` with `status: 'cancelled'` and remaining in-flight tasks. Verify the `noReply` behavior matches the intended design.",
+    "No test verifying `endedAt` is populated on task completion. Since the field exists on `TaskState` but is never assigned, a test would expose the missing implementation."
+  ]
+}

--- a/.context/systematic/ce-review/20260423-154842-9db4dc23/diff.patch
+++ b/.context/systematic/ce-review/20260423-154842-9db4dc23/diff.patch
@@ -1,0 +1,1432 @@
+diff --git a/src/discovery/agents.ts b/src/discovery/agents.ts
+index f0aa6db..2e2f22b 100644
+--- a/src/discovery/agents.ts
++++ b/src/discovery/agents.ts
+@@ -1 +1,56 @@
+-// TODO: implement in T5 — agent file discovery
++import { readdirSync } from 'node:fs'
++import { basename } from 'node:path'
++
++export interface Agent {
++  name: string
++  source: 'builtin' | 'user' | 'repo'
++}
++
++const BUILTIN_AGENTS: readonly string[] = [
++  'default',
++  'explore',
++  'task',
++  'general-purpose',
++  'code-review',
++  'research',
++]
++
++interface DiscoverOptions {
++  userAgentsDir?: string
++  repoAgentsDir?: string
++}
++
++function scanDir(dir: string, source: 'user' | 'repo'): Agent[] {
++  try {
++    const entries = readdirSync(dir)
++    return entries
++      .filter((f) => f.endsWith('.md'))
++      .map((f) => ({
++        name: basename(f, '.md'),
++        source,
++      }))
++  } catch {
++    return []
++  }
++}
++
++export function discoverAgents(opts: DiscoverOptions): Agent[] {
++  const builtins: Agent[] = BUILTIN_AGENTS.map((name) => ({
++    name,
++    source: 'builtin',
++  }))
++
++  const userAgents = opts.userAgentsDir
++    ? scanDir(opts.userAgentsDir, 'user')
++    : []
++
++  const repoAgents = opts.repoAgentsDir
++    ? scanDir(opts.repoAgentsDir, 'repo')
++    : []
++
++  // Repo overrides user with same name
++  const overriddenNames = new Set(repoAgents.map((a) => a.name))
++  const filteredUser = userAgents.filter((a) => !overriddenNames.has(a.name))
++
++  return [...builtins, ...filteredUser, ...repoAgents]
++}
+diff --git a/src/discovery/description.ts b/src/discovery/description.ts
+index fceb7fe..dfffe5e 100644
+--- a/src/discovery/description.ts
++++ b/src/discovery/description.ts
+@@ -1 +1,22 @@
+-// TODO: implement in T5 — build copilot_delegate description string
++import type { Agent } from './agents'
++
++const MAX_DISPLAYED = 20
++
++export function buildDescription(agents: Agent[]): string {
++  const displayed = agents.slice(0, MAX_DISPLAYED)
++  const remaining = agents.length - MAX_DISPLAYED
++
++  const lines = ['Available Copilot agents:']
++
++  for (const agent of displayed) {
++    lines.push(`  - ${agent.name} (${agent.source})`)
++  }
++
++  if (remaining > 0) {
++    lines.push(
++      `  ... and ${remaining} more (use copilot_list_agents to see all)`,
++    )
++  }
++
++  return lines.join('\n')
++}
+diff --git a/src/lib/ansi.ts b/src/lib/ansi.ts
+index e3bfe8f..1d86981 100644
+--- a/src/lib/ansi.ts
++++ b/src/lib/ansi.ts
+@@ -1 +1,9 @@
+-// TODO: implement in T3 — ANSI escape sequence stripper
++// biome-ignore lint/complexity/useRegexLiterals: constructor avoids control-character regex literal lint
++const ANSI_ESCAPE_PATTERN = new RegExp(
++  '(?:\\u001B|\\u009B)[[\\]()#;?]*(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]|(?:[\\dA-PR-TZcf-nq-uy=><~]))',
++  'g',
++)
++
++export function stripAnsi(text: string): string {
++  return text.replace(ANSI_ESCAPE_PATTERN, '')
++}
+diff --git a/src/lib/kill-tree.ts b/src/lib/kill-tree.ts
+index 10ef90c..9c96590 100644
+--- a/src/lib/kill-tree.ts
++++ b/src/lib/kill-tree.ts
+@@ -1 +1,15 @@
+-// TODO: implement in T3 — cross-platform process tree kill
++import fkill from 'fkill'
++
++export async function killProcessTree(pid: number): Promise<void> {
++  if (!Number.isFinite(pid) || pid <= 0) {
++    return
++  }
++
++  const options = {
++    force: false,
++    forceAfterTimeout: 2000,
++    waitForExit: 5000,
++  }
++
++  await fkill(-pid, options)
++}
+diff --git a/src/runtime/notify.ts b/src/runtime/notify.ts
+index f2310b6..7eb9f7a 100644
+--- a/src/runtime/notify.ts
++++ b/src/runtime/notify.ts
+@@ -1 +1,145 @@
+-// TODO: implement in T4 — client.session.promptAsync wrapper
++/**
++ * Notification injection for Copilot delegation completions.
++ *
++ * Injects `<system-reminder>` messages into the parent OpenCode session
++ * when a delegated Copilot subprocess completes. Uses `noReply` semantics
++ * mirroring OMO's per-parent-session in-flight counter pattern.
++ *
++ * Correctness invariant: decrement the in-flight counter synchronously
++ * (before any await) to prevent concurrent completions from both reading
++ * the same counter value and both setting noReply: false.
++ */
++
++import type { TaskStatus } from './envelope'
++
++/** Minimal client interface for notification injection. */
++export type NotifyClient = {
++  session: {
++    prompt: (opts: {
++      path: { id: string }
++      body: {
++        noReply: boolean
++        parts: Array<{ type: string; text: string; synthetic: boolean }>
++      }
++    }) => Promise<unknown>
++  }
++  tui: {
++    showToast: (opts: { body: { message: string; variant: string } }) => void
++  }
++  app: {
++    log: (...args: unknown[]) => void
++  }
++}
++
++/** Task information needed for building the notification. */
++export type NotifyTaskInfo = {
++  taskId: string
++  parentSessionID: string
++  status: TaskStatus
++  agentName?: string
++  modelName?: string
++  startedAt: number
++  exitCode?: number
++}
++
++/** Per-parent-session in-flight task counters. */
++const inFlightCounters = new Map<string, number>()
++
++/** Increment the in-flight counter for a parent session. */
++export function incrementInFlight(parentSessionID: string): void {
++  const current = inFlightCounters.get(parentSessionID) ?? 0
++  inFlightCounters.set(parentSessionID, current + 1)
++}
++
++/** Reset all counters (for testing only). */
++export function resetInFlightCounters(): void {
++  inFlightCounters.clear()
++}
++
++/** Format duration in human-readable form. */
++function formatDuration(ms: number): string {
++  if (ms < 1000) return `${ms}ms`
++  const seconds = Math.round(ms / 1000)
++  if (seconds < 60) return `${seconds}s`
++  const minutes = Math.floor(seconds / 60)
++  const remainingSeconds = seconds % 60
++  return `${minutes}m ${remainingSeconds}s`
++}
++
++/** Build the `<system-reminder>` notification text. */
++function buildNotificationText(task: NotifyTaskInfo): string {
++  const agent = task.agentName ?? 'default'
++  const model = task.modelName ?? 'default'
++  const duration = formatDuration(Date.now() - task.startedAt)
++
++  let text = `<system-reminder>
++[COPILOT DELEGATION COMPLETED]
++**Task ID:** \`${task.taskId}\`
++**Agent:** ${agent}
++**Model:** ${model}
++**Duration:** ${duration}
++**Status:** ${task.status}
++
++Use \`copilot_output(task_id="${task.taskId}")\` to retrieve the structured result.`
++
++  if (task.status === 'failed') {
++    text += `\n\n**ACTION REQUIRED:** Subprocess exited with code ${task.exitCode ?? 'unknown'}.`
++  }
++
++  text += '\n</system-reminder>'
++  return text
++}
++
++/**
++ * Notify the parent session that a Copilot delegation has completed.
++ *
++ * Decrements the in-flight counter synchronously, then injects the
++ * notification via client.session.prompt with correct noReply semantics.
++ * Never throws — logs and swallows prompt/toast errors.
++ */
++export async function notifyCompletion(
++  client: NotifyClient,
++  task: NotifyTaskInfo,
++): Promise<void> {
++  // Decrement synchronously BEFORE any await — correctness invariant
++  const current = inFlightCounters.get(task.parentSessionID) ?? 0
++  const remaining = Math.max(0, current - 1)
++  inFlightCounters.set(task.parentSessionID, remaining)
++
++  // Failed exits always force a parent turn
++  const noReply: boolean =
++    task.status === 'failed' || task.status === 'cancelled'
++      ? false
++      : remaining > 0
++
++  const text = buildNotificationText(task)
++
++  try {
++    await client.session.prompt({
++      path: { id: task.parentSessionID },
++      body: {
++        noReply,
++        parts: [{ type: 'text', text, synthetic: true }],
++      },
++    })
++  } catch (error) {
++    client.app.log(
++      'notify',
++      `Failed to inject notification for ${task.taskId}: ${error}`,
++    )
++  }
++
++  try {
++    const variant = task.status === 'complete' ? 'success' : 'error'
++    const toastMessage =
++      task.status === 'complete'
++        ? `Copilot delegation ${task.taskId} completed`
++        : `Copilot delegation ${task.taskId} ${task.status}`
++
++    client.tui.showToast({
++      body: { message: toastMessage, variant },
++    })
++  } catch {
++    // Toast failure is non-critical
++  }
++}
+diff --git a/src/runtime/subprocess.ts b/src/runtime/subprocess.ts
+index eeba72e..1ff9a66 100644
+--- a/src/runtime/subprocess.ts
++++ b/src/runtime/subprocess.ts
+@@ -1 +1,160 @@
+-// TODO: implement in T3 — subprocess spawn + line-buffered stdout parser
++import { type ChildProcess, spawn } from 'node:child_process'
++import { stripAnsi } from '../lib/ansi'
++import { killProcessTree } from '../lib/kill-tree'
++import type { TaskStatus } from './envelope'
++import { type ParsedEvent, parseJsonlLine } from './jsonl-parser'
++
++type SpawnCopilotOptions = {
++  cwd: string
++  env?: Record<string, string>
++}
++
++type SpawnCopilotResult = {
++  taskId: string
++  pid: number
++  events: ParsedEvent[]
++  completionPromise: Promise<void>
++  abortController: AbortController
++  child: ChildProcess
++  status: TaskStatus
++  exitCode?: number
++  stdoutLineBuffer: string
++  finalMessage?: string
++  errorText?: string
++}
++
++function flushBufferedStdout(task: SpawnCopilotResult): void {
++  if (task.stdoutLineBuffer.trim().length === 0) {
++    task.stdoutLineBuffer = ''
++    return
++  }
++
++  task.events.push(parseJsonlLine(task.stdoutLineBuffer))
++  task.stdoutLineBuffer = ''
++}
++
++function assignFinalMessage(task: SpawnCopilotResult): void {
++  const lastMessage = [...task.events]
++    .reverse()
++    .find((event) => event.type === 'message')
++  const content = lastMessage?.data.content
++
++  if (typeof content === 'string' && content.length > 0) {
++    task.finalMessage = stripAnsi(content)
++  }
++}
++
++function finalizeTask(
++  task: SpawnCopilotResult,
++  exitCode: number | null,
++  stderrText: string,
++): void {
++  flushBufferedStdout(task)
++  task.exitCode = exitCode ?? undefined
++
++  if (task.status !== 'cancelled') {
++    task.status = exitCode === 0 ? 'complete' : 'failed'
++  }
++
++  if (stderrText.trim().length > 0) {
++    task.errorText = stripAnsi(stderrText.trim())
++  }
++
++  assignFinalMessage(task)
++}
++
++function resolveAuthEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
++  const authToken = env.COPILOT_GITHUB_TOKEN ?? env.GH_TOKEN ?? env.GITHUB_TOKEN
++
++  if (!authToken) {
++    return env
++  }
++
++  return {
++    ...env,
++    COPILOT_GITHUB_TOKEN: authToken,
++  }
++}
++
++export function spawnCopilot(
++  args: string[],
++  opts: SpawnCopilotOptions,
++): SpawnCopilotResult {
++  const env = resolveAuthEnv({
++    ...process.env,
++    ...opts.env,
++  })
++
++  const child = spawn('copilot', args, {
++    cwd: opts.cwd,
++    detached: true,
++    env,
++    stdio: ['ignore', 'pipe', 'pipe'],
++    windowsHide: true,
++  })
++
++  const events: ParsedEvent[] = []
++  const task: SpawnCopilotResult = {
++    taskId: `cpl_${crypto.randomUUID()}`,
++    pid: child.pid ?? -1,
++    events,
++    abortController: new AbortController(),
++    child,
++    status: 'running',
++    exitCode: undefined,
++    stdoutLineBuffer: '',
++    completionPromise: Promise.resolve(),
++  }
++
++  let stderrText = ''
++
++  child.stdout?.setEncoding('utf8')
++  child.stdout?.on('data', (chunk: string) => {
++    task.stdoutLineBuffer += chunk
++
++    const lines = task.stdoutLineBuffer.split(/\r?\n/)
++    task.stdoutLineBuffer = lines.pop() ?? ''
++
++    for (const line of lines) {
++      if (line.length === 0) {
++        continue
++      }
++
++      const event = parseJsonlLine(line)
++      events.push(event)
++    }
++  })
++
++  child.stderr?.setEncoding('utf8')
++  child.stderr?.on('data', (chunk: string) => {
++    stderrText += chunk
++  })
++
++  task.abortController.signal.addEventListener(
++    'abort',
++    () => {
++      if (task.status !== 'running') {
++        return
++      }
++
++      task.status = 'cancelled'
++      void killProcessTree(task.pid)
++    },
++    { once: true },
++  )
++
++  task.completionPromise = new Promise<void>((resolve) => {
++    child.once('error', (error) => {
++      task.status = 'failed'
++      task.errorText = stripAnsi(error.message)
++      resolve()
++    })
++
++    child.once('close', (code) => {
++      finalizeTask(task, code, stderrText)
++      resolve()
++    })
++  })
++
++  return task
++}
+diff --git a/src/runtime/task-registry.ts b/src/runtime/task-registry.ts
+index 5aab417..9138b1d 100644
+--- a/src/runtime/task-registry.ts
++++ b/src/runtime/task-registry.ts
+@@ -1 +1,64 @@
+-// TODO: implement in T3 — in-memory task registry
++import type { ChildProcess } from 'node:child_process'
++import { killProcessTree } from '../lib/kill-tree'
++import type { TaskStatus } from './envelope'
++import type { ParsedEvent } from './jsonl-parser'
++
++export type TaskState = {
++  taskId: string
++  parentSessionID: string
++  pid: number
++  startedAt: number
++  endedAt?: number
++  status: TaskStatus
++  exitCode?: number
++  args: string[]
++  cwd: string
++  agentName?: string
++  modelName?: string
++  stdoutLineBuffer: string
++  events: ParsedEvent[]
++  finalMessage?: string
++  errorText?: string
++  child: ChildProcess
++  completionPromise: Promise<void>
++  abortController: AbortController
++}
++
++export type CreateTaskInput = Omit<TaskState, 'taskId'>
++
++const tasks = new Map<string, TaskState>()
++
++export function createTask(input: CreateTaskInput): TaskState {
++  const taskId = `cpl_${crypto.randomUUID()}`
++  const task: TaskState = {
++    ...input,
++    taskId,
++  }
++
++  tasks.set(taskId, task)
++  return task
++}
++
++export function getTask(taskId: string): TaskState | undefined {
++  return tasks.get(taskId)
++}
++
++export function getAllTasks(): TaskState[] {
++  return [...tasks.values()]
++}
++
++export async function cleanupAll(): Promise<void> {
++  const runningTasks = [...tasks.values()]
++
++  await Promise.allSettled(
++    runningTasks.map(async (task) => {
++      task.abortController.abort()
++
++      if (task.pid > 0 && task.status === 'running') {
++        await killProcessTree(task.pid)
++      }
++    }),
++  )
++
++  tasks.clear()
++}
+diff --git a/tests/agents.test.ts b/tests/agents.test.ts
+new file mode 100644
+index 0000000..8e5df8c
+--- /dev/null
++++ b/tests/agents.test.ts
+@@ -0,0 +1,257 @@
++import { describe, expect, it } from 'bun:test'
++import { join } from 'node:path'
++import { type Agent, discoverAgents } from '../src/discovery/agents'
++import { buildDescription } from '../src/discovery/description'
++
++const fixturesDir = join(import.meta.dir, 'fixtures', 'agents')
++const userDir = join(fixturesDir, 'user')
++const repoDir = join(fixturesDir, 'repo')
++
++describe('discoverAgents', () => {
++  describe('built-in agents', () => {
++    it('should return built-in agents when no directories are provided', () => {
++      // Given no user or repo agent directories
++      // When discovering agents
++      const agents = discoverAgents({})
++
++      // Then only built-in agents are returned
++      const builtins = agents.filter((a) => a.source === 'builtin')
++      expect(builtins).toHaveLength(6)
++      expect(builtins.map((a) => a.name)).toEqual([
++        'default',
++        'explore',
++        'task',
++        'general-purpose',
++        'code-review',
++        'research',
++      ])
++    })
++
++    it('should mark all built-in agents with source "builtin"', () => {
++      // Given no external directories
++      // When discovering agents
++      const agents = discoverAgents({})
++
++      // Then every agent has source "builtin"
++      for (const agent of agents) {
++        expect(agent.source).toBe('builtin')
++      }
++    })
++  })
++
++  describe('user agents', () => {
++    it('should include user agents from the user directory', () => {
++      // Given a user agents directory with .md files
++      // When discovering agents
++      const agents = discoverAgents({ userAgentsDir: userDir })
++
++      // Then user agents appear after built-ins
++      const userAgents = agents.filter((a) => a.source === 'user')
++      expect(userAgents.length).toBe(2)
++      expect(userAgents.map((a) => a.name).sort()).toEqual([
++        'custom-helper',
++        'my-reviewer',
++      ])
++    })
++
++    it('should place user agents after built-in agents', () => {
++      // Given a user agents directory
++      // When discovering agents
++      const agents = discoverAgents({ userAgentsDir: userDir })
++
++      // Then built-ins come first, then user agents
++      const firstUserIndex = agents.findIndex((a) => a.source === 'user')
++      const lastBuiltinIndex = agents.findLastIndex(
++        (a) => a.source === 'builtin',
++      )
++      expect(firstUserIndex).toBeGreaterThan(lastBuiltinIndex)
++    })
++  })
++
++  describe('repo agents', () => {
++    it('should include repo agents from the repo directory', () => {
++      // Given a repo agents directory with .md files
++      // When discovering agents
++      const agents = discoverAgents({ repoAgentsDir: repoDir })
++
++      // Then repo agents appear after built-ins
++      const repoAgents = agents.filter((a) => a.source === 'repo')
++      expect(repoAgents.length).toBe(2)
++      expect(repoAgents.map((a) => a.name).sort()).toEqual([
++        'custom-helper',
++        'project-bot',
++      ])
++    })
++  })
++
++  describe('merge and override behavior', () => {
++    it('should merge built-in, user, and repo agents in order', () => {
++      // Given both user and repo directories
++      // When discovering agents
++      const agents = discoverAgents({
++        userAgentsDir: userDir,
++        repoAgentsDir: repoDir,
++      })
++
++      // Then agents appear in order: builtin, user, repo
++      const sources = agents.map((a) => a.source)
++      const firstUser = sources.indexOf('user')
++      const firstRepo = sources.indexOf('repo')
++      const lastBuiltin = sources.lastIndexOf('builtin')
++
++      expect(lastBuiltin).toBeLessThan(firstUser)
++      expect(firstUser).toBeLessThan(firstRepo)
++    })
++
++    it('should let repo agents override user agents with the same name', () => {
++      // Given user has "custom-helper" and repo also has "custom-helper"
++      // When discovering agents
++      const agents = discoverAgents({
++        userAgentsDir: userDir,
++        repoAgentsDir: repoDir,
++      })
++
++      // Then only one "custom-helper" exists, with source "repo"
++      const customHelpers = agents.filter((a) => a.name === 'custom-helper')
++      expect(customHelpers).toHaveLength(1)
++      expect(customHelpers[0].source).toBe('repo')
++    })
++
++    it('should not override built-in agents with user or repo agents of the same name', () => {
++      // Given user and repo dirs (neither contains a file named "default.md")
++      // When discovering agents
++      const agents = discoverAgents({
++        userAgentsDir: userDir,
++        repoAgentsDir: repoDir,
++      })
++
++      // Then built-in "default" remains
++      const defaults = agents.filter((a) => a.name === 'default')
++      expect(defaults).toHaveLength(1)
++      expect(defaults[0].source).toBe('builtin')
++    })
++  })
++
++  describe('missing directories', () => {
++    it('should return only built-ins when user directory does not exist', () => {
++      // Given a non-existent user directory
++      // When discovering agents
++      const agents = discoverAgents({
++        userAgentsDir: '/tmp/nonexistent-user-agents-dir',
++      })
++
++      // Then only built-in agents are returned
++      expect(agents).toHaveLength(6)
++      expect(agents.every((a) => a.source === 'builtin')).toBe(true)
++    })
++
++    it('should return only built-ins when repo directory does not exist', () => {
++      // Given a non-existent repo directory
++      // When discovering agents
++      const agents = discoverAgents({
++        repoAgentsDir: '/tmp/nonexistent-repo-agents-dir',
++      })
++
++      // Then only built-in agents are returned
++      expect(agents).toHaveLength(6)
++    })
++
++    it('should handle both directories missing gracefully', () => {
++      // Given both directories are non-existent
++      // When discovering agents
++      const agents = discoverAgents({
++        userAgentsDir: '/tmp/nope-user',
++        repoAgentsDir: '/tmp/nope-repo',
++      })
++
++      // Then only built-in agents are returned, no errors thrown
++      expect(agents).toHaveLength(6)
++    })
++  })
++})
++
++describe('buildDescription', () => {
++  it('should format agents as a multi-line string', () => {
++    // Given a list of agents
++    const agents: Agent[] = [
++      { name: 'default', source: 'builtin' },
++      { name: 'explore', source: 'builtin' },
++      { name: 'my-agent', source: 'user' },
++    ]
++
++    // When building the description
++    const desc = buildDescription(agents)
++
++    // Then it contains a header and formatted entries
++    expect(desc).toContain('Available Copilot agents:')
++    expect(desc).toContain('  - default (builtin)')
++    expect(desc).toContain('  - explore (builtin)')
++    expect(desc).toContain('  - my-agent (user)')
++  })
++
++  it('should list agents in the provided order', () => {
++    // Given ordered agents
++    const agents: Agent[] = [
++      { name: 'default', source: 'builtin' },
++      { name: 'custom', source: 'user' },
++      { name: 'repo-bot', source: 'repo' },
++    ]
++
++    // When building the description
++    const desc = buildDescription(agents)
++
++    // Then lines appear in order
++    const lines = desc.split('\n')
++    const defaultIdx = lines.findIndex((l) => l.includes('default'))
++    const customIdx = lines.findIndex((l) => l.includes('custom'))
++    const repoBotIdx = lines.findIndex((l) => l.includes('repo-bot'))
++    expect(defaultIdx).toBeLessThan(customIdx)
++    expect(customIdx).toBeLessThan(repoBotIdx)
++  })
++
++  it('should cap at 20 entries and show truncation message', () => {
++    // Given 25 agents
++    const agents: Agent[] = Array.from({ length: 25 }, (_, i) => ({
++      name: `agent-${String(i).padStart(2, '0')}`,
++      source: 'builtin' as const,
++    }))
++
++    // When building the description
++    const desc = buildDescription(agents)
++
++    // Then only 20 are listed, with a truncation notice
++    const agentLines = desc.split('\n').filter((l) => l.trim().startsWith('- '))
++    expect(agentLines).toHaveLength(20)
++    expect(desc).toContain(
++      '... and 5 more (use copilot_list_agents to see all)',
++    )
++  })
++
++  it('should not show truncation message for exactly 20 agents', () => {
++    // Given exactly 20 agents
++    const agents: Agent[] = Array.from({ length: 20 }, (_, i) => ({
++      name: `agent-${i}`,
++      source: 'builtin' as const,
++    }))
++
++    // When building the description
++    const desc = buildDescription(agents)
++
++    // Then no truncation message
++    expect(desc).not.toContain('... and')
++    expect(desc).not.toContain('more')
++  })
++
++  it('should handle an empty agent list', () => {
++    // Given no agents
++    const agents: Agent[] = []
++
++    // When building the description
++    const desc = buildDescription(agents)
++
++    // Then it still has the header
++    expect(desc).toContain('Available Copilot agents:')
++    const agentLines = desc.split('\n').filter((l) => l.trim().startsWith('- '))
++    expect(agentLines).toHaveLength(0)
++  })
++})
+diff --git a/tests/fixtures/agents/repo/custom-helper.md b/tests/fixtures/agents/repo/custom-helper.md
+new file mode 100644
+index 0000000..a3a66a7
+--- /dev/null
++++ b/tests/fixtures/agents/repo/custom-helper.md
+@@ -0,0 +1,3 @@
++# Custom Helper (Repo Override)
++
++A repo-level override of the user custom-helper agent.
+diff --git a/tests/fixtures/agents/repo/project-bot.md b/tests/fixtures/agents/repo/project-bot.md
+new file mode 100644
+index 0000000..db06127
+--- /dev/null
++++ b/tests/fixtures/agents/repo/project-bot.md
+@@ -0,0 +1,3 @@
++# Project Bot
++
++A repo-specific agent for this project.
+diff --git a/tests/fixtures/agents/user/custom-helper.md b/tests/fixtures/agents/user/custom-helper.md
+new file mode 100644
+index 0000000..cdfa03c
+--- /dev/null
++++ b/tests/fixtures/agents/user/custom-helper.md
+@@ -0,0 +1,3 @@
++# Custom Helper
++
++A user-defined helper agent for common tasks.
+diff --git a/tests/fixtures/agents/user/my-reviewer.md b/tests/fixtures/agents/user/my-reviewer.md
+new file mode 100644
+index 0000000..6715417
+--- /dev/null
++++ b/tests/fixtures/agents/user/my-reviewer.md
+@@ -0,0 +1,3 @@
++# My Reviewer
++
++A user-defined code review agent.
+diff --git a/tests/notify.test.ts b/tests/notify.test.ts
+new file mode 100644
+index 0000000..3e8fb3b
+--- /dev/null
++++ b/tests/notify.test.ts
+@@ -0,0 +1,296 @@
++import { afterEach, describe, expect, it } from 'bun:test'
++import {
++  incrementInFlight,
++  type NotifyClient,
++  type NotifyTaskInfo,
++  notifyCompletion,
++  resetInFlightCounters,
++} from '../src/runtime/notify'
++
++/** Create a mock client that records prompt and toast calls. */
++function mockClient(): NotifyClient & {
++  promptCalls: Array<{ sessionId: string; noReply: boolean; text: string }>
++  toastCalls: Array<{ message: string; variant: string }>
++} {
++  const promptCalls: Array<{
++    sessionId: string
++    noReply: boolean
++    text: string
++  }> = []
++  const toastCalls: Array<{ message: string; variant: string }> = []
++
++  return {
++    promptCalls,
++    toastCalls,
++    session: {
++      prompt: async (opts: {
++        path: { id: string }
++        body: {
++          noReply: boolean
++          parts: Array<{ type: string; text: string; synthetic: boolean }>
++        }
++      }) => {
++        promptCalls.push({
++          sessionId: opts.path.id,
++          noReply: opts.body.noReply,
++          text: opts.body.parts[0].text,
++        })
++      },
++    },
++    tui: {
++      showToast: (opts: { body: { message: string; variant: string } }) => {
++        toastCalls.push({
++          message: opts.body.message,
++          variant: opts.body.variant,
++        })
++      },
++    },
++    app: {
++      log: () => {},
++    },
++  }
++}
++
++/** Create a minimal task info for notification. */
++function makeTaskInfo(overrides: Partial<NotifyTaskInfo> = {}): NotifyTaskInfo {
++  return {
++    taskId: 'cpl_test-1234',
++    parentSessionID: 'session-A',
++    status: 'complete',
++    agentName: undefined,
++    modelName: undefined,
++    startedAt: Date.now() - 5000,
++    exitCode: 0,
++    ...overrides,
++  }
++}
++
++afterEach(() => {
++  resetInFlightCounters()
++})
++
++describe('notification injection', () => {
++  describe('noReply semantics', () => {
++    it('should set noReply: true when other tasks remain in flight', async () => {
++      // Given 3 in-flight tasks for session A
++      const client = mockClient()
++      incrementInFlight('session-A')
++      incrementInFlight('session-A')
++      incrementInFlight('session-A')
++
++      // When the first task completes
++      await notifyCompletion(client, makeTaskInfo())
++
++      // Then noReply is true (2 tasks still running)
++      expect(client.promptCalls).toHaveLength(1)
++      expect(client.promptCalls[0].noReply).toBe(true)
++    })
++
++    it('should set noReply: false when the last task completes', async () => {
++      // Given 1 in-flight task for session A
++      const client = mockClient()
++      incrementInFlight('session-A')
++
++      // When the only task completes
++      await notifyCompletion(client, makeTaskInfo())
++
++      // Then noReply is false (forces parent turn)
++      expect(client.promptCalls[0].noReply).toBe(false)
++    })
++
++    it('should always set noReply: false on failed status regardless of count', async () => {
++      // Given 3 in-flight tasks
++      const client = mockClient()
++      incrementInFlight('session-A')
++      incrementInFlight('session-A')
++      incrementInFlight('session-A')
++
++      // When a task fails (2 still running)
++      await notifyCompletion(
++        client,
++        makeTaskInfo({ status: 'failed', exitCode: 1 }),
++      )
++
++      // Then noReply is false (failed always forces turn)
++      expect(client.promptCalls[0].noReply).toBe(false)
++    })
++
++    it('should never leave noReply as undefined', async () => {
++      // Given 1 in-flight task
++      const client = mockClient()
++      incrementInFlight('session-A')
++
++      // When the task completes
++      await notifyCompletion(client, makeTaskInfo())
++
++      // Then noReply is explicitly boolean, not undefined
++      expect(client.promptCalls[0].noReply).toBeDefined()
++      expect(typeof client.promptCalls[0].noReply).toBe('boolean')
++    })
++  })
++
++  describe('multi-session isolation', () => {
++    it('should isolate in-flight counters per parent session', async () => {
++      // Given session A has 2 tasks and session B has 1 task
++      const client = mockClient()
++      incrementInFlight('session-A')
++      incrementInFlight('session-A')
++      incrementInFlight('session-B')
++
++      // When session A's first task completes
++      await notifyCompletion(
++        client,
++        makeTaskInfo({ parentSessionID: 'session-A' }),
++      )
++
++      // Then A still has 1 task → noReply: true
++      expect(client.promptCalls[0].noReply).toBe(true)
++
++      // When session B's only task completes
++      await notifyCompletion(
++        client,
++        makeTaskInfo({
++          parentSessionID: 'session-B',
++          taskId: 'cpl_test-5678',
++        }),
++      )
++
++      // Then B's last task → noReply: false (independent of A's count)
++      expect(client.promptCalls[1].noReply).toBe(false)
++
++      // When session A's last task completes
++      await notifyCompletion(
++        client,
++        makeTaskInfo({
++          parentSessionID: 'session-A',
++          taskId: 'cpl_test-9999',
++        }),
++      )
++
++      // Then A's last task → noReply: false
++      expect(client.promptCalls[2].noReply).toBe(false)
++    })
++  })
++
++  describe('notification shape', () => {
++    it('should contain system-reminder and completion marker', async () => {
++      // Given a completing task
++      const client = mockClient()
++      incrementInFlight('session-A')
++
++      // When notified
++      await notifyCompletion(client, makeTaskInfo())
++
++      // Then the text contains required literals
++      const text = client.promptCalls[0].text
++      expect(text).toContain('<system-reminder>')
++      expect(text).toContain('[COPILOT DELEGATION COMPLETED]')
++      expect(text).toContain('</system-reminder>')
++    })
++
++    it('should include task ID, status, and copilot_output hint', async () => {
++      // Given a completing task with specific ID
++      const client = mockClient()
++      incrementInFlight('session-A')
++
++      // When notified
++      await notifyCompletion(client, makeTaskInfo({ taskId: 'cpl_abc-def' }))
++
++      // Then text includes task ID and output hint
++      const text = client.promptCalls[0].text
++      expect(text).toContain('cpl_abc-def')
++      expect(text).toContain('copilot_output')
++    })
++
++    it('should show agent and model as default when not specified', async () => {
++      // Given a task with no agent or model
++      const client = mockClient()
++      incrementInFlight('session-A')
++
++      // When notified
++      await notifyCompletion(client, makeTaskInfo())
++
++      // Then agent and model show as "default"
++      const text = client.promptCalls[0].text
++      expect(text).toContain('default')
++    })
++
++    it('should include ACTION REQUIRED on failed status', async () => {
++      // Given a failed task
++      const client = mockClient()
++      incrementInFlight('session-A')
++
++      // When notified with failed status
++      await notifyCompletion(
++        client,
++        makeTaskInfo({ status: 'failed', exitCode: 1 }),
++      )
++
++      // Then text includes action required
++      const text = client.promptCalls[0].text
++      expect(text).toContain('ACTION REQUIRED')
++      expect(text).toContain('1')
++    })
++
++    it('should send prompt to the correct parent session ID', async () => {
++      // Given a task for session B
++      const client = mockClient()
++      incrementInFlight('session-B')
++
++      // When notified
++      await notifyCompletion(
++        client,
++        makeTaskInfo({ parentSessionID: 'session-B' }),
++      )
++
++      // Then prompt is sent to session B
++      expect(client.promptCalls[0].sessionId).toBe('session-B')
++    })
++  })
++
++  describe('TUI toast', () => {
++    it('should fire a toast on successful completion', async () => {
++      // Given a completing task
++      const client = mockClient()
++      incrementInFlight('session-A')
++
++      // When notified
++      await notifyCompletion(client, makeTaskInfo())
++
++      // Then toast is fired with success variant
++      expect(client.toastCalls).toHaveLength(1)
++      expect(client.toastCalls[0].variant).toBe('success')
++    })
++
++    it('should fire toast with error variant on failure', async () => {
++      // Given a failed task
++      const client = mockClient()
++      incrementInFlight('session-A')
++
++      // When notified
++      await notifyCompletion(
++        client,
++        makeTaskInfo({ status: 'failed', exitCode: 1 }),
++      )
++
++      // Then toast is fired with error variant
++      expect(client.toastCalls[0].variant).toBe('error')
++    })
++  })
++
++  describe('error handling', () => {
++    it('should not throw when prompt call fails', async () => {
++      // Given a client whose prompt throws
++      const client = mockClient()
++      client.session.prompt = async () => {
++        throw new Error('session expired')
++      }
++      incrementInFlight('session-A')
++
++      // When notified — should not throw
++      await expect(
++        notifyCompletion(client, makeTaskInfo()),
++      ).resolves.toBeUndefined()
++    })
++  })
++})
+diff --git a/tests/subprocess.test.ts b/tests/subprocess.test.ts
+new file mode 100644
+index 0000000..a0c02d9
+--- /dev/null
++++ b/tests/subprocess.test.ts
+@@ -0,0 +1,312 @@
++import { afterEach, describe, expect, it } from 'bun:test'
++import {
++  chmodSync,
++  existsSync,
++  mkdtempSync,
++  readFileSync,
++  rmSync,
++  writeFileSync,
++} from 'node:fs'
++import { tmpdir } from 'node:os'
++import { join } from 'node:path'
++import { setTimeout as delay } from 'node:timers/promises'
++import type { TaskStatus } from '../src/runtime/envelope'
++import type { ParsedEvent } from '../src/runtime/jsonl-parser'
++
++type SpawnCopilotResult = {
++  taskId: string
++  pid: number
++  events: ParsedEvent[]
++  completionPromise: Promise<void>
++  abortController: AbortController
++  child: { pid: number }
++  status: TaskStatus
++  exitCode?: number
++  stdoutLineBuffer: string
++}
++
++type SpawnCopilotFn = (
++  args: string[],
++  opts: { cwd: string; env?: Record<string, string> },
++) => SpawnCopilotResult
++
++type CreateTaskFn = (input: {
++  parentSessionID: string
++  pid: number
++  startedAt: number
++  status: TaskStatus
++  args: string[]
++  cwd: string
++  stdoutLineBuffer: string
++  events: ParsedEvent[]
++  child: { pid: number }
++  completionPromise: Promise<void>
++  abortController: AbortController
++}) => {
++  taskId: string
++}
++
++type GetTaskFn = (taskId: string) => unknown
++type GetAllTasksFn = () => unknown[]
++type CleanupAllFn = () => Promise<void>
++type StripAnsiFn = (text: string) => string
++type KillProcessTreeFn = (pid: number) => Promise<void>
++
++function requireFunction<T>(value: unknown): T {
++  expect(typeof value).toBe('function')
++  return value as T
++}
++
++async function loadModules() {
++  const subprocessModule = await import('../src/runtime/subprocess')
++  const registryModule = await import('../src/runtime/task-registry')
++  const ansiModule = await import('../src/lib/ansi')
++  const killTreeModule = await import('../src/lib/kill-tree')
++
++  return {
++    spawnCopilot: requireFunction<SpawnCopilotFn>(
++      Reflect.get(subprocessModule, 'spawnCopilot'),
++    ),
++    createTask: requireFunction<CreateTaskFn>(
++      Reflect.get(registryModule, 'createTask'),
++    ),
++    getTask: requireFunction<GetTaskFn>(Reflect.get(registryModule, 'getTask')),
++    getAllTasks: requireFunction<GetAllTasksFn>(
++      Reflect.get(registryModule, 'getAllTasks'),
++    ),
++    cleanupAll: requireFunction<CleanupAllFn>(
++      Reflect.get(registryModule, 'cleanupAll'),
++    ),
++    stripAnsi: requireFunction<StripAnsiFn>(
++      Reflect.get(ansiModule, 'stripAnsi'),
++    ),
++    killProcessTree: requireFunction<KillProcessTreeFn>(
++      Reflect.get(killTreeModule, 'killProcessTree'),
++    ),
++  }
++}
++
++function makeFakeCopilotBin(): string {
++  const binDir = mkdtempSync(join(tmpdir(), 'copilot-bin-'))
++  const copilotPath = join(binDir, 'copilot')
++
++  writeFileSync(copilotPath, '#!/usr/bin/env bash\nexec bash "$@"\n')
++  chmodSync(copilotPath, 0o755)
++
++  return binDir
++}
++
++function makeSpawnEnv(binDir: string): Record<string, string> {
++  return {
++    PATH: `${binDir}:${process.env.PATH ?? ''}`,
++  }
++}
++
++async function waitForFile(filePath: string): Promise<void> {
++  for (let attempt = 0; attempt < 100; attempt += 1) {
++    if (existsSync(filePath)) {
++      return
++    }
++
++    await delay(20)
++  }
++
++  throw new Error(`Timed out waiting for file: ${filePath}`)
++}
++
++function expectProcessToBeGone(pid: number): void {
++  expect(() => process.kill(pid, 0)).toThrow()
++}
++
++const tempPaths: string[] = []
++
++afterEach(async () => {
++  const { cleanupAll } = await loadModules()
++  await cleanupAll()
++
++  for (const tempPath of tempPaths.splice(0)) {
++    rmSync(tempPath, { force: true, recursive: true })
++  }
++})
++
++describe('subprocess runtime', () => {
++  describe('spawnCopilot', () => {
++    it('captures parsed events and marks successful exits as complete', async () => {
++      // Given a fake copilot binary that emits JSONL and exits successfully
++      const { spawnCopilot } = await loadModules()
++      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
++      const binDir = makeFakeCopilotBin()
++      tempPaths.push(cwd, binDir)
++
++      const task = spawnCopilot(
++        [
++          '-c',
++          [
++            'printf \'%s\\n\' \'{"type":"assistant.message","data":{"messageId":"msg-1","content":"done","toolRequests":[]}}\'',
++            'printf \'%s\\n\' \'{"type":"result","sessionId":"session-1","exitCode":0,"usage":{}}\'',
++            'exit 0',
++          ].join('; '),
++        ],
++        { cwd, env: makeSpawnEnv(binDir) },
++      )
++
++      // When the subprocess finishes
++      await task.completionPromise
++
++      // Then parsed events are accumulated and status reflects success
++      expect(task.taskId.startsWith('cpl_')).toBe(true)
++      expect(task.pid).toBeGreaterThan(0)
++      expect(task.status).toBe('complete')
++      expect(task.exitCode).toBe(0)
++      expect(task.events).toHaveLength(2)
++      expect(task.events[0]?.type).toBe('message')
++      expect(task.events[0]?.data.content).toBe('done')
++      expect(task.stdoutLineBuffer).toBe('')
++    })
++
++    it('marks non-zero exits as failed', async () => {
++      // Given a fake copilot binary that exits with a non-zero status
++      const { spawnCopilot } = await loadModules()
++      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
++      const binDir = makeFakeCopilotBin()
++      tempPaths.push(cwd, binDir)
++
++      const task = spawnCopilot(
++        [
++          '-c',
++          [
++            'printf \'%s\\n\' \'{"type":"result","sessionId":"session-2","exitCode":7,"usage":{}}\'',
++            'exit 7',
++          ].join('; '),
++        ],
++        { cwd, env: makeSpawnEnv(binDir) },
++      )
++
++      // When the subprocess finishes
++      await task.completionPromise
++
++      // Then status reflects the failed exit code
++      expect(task.status).toBe('failed')
++      expect(task.exitCode).toBe(7)
++      expect(task.events).toHaveLength(1)
++      expect(task.events[0]?.type).toBe('usage')
++    })
++
++    it('buffers stdout until a full JSONL line is available', async () => {
++      // Given a fake copilot binary that splits one JSONL line across chunks
++      const { spawnCopilot } = await loadModules()
++      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
++      const binDir = makeFakeCopilotBin()
++      tempPaths.push(cwd, binDir)
++
++      const task = spawnCopilot(
++        [
++          '-c',
++          [
++            'printf \'%s\' \'{"type":"assistant.message","data":{"messageId":"msg-2","content":"chunk\'',
++            'sleep 0.05',
++            "printf '%s\\n' 'ed\",\"toolRequests\":[]}}'",
++            'printf \'%s\\n\' \'{"type":"result","sessionId":"session-3","exitCode":0,"usage":{}}\'',
++            'exit 0',
++          ].join('; '),
++        ],
++        { cwd, env: makeSpawnEnv(binDir) },
++      )
++
++      // When the subprocess finishes
++      await task.completionPromise
++
++      // Then the split line is reassembled into one parsed event
++      expect(task.status).toBe('complete')
++      expect(task.events).toHaveLength(2)
++      expect(task.events[0]?.data.content).toBe('chunked')
++      expect(task.stdoutLineBuffer).toBe('')
++    })
++
++    it('cancels the subprocess tree through the abort controller', async () => {
++      // Given a fake copilot binary that starts a long-lived child process
++      const { spawnCopilot } = await loadModules()
++      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
++      const binDir = makeFakeCopilotBin()
++      const pidFile = join(cwd, 'grandchild.pid')
++      tempPaths.push(cwd, binDir)
++
++      const task = spawnCopilot(
++        ['-c', [`sleep 30 & echo $! > '${pidFile}'`, 'wait'].join('; ')],
++        { cwd, env: makeSpawnEnv(binDir) },
++      )
++
++      await waitForFile(pidFile)
++      const grandchildPid = Number.parseInt(
++        readFileSync(pidFile, 'utf-8').trim(),
++        10,
++      )
++      const startedAt = Date.now()
++
++      // When cancellation is requested
++      task.abortController.abort()
++      await task.completionPromise
++
++      // Then the process tree is gone and the task is marked cancelled
++      expect(task.status).toBe('cancelled')
++      expect(Date.now() - startedAt).toBeLessThan(3000)
++      expectProcessToBeGone(grandchildPid)
++    })
++  })
++
++  describe('task registry', () => {
++    it('creates tasks with cpl_ ids and exposes them through lookup helpers', async () => {
++      // Given a new task registry entry
++      const { createTask, getTask, getAllTasks } = await loadModules()
++      const child = Bun.spawn({ cmd: ['bash', '-c', 'sleep 30'] })
++      const abortController = new AbortController()
++
++      const task = createTask({
++        parentSessionID: 'session-1',
++        pid: child.pid,
++        startedAt: Date.now(),
++        status: 'running',
++        args: ['-c', 'sleep 30'],
++        cwd: process.cwd(),
++        stdoutLineBuffer: '',
++        events: [],
++        child,
++        completionPromise: child.exited.then(() => undefined),
++        abortController,
++      })
++
++      // When the task is read back from the registry
++      const fetched = getTask(task.taskId)
++      const allTasks = getAllTasks()
++
++      // Then it is stored under a generated cpl_ id
++      expect(task.taskId.startsWith('cpl_')).toBe(true)
++      expect(fetched).toBe(task)
++      expect(allTasks).toContain(task)
++    })
++  })
++
++  describe('helpers', () => {
++    it('strips ANSI escape sequences from text', async () => {
++      // Given ANSI-colored terminal output
++      const { stripAnsi } = await loadModules()
++      const input = '\u001b[31mred\u001b[0m normal \u001b[1mbold\u001b[0m'
++
++      // When ANSI codes are stripped
++      const result = stripAnsi(input)
++
++      // Then the visible text remains without escape sequences
++      expect(result).toBe('red normal bold')
++    })
++
++    it('ignores invalid pids when killing a process tree', async () => {
++      // Given an invalid process id
++      const { killProcessTree } = await loadModules()
++
++      // When killProcessTree is asked to terminate it
++      await killProcessTree(0)
++
++      // Then the helper exits without throwing
++    })
++  })
++})

--- a/.context/systematic/ce-review/20260423-154842-9db4dc23/maintainability-reviewer.json
+++ b/.context/systematic/ce-review/20260423-154842-9db4dc23/maintainability-reviewer.json
@@ -1,0 +1,98 @@
+{
+  "reviewer": "maintainability",
+  "findings": [
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 295,
+      "category": "premature-abstraction / naming",
+      "description": "`SpawnCopilotResult` is named like a passive DTO but acts as a live task handle: it owns a `ChildProcess`, an `AbortController`, mutable `status`, and a `completionPromise`. A caller receives this object and must mutate it to cancel or observe completion. This mismatch makes the lifetime model hard to reason about.",
+      "confidence": 0.85,
+      "suggestion": "Rename to `CopilotTask` or split into a pure `SpawnResult` (snapshot) and a separate `TaskHandle` / `TaskController` that owns the mutable runtime state."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 362,
+      "category": "coupling",
+      "description": "`spawnCopilot` generates its own `taskId` (`cpl_${crypto.randomUUID()}`) but never registers the task with `task-registry.ts`. Meanwhile `task-registry.ts` has an identical `TaskState` shape and its own `createTask` that generates a *second* ID. Any integration code will need to reconcile two IDs for the same logical task, creating a brittle hand-off.",
+      "confidence": 0.9,
+      "suggestion": "Either have `spawnCopilot` accept a `taskId` from the registry, or move `spawnCopilot` into the registry module so it can create and register the task atomically."
+    },
+    {
+      "file": "src/runtime/subprocess.ts vs src/runtime/task-registry.ts",
+      "line": null,
+      "category": "coupling / duplication",
+      "description": "`SpawnCopilotResult` and `TaskState` duplicate ~12 fields (pid, events, status, exitCode, stdoutLineBuffer, finalMessage, errorText, child, completionPromise, abortController, etc.). This near-identical shape means every future change to task metadata requires edits in two places.",
+      "confidence": 0.9,
+      "suggestion": "Extract a shared `BaseTask` or `Task` interface in a common location (e.g., `src/runtime/task.ts`) and have both modules extend or reference it."
+    },
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 178,
+      "category": "coupling",
+      "description": "`inFlightCounters` is module-level mutable `Map` state with no eviction policy. In a long-running process (e.g., a server or REPL), parent session IDs will accumulate indefinitely, leaking memory.",
+      "confidence": 0.8,
+      "suggestion": "Add a `delete` call when a counter reaches zero, or wrap the map in a small class that manages lifecycle."
+    },
+    {
+      "file": "src/discovery/agents.ts",
+      "line": 29,
+      "category": "complexity / error-handling",
+      "description": "`scanDir` silently swallows *all* errors in a bare `catch`. If the directory exists but is unreadable (permissions), the caller gets an empty list with no diagnostic. This masks configuration mistakes.",
+      "confidence": 0.75,
+      "suggestion": "Distinguish `ENOENT` (return empty) from other errors (re-throw or log)."
+    },
+    {
+      "file": "src/lib/kill-tree.ts",
+      "line": 114,
+      "category": "dead-code / error-handling",
+      "description": "`killProcessTree` returns silently for invalid PIDs without logging or throwing. The `-1` sentinel PID produced by `spawnCopilot` when `child.pid` is undefined will flow here and be silently ignored, making process leaks invisible.",
+      "confidence": 0.8,
+      "suggestion": "Log a warning when PID is invalid, or throw so the caller can decide."
+    },
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 148,
+      "category": "premature-abstraction",
+      "description": "`NotifyClient` is a broad, hand-rolled interface (`session`, `tui`, `app`) that mirrors an external client shape. It is only consumed by `notifyCompletion`. The abstraction adds indirection without enabling multiple implementations—tests mock the whole tree anyway.",
+      "confidence": 0.65,
+      "suggestion": "Inline the minimal shape needed (a `prompt` function and a `showToast` function) as separate parameters, or accept a smaller, task-specific interface."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 349,
+      "category": "naming",
+      "description": "`resolveAuthEnv` only resolves the GitHub auth token. The name implies general auth resolution, but the function is a single-field normalizer.",
+      "confidence": 0.7,
+      "suggestion": "Rename to `normalizeCopilotTokenEnv` or similar to reflect the single concern."
+    },
+    {
+      "file": "tests/subprocess.test.ts",
+      "line": 1180,
+      "category": "unnecessary-indirection",
+      "description": "`loadModules` uses `Reflect.get` to dynamically extract exports. This adds a layer of runtime indirection that TypeScript cannot check, and the `requireFunction` helper only asserts `typeof === 'function'`.",
+      "confidence": 0.6,
+      "suggestion": "Use static ES imports (`import { spawnCopilot } from '../src/runtime/subprocess'`) and let the type checker validate the shapes."
+    },
+    {
+      "file": "src/runtime/task-registry.ts",
+      "line": 460,
+      "category": "dead-code",
+      "description": "`TaskState` declares `endedAt?: number` but nothing in the diff writes to this field. If it is meant to be set by a future consumer, it is currently dead weight; if it is forgotten, it is a bug.",
+      "confidence": 0.7,
+      "suggestion": "Populate `endedAt` in `cleanupAll` or in a post-completion hook, or remove the field until needed."
+    }
+  ],
+  "residual_risks": [
+    "The `inFlightCounters` Map in `notify.ts` is shared mutable state without locking. While the decrement happens synchronously, concurrent increments/decrements across event-loop ticks could still race if `incrementInFlight` and `notifyCompletion` are called from different async contexts.",
+    "`spawnCopilot` attaches event listeners (`child.stdout.on('data')`, `child.stderr.on('data')`) but never removes them. If the `ChildProcess` object is retained in the registry, these closures keep the `task` object alive, creating a potential memory leak.",
+    "`fkill` is wrapped in a thin wrapper (`killProcessTree`) that hard-codes timeouts (`forceAfterTimeout: 2000`, `waitForExit: 5000`). If these values need tuning per-environment, the constants are buried in a library module and not configurable.",
+    "`scanDir` in `agents.ts` only looks at filenames, not file contents. A malformed `.md` file (e.g., empty, invalid frontmatter) will still surface as an available agent, which may lead to confusing runtime failures later."
+  ],
+  "testing_gaps": [
+    "No test verifies that `task-registry.ts` `cleanupAll` correctly sets `endedAt` (if that field is intended to be used).",
+    "No test for `agents.ts` `scanDir` when a directory exists but is unreadable (permissions error).",
+    "No test for `kill-tree.ts` behavior when `pid` is `-1` (the sentinel from `spawnCopilot`).",
+    "No test for `notify.ts` memory-leak scenario: repeatedly calling `incrementInFlight` with new session IDs and verifying that counters are evicted when they reach zero.",
+    "No integration test showing `spawnCopilot` + `task-registry` working together; the two modules are tested in isolation, hiding the double-ID problem."
+  ]
+}

--- a/.context/systematic/ce-review/20260423-154842-9db4dc23/metadata.json
+++ b/.context/systematic/ce-review/20260423-154842-9db4dc23/metadata.json
@@ -1,0 +1,7 @@
+{
+  "run_id": "20260423-154842-9db4dc23",
+  "branch": "feat/subprocess-agents",
+  "head_sha": "f4db6768f077678e037a3a229150584173b4733b",
+  "verdict": "Ready with fixes",
+  "completed_at": "2026-04-23T23:02:25Z"
+}

--- a/.context/systematic/ce-review/20260423-154842-9db4dc23/reliability-reviewer.json
+++ b/.context/systematic/ce-review/20260423-154842-9db4dc23/reliability-reviewer.json
@@ -1,0 +1,121 @@
+{
+  "reviewer": "reliability",
+  "findings": [
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 88,
+      "severity": "high",
+      "category": "missing-error-handling",
+      "confidence": 0.92,
+      "description": "Synchronous spawn errors are unhandled. `spawn('copilot', ...)` can throw immediately if the binary is missing, not executable, or the cwd is invalid. No try/catch means the caller receives a thrown exception instead of a controlled error state.",
+      "impact": "Caller cannot distinguish spawn failures from other runtime errors; unhandled exception may crash the invoking task or session.",
+      "recommendation": "Wrap `spawn()` in a try/catch and return a failed SpawnCopilotResult (or throw a typed SpawnError) so callers can handle it consistently."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 141,
+      "severity": "high",
+      "category": "unhandled-rejection",
+      "confidence": 0.88,
+      "description": "Abort handler fires `killProcessTree` as fire-and-forget (`void killProcessTree(...)`). If `fkill` throws (e.g., permission denied, process already dead), the promise rejection is unhandled and can crash the process in Node ≥15.",
+      "impact": "Intermittent unhandled promise rejections during cancellation or cleanup, especially on systems where process tree killing is restricted.",
+      "recommendation": "Await `killProcessTree` inside the handler and catch/log errors, or attach a `.catch()` to the promise to ensure the rejection is handled."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 88,
+      "severity": "medium",
+      "category": "missing-timeout",
+      "confidence": 0.85,
+      "description": "No timeout is set on the spawned subprocess. A hung `copilot` process (e.g., waiting on stdin, network deadlock) will run indefinitely, leaking a process and a task slot.",
+      "impact": "Resource leak; long-running or zombie processes accumulate until the host or parent session is restarted.",
+      "recommendation": "Add an optional timeout parameter to `spawnCopilot`. Use `setTimeout` to call `abortController.abort()` if the process exceeds the budget."
+    },
+    {
+      "file": "src/runtime/task-registry.ts",
+      "line": 29,
+      "severity": "medium",
+      "category": "memory-leak",
+      "confidence": 0.9,
+      "description": "The `tasks` Map is append-only. Individual tasks are never removed when they complete; only `cleanupAll()` clears the entire map. In a long-running session with many delegations, memory grows linearly.",
+      "impact": "Unbounded memory growth in long-lived OpenCode sessions; eventual OOM or performance degradation.",
+      "recommendation": "Add `deleteTask(taskId: string)` and invoke it after `completionPromise` resolves (or after `notifyCompletion` finishes) to evict finished tasks."
+    },
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 46,
+      "severity": "medium",
+      "category": "memory-leak",
+      "confidence": 0.85,
+      "description": "`inFlightCounters` entries are never deleted when a session's counter reaches zero. Over many sessions, the Map accumulates stale keys.",
+      "impact": "Small but unbounded memory leak for long-running parent sessions or high-churn session IDs.",
+      "recommendation": "Delete the map entry when `remaining === 0` after decrementing."
+    },
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 118,
+      "severity": "medium",
+      "category": "missing-timeout",
+      "confidence": 0.8,
+      "description": "`client.session.prompt()` is awaited without a timeout. If the parent session's prompt transport hangs (e.g., deadlocked IPC, network partition), `notifyCompletion` will never return, blocking any caller that awaits it.",
+      "impact": "Notification promises can hang indefinitely, leaking async contexts and preventing clean task finalization.",
+      "recommendation": "Race `client.session.prompt()` against a timeout (e.g., `Promise.race` with a 5s delay) and treat timeout as a logged failure."
+    },
+    {
+      "file": "src/runtime/task-registry.ts",
+      "line": 53,
+      "severity": "low",
+      "category": "race-condition",
+      "confidence": 0.75,
+      "description": "`cleanupAll()` calls `abortController.abort()` which triggers the abort handler in `subprocess.ts` to call `killProcessTree`. It then immediately calls `killProcessTree` again for the same PID. `fkill` is generally idempotent, but this is a redundant double-kill with no synchronization.",
+      "impact": "Minor — noisy errors in logs if the first kill succeeds and the second races; generally harmless but wastes resources.",
+      "recommendation": "Set a guard flag (e.g., `task.status = 'cancelled'`) before calling abort, and skip the explicit `killProcessTree` in `cleanupAll` if the abort handler already initiated it, or rely solely on the abort handler."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 98,
+      "severity": "low",
+      "category": "data-integrity",
+      "confidence": 0.7,
+      "description": "If `child.pid` is undefined, `task.pid` is set to `-1`. `killProcessTree` guards against this, but the `-1` sentinel leaks into `task-registry` and any downstream logging/metrics without validation.",
+      "impact": "Misleading telemetry or failed kill attempts that are silently swallowed; hard to debug why a process wasn't killed.",
+      "recommendation": "Reject or throw at spawn time if `child.pid` is missing, since a process we can't identify is not useful for lifecycle management."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 146,
+      "severity": "low",
+      "category": "error-swallowing",
+      "confidence": 0.65,
+      "description": "`completionPromise` always resolves, even when the child emits an 'error' event or exits non-zero. Callers awaiting the promise cannot detect failure from resolution alone; they must inspect `task.status` and `task.exitCode` afterwards.",
+      "impact": "Footgun for consumers — easy to assume `await task.completionPromise` means success.",
+      "recommendation": "Document the behavior explicitly in the type/interface, or consider rejecting the promise on failure so callers can use standard try/catch."
+    }
+  ],
+  "residual_risks": [
+    {
+      "description": "`fkill` dependency introduces an external kill strategy that may behave differently across platforms (Windows vs POSIX). If `fkill` has bugs or incompatibilities on a specific OS, process cleanup will fail silently or throw.",
+      "mitigation": "Pin `fkill` to a well-tested version and add CI coverage on all target platforms. Consider a fallback to `process.kill` if `fkill` throws."
+    },
+    {
+      "description": "`child.stdout` and `child.stderr` are accessed with optional chaining, but if they are unexpectedly null (e.g., due to stdio misconfiguration), the process will still spawn but no output will be captured. This failure mode is silent.",
+      "mitigation": "Assert that stdout/stderr are non-null after spawn in non-test builds, or log a warning if pipes are missing."
+    },
+    {
+      "description": "`parseJsonlLine` is defensive and returns `unknown` for malformed lines, but malformed JSONL from Copilot CLI will silently accumulate as `unknown` events without any telemetry. Debugging output issues will be difficult without logs.",
+      "mitigation": "Add an optional `onParseError` callback or log malformed lines at debug level in `subprocess.ts`."
+    }
+  ],
+  "testing_gaps": [
+    "No test for synchronous `spawn` failure (e.g., missing binary, permission denied).",
+    "No test for hung subprocess / absence of timeout behavior.",
+    "No test for `killProcessTree` throwing (e.g., permission denied, PID reuse).",
+    "No test verifying task removal from registry after completion (memory leak path).",
+    "No test for double-abort or concurrent `cleanupAll` + `abortController.abort()` race.",
+    "No test for `notifyCompletion` timeout / hanging parent session prompt.",
+    "No test for `inFlightCounters` cleanup when counter reaches zero.",
+    "No test for `child.pid` being undefined at spawn time.",
+    "No test for large stderr/stdout backpressure (pipe buffer exhaustion).",
+    "No test for malformed JSONL interleaved with valid lines."
+  ]
+}

--- a/.context/systematic/ce-review/20260423-154842-9db4dc23/security-reviewer.json
+++ b/.context/systematic/ce-review/20260423-154842-9db4dc23/security-reviewer.json
@@ -1,0 +1,84 @@
+{
+  "reviewer": "security",
+  "findings": [
+    {
+      "category": "command-injection",
+      "severity": "high",
+      "confidence": 0.85,
+      "file": "src/runtime/subprocess.ts",
+      "lines": "83-94",
+      "title": "Arbitrary binary execution via unvalidated PATH override in opts.env",
+      "description": "Caller-provided `opts.env` is merged with `process.env` without validation and passed to `spawn()`. A caller can inject `PATH` to redirect the `copilot` command resolution to an attacker-controlled binary. The existing test suite explicitly demonstrates this pattern (`makeSpawnEnv` overrides PATH to run a fake copilot binary). If `opts.env` is influenced by user input (e.g., agent configuration), this is a direct remote code execution vector.",
+      "attack_path": "User-controlled agent config → opts.env.PATH override → spawn('copilot') resolves to attacker binary → arbitrary code execution with parent privileges.",
+      "recommendation": "Validate `opts.env` against an allowlist of permitted keys, or explicitly strip `PATH` from caller input and construct a safe PATH internally."
+    },
+    {
+      "category": "information-disclosure",
+      "severity": "high",
+      "confidence": 0.8,
+      "file": "src/runtime/subprocess.ts",
+      "lines": "73-76, 83-86",
+      "title": "Full parent environment leaked to subprocess",
+      "description": "`resolveAuthEnv` spreads the entire environment object (`...env`) into the child process. The copilot subprocess receives every environment variable from the parent, including unrelated secrets (AWS credentials, other API tokens, SSH agent sockets, kubeconfig paths, internal service URLs). A compromised or malicious copilot subprocess can harvest these secrets.",
+      "attack_path": "Compromised/malicious copilot CLI or dependency → reads process.env → exfiltrates parent secrets.",
+      "recommendation": "Pass only the minimum required environment variables to the child (e.g., PATH, HOME, COPILOT_GITHUB_TOKEN). Do not spread the full parent env."
+    },
+    {
+      "category": "auth-bypass",
+      "severity": "moderate",
+      "confidence": 0.75,
+      "file": "src/runtime/subprocess.ts",
+      "lines": "83-86",
+      "title": "Auth token injection via caller-controlled opts.env",
+      "description": "`opts.env` is merged on top of `process.env` before `resolveAuthEnv` executes. A caller can inject `COPILOT_GITHUB_TOKEN` to override the parent's GitHub token. The child process will then authenticate to GitHub APIs using the attacker-controlled token, enabling potential data exfiltration to attacker-controlled endpoints or API gateways.",
+      "attack_path": "Attacker controls opts.env → injects COPILOT_GITHUB_TOKEN → child authenticates to GitHub with attacker token → code/prompts exfiltrated.",
+      "recommendation": "Do not allow caller-provided env to override security-critical variables. Resolve the auth token from a restricted, internally-managed source after merging env."
+    },
+    {
+      "category": "information-disclosure",
+      "severity": "moderate",
+      "confidence": 0.7,
+      "file": "src/runtime/subprocess.ts",
+      "lines": "67, 75-76",
+      "title": "Auth token duplicated across multiple environment variables",
+      "description": "When `GH_TOKEN` or `GITHUB_TOKEN` is present but `COPILOT_GITHUB_TOKEN` is absent, `resolveAuthEnv` copies the token into `COPILOT_GITHUB_TOKEN` while leaving the original variable in the environment. The child receives multiple copies of the same secret, increasing exposure if the child logs its environment or if any of these variables are inadvertently logged by downstream tools.",
+      "attack_path": "Child process or its dependencies log env vars → token appears under multiple names → harder to audit/revoke, increased leak surface.",
+      "recommendation": "After copying the token to `COPILOT_GITHUB_TOKEN`, delete `GH_TOKEN` and `GITHUB_TOKEN` from the child environment to minimize secret duplication."
+    },
+    {
+      "category": "race-condition",
+      "severity": "moderate",
+      "confidence": 0.65,
+      "file": "src/lib/kill-tree.ts",
+      "lines": "14",
+      "title": "PID reuse risk in asynchronous process tree kill",
+      "description": "`killProcessTree` is called asynchronously. Between the child process exiting and `fkill` executing, the OS may reuse the PID for a different process. `fkill(-pid, ...)` sends SIGTERM to the process group ID equal to the original child PID; if reused, an unrelated process or process group receives the signal. The `waitForExit: 5000` option does not verify process identity before signaling.",
+      "attack_path": "Child exits quickly → PID reused by unrelated process → abort triggers fkill(-pid) → legitimate process terminated.",
+      "recommendation": "Use Node.js `child.kill()` on the `ChildProcess` instance directly when possible, which references the OS handle rather than a numeric PID. If fkill is required, verify the process is still the expected child (e.g., via `process.kill(pid, 0)` and checking start time) before signaling the group."
+    },
+    {
+      "category": "information-disclosure",
+      "severity": "moderate",
+      "confidence": 0.6,
+      "file": "src/runtime/subprocess.ts",
+      "lines": "128-131, 59-61",
+      "title": "Unfiltered stderr capture may retain sensitive data",
+      "description": "Child stderr is captured verbatim into `task.errorText` without filtering or redaction. If the copilot CLI or any intermediate shell logs HTTP requests (including `Authorization` headers), file paths, or tokens to stderr, this sensitive data is stored in the in-memory task registry and may be exposed through task inspection APIs or error reporting.",
+      "attack_path": "Copilot CLI logs auth header to stderr → stderr captured in task.errorText → task registry retains token in memory → exposed via getTask or diagnostics.",
+      "recommendation": "Apply a redaction filter to stderr content before storing it, or avoid persisting full stderr in the task object."
+    }
+  ],
+  "residual_risks": [
+    "`opts.env` allowlist/filtering is not implemented. Even if PATH is restricted, other dangerous variables (LD_PRELOAD, DYLD_INSERT_LIBRARIES, NODE_OPTIONS) could be injected if the caller can influence opts.env.",
+    "`fkill` is an external npm dependency. Its security posture and supply-chain integrity are outside the scope of this review but represent a transitive trust boundary for signal delivery.",
+    "Process group signaling (`fkill(-pid)`) behavior differs across platforms (Unix vs Windows). The `detached: true` flag creates a process group on Unix but semantics vary on Windows, potentially leading to incomplete cleanup or unexpected signal targets.",
+    "`resolveAuthEnv` does not validate token format or length before propagation. A malformed or extremely long token could cause issues in downstream consumers."
+  ],
+  "testing_gaps": [
+    "No test verifies that dangerous environment variables (PATH, LD_PRELOAD, DYLD_INSERT_LIBRARIES, NODE_OPTIONS) are rejected or sanitized in `opts.env`.",
+    "No test verifies that the child process receives only the minimum required environment variables rather than the full parent env.",
+    "No test covers token precedence edge cases: empty string values (`''`), whitespace-only tokens, or multiple simultaneous tokens.",
+    "No test simulates rapid child exit followed by PID reuse to verify that `killProcessTree` does not affect unrelated processes.",
+    "No test verifies that stderr content containing patterns like `Authorization: token` or `ghp_` is redacted before storage in `task.errorText`."
+  ]
+}

--- a/.context/systematic/ce-review/20260423-154842-9db4dc23/testing-reviewer.json
+++ b/.context/systematic/ce-review/20260423-154842-9db4dc23/testing-reviewer.json
@@ -1,0 +1,148 @@
+{
+  "reviewer": "testing",
+  "findings": [
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 111,
+      "severity": "high",
+      "category": "untested-branch",
+      "confidence": 0.92,
+      "message": "`cancelled` status in noReply logic is never tested. The condition `task.status === 'failed' || task.status === 'cancelled'` forces `noReply: false`, but only `failed` has a test case. A regression that accidentally dropped `cancelled` from this condition would not be caught.",
+      "suggestion": "Add a notify test with `status: 'cancelled'` and assert `noReply: false`."
+    },
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 133,
+      "severity": "high",
+      "category": "untested-branch",
+      "confidence": 0.92,
+      "message": "Toast variant and message for `cancelled` status are untested. The ternary `task.status === 'complete' ? 'success' : 'error'` should yield `error` for cancelled, but no test exercises this branch.",
+      "suggestion": "Add a notify test with `status: 'cancelled'` asserting toast variant is `error` and message contains 'cancelled'."
+    },
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 60,
+      "severity": "medium",
+      "category": "untested-branch",
+      "confidence": 0.85,
+      "message": "`formatDuration` has three branches (`<1000ms`, `<60s`, `>=60s`) but tests only implicitly hit the `<60s` path (startedAt is 5000ms ago). The `<1000ms` and `>=60s` branches have no coverage.",
+      "suggestion": "Add tests for durations 500ms and 90000ms to verify all three formatting branches."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 66,
+      "severity": "high",
+      "category": "untested-branch",
+      "confidence": 0.9,
+      "message": "`resolveAuthEnv` is completely untested. The token fallback chain (`COPILOT_GITHUB_TOKEN ?? GH_TOKEN ?? GITHUB_TOKEN`) and the passthrough when no token exists have zero test coverage.",
+      "suggestion": "Export `resolveAuthEnv` (or test via spawn with controlled env) and add cases for: no token, GH_TOKEN present, GITHUB_TOKEN present, COPILOT_GITHUB_TOKEN already set."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 59,
+      "severity": "high",
+      "category": "untested-branch",
+      "confidence": 0.9,
+      "message": "`finalizeTask` never captures stderr in tests. The branch `if (stderrText.trim().length > 0) { task.errorText = ... }` is not exercised. A regression that broke stderr capture would go unnoticed.",
+      "suggestion": "Add a subprocess test where the fake copilot binary writes to stderr and assert `task.errorText` contains the stripped content."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 147,
+      "severity": "high",
+      "category": "untested-branch",
+      "confidence": 0.88,
+      "message": "The `child.once('error', ...)` spawn error handler is untested. If `copilot` binary is missing or not executable, the task should be marked `failed` with `errorText` set. No test simulates this.",
+      "suggestion": "Add a test spawning a non-existent binary (or a path guaranteed to fail) and assert `task.status === 'failed'` and `errorText` is populated."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 136,
+      "severity": "medium",
+      "category": "untested-branch",
+      "confidence": 0.85,
+      "message": "The double-abort guard `if (task.status !== 'running') { return }` is untested. Calling `abortController.abort()` twice should not attempt to kill the process tree a second time.",
+      "suggestion": "Add a test that calls `abort()` twice and verifies `killProcessTree` is only invoked once (e.g., by mocking it) or simply that it does not throw."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 42,
+      "severity": "medium",
+      "category": "untested-branch",
+      "confidence": 0.8,
+      "message": "`assignFinalMessage` short-circuits when no `message` events exist. No test verifies that `finalMessage` remains undefined for a task that only emits `usage`/`result` events.",
+      "suggestion": "Add a subprocess test that emits only a `result` event (no `assistant.message`) and assert `task.finalMessage` is undefined."
+    },
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 132,
+      "severity": "medium",
+      "category": "missing-edge-case",
+      "confidence": 0.9,
+      "message": "Toast failure swallowing is untested. The `try/catch` around `client.tui.showToast` exists to prevent toast errors from bubbling, but no test makes the toast throw.",
+      "suggestion": "Add a notify test where `client.tui.showToast` throws and assert `notifyCompletion` still resolves without error."
+    },
+    {
+      "file": "src/runtime/notify.ts",
+      "line": 105,
+      "severity": "medium",
+      "category": "missing-edge-case",
+      "confidence": 0.82,
+      "message": "Counter underflow defense is untested. If `notifyCompletion` is called without a matching `incrementInFlight`, `current` is 0 and `remaining` becomes 0 via `Math.max(0, current - 1)`. No test verifies this defensive behavior.",
+      "suggestion": "Add a test that calls `notifyCompletion` without prior `incrementInFlight` and assert `noReply: false` and the counter remains 0."
+    },
+    {
+      "file": "tests/subprocess.test.ts",
+      "line": 302,
+      "severity": "low",
+      "category": "weak-assertion",
+      "confidence": 0.7,
+      "message": "`ignores invalid pids when killing a process tree` only asserts the function doesn't throw. It does not verify that `fkill` is never called (the actual behavior enforced by the guard clause).",
+      "suggestion": "If possible, mock `fkill` and assert it is not invoked for invalid pids, or at minimum assert the function returns undefined immediately."
+    },
+    {
+      "file": "tests/agents.test.ts",
+      "line": 18,
+      "severity": "low",
+      "category": "brittle-test",
+      "confidence": 0.6,
+      "message": "Built-in agent count and exact name list are hardcoded (`toHaveLength(6)` and explicit array). Adding or renaming a built-in agent will break this test even though the behavior (discovering builtins) hasn't changed.",
+      "suggestion": "Consider asserting that all returned agents have `source: 'builtin'` and that the list is non-empty, rather than pinning the exact count and names."
+    },
+    {
+      "file": "src/runtime/subprocess.ts",
+      "line": 119,
+      "severity": "low",
+      "category": "missing-edge-case",
+      "confidence": 0.65,
+      "message": "Empty stdout lines between JSONL events are skipped via `if (line.length === 0) { continue }`, but no test emits empty lines to verify they don't create spurious `unknown` events.",
+      "suggestion": "Add a subprocess test that includes empty lines in stdout and assert they are ignored (events length should not increase for empty lines)."
+    },
+    {
+      "file": "src/discovery/agents.ts",
+      "line": 27,
+      "severity": "low",
+      "category": "missing-edge-case",
+      "confidence": 0.7,
+      "message": "`scanDir` filters for `.md` files, but no test has a directory with mixed file types (e.g., `.md` and `.txt`) to verify non-`.md` files are excluded.",
+      "suggestion": "Add a fixture directory with a `.txt` file and assert it does not appear in discovered agents."
+    }
+  ],
+  "residual_risks": [
+    "The untested `cancelled` paths in `notifyCompletion` mean a refactor of the noReply or toast logic could silently break cancellation UX.",
+    "Untested stderr capture (`errorText`) means production subprocess errors may be lost without regression detection.",
+    "Untested spawn error handling means a broken `copilot` binary path or permission issue would fail silently in production with no test signal.",
+    "`resolveAuthEnv` is entirely unverified; a typo in the env var fallback chain would break GitHub Copilot authentication in all delegated tasks."
+  ],
+  "testing_gaps": [
+    "`cancelled` status handling in notify (noReply semantics and toast variant)",
+    "Auth environment resolution (`resolveAuthEnv` token fallback)",
+    "Stderr capture and `errorText` propagation in subprocess runtime",
+    "Spawn error handling (`child.once('error')` branch)",
+    "Double-abort guard in subprocess abort listener",
+    "Toast error swallowing in notify",
+    "Duration formatting edge cases (<1s and >1min)",
+    "`assignFinalMessage` behavior when no message events exist",
+    "Counter underflow in notify when `notifyCompletion` is called without matching `incrementInFlight`"
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "opencode-copilot-delegate",
+      "dependencies": {
+        "fkill": "10.0.3",
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
         "@opencode-ai/plugin": "^1.14.19",
@@ -54,6 +57,10 @@
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.20", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-kPZP1An1ZdWOfLfDYhNjh665HX4RcI8au6Lzjn0FktoQ3RpWHq1WXRLHrJO8rJqwWvQDOzS48cXt9jbr+uwQiA=="],
 
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
@@ -72,19 +79,39 @@
 
     "effect": ["effect@4.0.0-beta.48", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw=="],
 
+    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
     "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
+    "fkill": ["fkill@10.0.3", "", { "dependencies": { "execa": "^9.6.0", "pid-port": "^2.0.0", "process-exists": "^5.0.0", "ps-list": "^9.0.0", "taskkill": "^5.0.0" } }, "sha512-E0zxFLM/drPziQ8UXxbgD2L1N3oSllgdNJjDOdUNx3g5l9vdouPZiF9up1av27sA9taZmS5VowatuVDNHAUymg=="],
+
+    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
+
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
+    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -98,11 +125,25 @@
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
+    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "pid-port": ["pid-port@2.1.1", "", { "dependencies": { "execa": "^9.6.0" } }, "sha512-teosUBzP9q3GMZDp/QlI/HSJHwnIBiCtDWhM/OxSB2PcR20Z0uFrrsAjKbG3e4WlQTVm5oTfmvgXEp+gk/rZ0w=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
+
+    "process-exists": ["process-exists@5.0.0", "", { "dependencies": { "ps-list": "^8.0.0" } }, "sha512-6QPRh5fyHD8MaXr4GYML8K/YY0Sq5dKHGIOrAKS3cYpHQdmygFCcijIu1dVoNKAZ0TWAMoeh8KDK9dF8auBkJA=="],
+
+    "ps-list": ["ps-list@9.0.0", "", {}, "sha512-lxMEoIL/BQlk2KunFzxwUPwMvjFH7x7cmvzSLsSHpyMXl9FFfLUlfKrYwFc4wx/ZaIxxuXC4n8rjQ1CX/tkXVQ=="],
 
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
@@ -112,11 +153,19 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
+
+    "taskkill": ["taskkill@5.0.0", "", { "dependencies": { "execa": "^6.1.0" } }, "sha512-+HRtZ40Vc+6YfCDWCeAsixwxJgMbPY4HHuTgzPYH3JXvqHWUlsCfy+ylXlAKhFNcuLp4xVeWeFBUhDk+7KYUvQ=="],
+
     "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
@@ -124,6 +173,28 @@
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
     "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "process-exists/ps-list": ["ps-list@8.1.1", "", {}, "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ=="],
+
+    "taskkill/execa": ["execa@6.1.0", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.1", "human-signals": "^3.0.1", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^3.0.7", "strip-final-newline": "^3.0.0" } }, "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA=="],
+
+    "taskkill/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "taskkill/execa/human-signals": ["human-signals@3.0.1", "", {}, "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ=="],
+
+    "taskkill/execa/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
+
+    "taskkill/execa/npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
+
+    "taskkill/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "taskkill/execa/strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "taskkill/execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "lint": "biome check .",
     "fix": "biome check . --write",
     "prepublishOnly": "bun run build"
+  },
+  "dependencies": {
+    "fkill": "10.0.3"
   }
 }

--- a/src/discovery/agents.ts
+++ b/src/discovery/agents.ts
@@ -1,1 +1,56 @@
-// TODO: implement in T5 — agent file discovery
+import { readdirSync } from 'node:fs'
+import { basename } from 'node:path'
+
+export interface Agent {
+  name: string
+  source: 'builtin' | 'user' | 'repo'
+}
+
+const BUILTIN_AGENTS: readonly string[] = [
+  'default',
+  'explore',
+  'task',
+  'general-purpose',
+  'code-review',
+  'research',
+]
+
+interface DiscoverOptions {
+  userAgentsDir?: string
+  repoAgentsDir?: string
+}
+
+function scanDir(dir: string, source: 'user' | 'repo'): Agent[] {
+  try {
+    const entries = readdirSync(dir)
+    return entries
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => ({
+        name: basename(f, '.md'),
+        source,
+      }))
+  } catch {
+    return []
+  }
+}
+
+export function discoverAgents(opts: DiscoverOptions): Agent[] {
+  const builtins: Agent[] = BUILTIN_AGENTS.map((name) => ({
+    name,
+    source: 'builtin',
+  }))
+
+  const userAgents = opts.userAgentsDir
+    ? scanDir(opts.userAgentsDir, 'user')
+    : []
+
+  const repoAgents = opts.repoAgentsDir
+    ? scanDir(opts.repoAgentsDir, 'repo')
+    : []
+
+  // Repo overrides user with same name
+  const overriddenNames = new Set(repoAgents.map((a) => a.name))
+  const filteredUser = userAgents.filter((a) => !overriddenNames.has(a.name))
+
+  return [...builtins, ...filteredUser, ...repoAgents]
+}

--- a/src/discovery/agents.ts
+++ b/src/discovery/agents.ts
@@ -48,9 +48,13 @@ export function discoverAgents(opts: DiscoverOptions): Agent[] {
     ? scanDir(opts.repoAgentsDir, 'repo')
     : []
 
-  // Repo overrides user with same name
+  // Repo overrides user with same name; builtins are never overridden
+  const builtinNames = new Set(BUILTIN_AGENTS)
   const overriddenNames = new Set(repoAgents.map((a) => a.name))
-  const filteredUser = userAgents.filter((a) => !overriddenNames.has(a.name))
+  const filteredUser = userAgents
+    .filter((a) => !builtinNames.has(a.name))
+    .filter((a) => !overriddenNames.has(a.name))
+  const filteredRepo = repoAgents.filter((a) => !builtinNames.has(a.name))
 
-  return [...builtins, ...filteredUser, ...repoAgents]
+  return [...builtins, ...filteredUser, ...filteredRepo]
 }

--- a/src/discovery/description.ts
+++ b/src/discovery/description.ts
@@ -1,1 +1,22 @@
-// TODO: implement in T5 — build copilot_delegate description string
+import type { Agent } from './agents'
+
+const MAX_DISPLAYED = 20
+
+export function buildDescription(agents: Agent[]): string {
+  const displayed = agents.slice(0, MAX_DISPLAYED)
+  const remaining = agents.length - MAX_DISPLAYED
+
+  const lines = ['Available Copilot agents:']
+
+  for (const agent of displayed) {
+    lines.push(`  - ${agent.name} (${agent.source})`)
+  }
+
+  if (remaining > 0) {
+    lines.push(
+      `  ... and ${remaining} more (use copilot_list_agents to see all)`,
+    )
+  }
+
+  return lines.join('\n')
+}

--- a/src/lib/ansi.ts
+++ b/src/lib/ansi.ts
@@ -1,1 +1,9 @@
-// TODO: implement in T3 — ANSI escape sequence stripper
+// biome-ignore lint/complexity/useRegexLiterals: constructor avoids control-character regex literal lint
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  '(?:\\u001B|\\u009B)[[\\]()#;?]*(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]|(?:[\\dA-PR-TZcf-nq-uy=><~]))',
+  'g',
+)
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_PATTERN, '')
+}

--- a/src/lib/kill-tree.ts
+++ b/src/lib/kill-tree.ts
@@ -1,1 +1,15 @@
-// TODO: implement in T3 — cross-platform process tree kill
+import fkill from 'fkill'
+
+export async function killProcessTree(pid: number): Promise<void> {
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return
+  }
+
+  const options = {
+    force: false,
+    forceAfterTimeout: 2000,
+    waitForExit: 5000,
+  }
+
+  await fkill(-pid, options)
+}

--- a/src/runtime/notify.ts
+++ b/src/runtime/notify.ts
@@ -1,1 +1,145 @@
-// TODO: implement in T4 — client.session.promptAsync wrapper
+/**
+ * Notification injection for Copilot delegation completions.
+ *
+ * Injects `<system-reminder>` messages into the parent OpenCode session
+ * when a delegated Copilot subprocess completes. Uses `noReply` semantics
+ * mirroring OMO's per-parent-session in-flight counter pattern.
+ *
+ * Correctness invariant: decrement the in-flight counter synchronously
+ * (before any await) to prevent concurrent completions from both reading
+ * the same counter value and both setting noReply: false.
+ */
+
+import type { TaskStatus } from './envelope'
+
+/** Minimal client interface for notification injection. */
+export type NotifyClient = {
+  session: {
+    prompt: (opts: {
+      path: { id: string }
+      body: {
+        noReply: boolean
+        parts: Array<{ type: string; text: string; synthetic: boolean }>
+      }
+    }) => Promise<unknown>
+  }
+  tui: {
+    showToast: (opts: { body: { message: string; variant: string } }) => void
+  }
+  app: {
+    log: (...args: unknown[]) => void
+  }
+}
+
+/** Task information needed for building the notification. */
+export type NotifyTaskInfo = {
+  taskId: string
+  parentSessionID: string
+  status: TaskStatus
+  agentName?: string
+  modelName?: string
+  startedAt: number
+  exitCode?: number
+}
+
+/** Per-parent-session in-flight task counters. */
+const inFlightCounters = new Map<string, number>()
+
+/** Increment the in-flight counter for a parent session. */
+export function incrementInFlight(parentSessionID: string): void {
+  const current = inFlightCounters.get(parentSessionID) ?? 0
+  inFlightCounters.set(parentSessionID, current + 1)
+}
+
+/** Reset all counters (for testing only). */
+export function resetInFlightCounters(): void {
+  inFlightCounters.clear()
+}
+
+/** Format duration in human-readable form. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  return `${minutes}m ${remainingSeconds}s`
+}
+
+/** Build the `<system-reminder>` notification text. */
+function buildNotificationText(task: NotifyTaskInfo): string {
+  const agent = task.agentName ?? 'default'
+  const model = task.modelName ?? 'default'
+  const duration = formatDuration(Date.now() - task.startedAt)
+
+  let text = `<system-reminder>
+[COPILOT DELEGATION COMPLETED]
+**Task ID:** \`${task.taskId}\`
+**Agent:** ${agent}
+**Model:** ${model}
+**Duration:** ${duration}
+**Status:** ${task.status}
+
+Use \`copilot_output(task_id="${task.taskId}")\` to retrieve the structured result.`
+
+  if (task.status === 'failed') {
+    text += `\n\n**ACTION REQUIRED:** Subprocess exited with code ${task.exitCode ?? 'unknown'}.`
+  }
+
+  text += '\n</system-reminder>'
+  return text
+}
+
+/**
+ * Notify the parent session that a Copilot delegation has completed.
+ *
+ * Decrements the in-flight counter synchronously, then injects the
+ * notification via client.session.prompt with correct noReply semantics.
+ * Never throws — logs and swallows prompt/toast errors.
+ */
+export async function notifyCompletion(
+  client: NotifyClient,
+  task: NotifyTaskInfo,
+): Promise<void> {
+  // Decrement synchronously BEFORE any await — correctness invariant
+  const current = inFlightCounters.get(task.parentSessionID) ?? 0
+  const remaining = Math.max(0, current - 1)
+  inFlightCounters.set(task.parentSessionID, remaining)
+
+  // Failed exits always force a parent turn
+  const noReply: boolean =
+    task.status === 'failed' || task.status === 'cancelled'
+      ? false
+      : remaining > 0
+
+  const text = buildNotificationText(task)
+
+  try {
+    await client.session.prompt({
+      path: { id: task.parentSessionID },
+      body: {
+        noReply,
+        parts: [{ type: 'text', text, synthetic: true }],
+      },
+    })
+  } catch (error) {
+    client.app.log(
+      'notify',
+      `Failed to inject notification for ${task.taskId}: ${error}`,
+    )
+  }
+
+  try {
+    const variant = task.status === 'complete' ? 'success' : 'error'
+    const toastMessage =
+      task.status === 'complete'
+        ? `Copilot delegation ${task.taskId} completed`
+        : `Copilot delegation ${task.taskId} ${task.status}`
+
+    client.tui.showToast({
+      body: { message: toastMessage, variant },
+    })
+  } catch {
+    // Toast failure is non-critical
+  }
+}

--- a/src/runtime/notify.ts
+++ b/src/runtime/notify.ts
@@ -104,7 +104,11 @@ export async function notifyCompletion(
   // Decrement synchronously BEFORE any await — correctness invariant
   const current = inFlightCounters.get(task.parentSessionID) ?? 0
   const remaining = Math.max(0, current - 1)
-  inFlightCounters.set(task.parentSessionID, remaining)
+  if (remaining === 0) {
+    inFlightCounters.delete(task.parentSessionID)
+  } else {
+    inFlightCounters.set(task.parentSessionID, remaining)
+  }
 
   // Failed exits always force a parent turn
   const noReply: boolean =

--- a/src/runtime/subprocess.ts
+++ b/src/runtime/subprocess.ts
@@ -143,16 +143,15 @@ export function spawnCopilot(
     { once: true },
   )
 
-  task.completionPromise = new Promise<void>((resolve, reject) => {
+  task.completionPromise = new Promise<void>((resolve) => {
     child.once('error', (error) => {
       task.status = 'failed'
       task.errorText = stripAnsi(error.message)
-      reject(error)
+      resolve()
     })
 
     child.once('close', (code) => {
       finalizeTask(task, code, stderrText)
-
       resolve()
     })
   })

--- a/src/runtime/subprocess.ts
+++ b/src/runtime/subprocess.ts
@@ -1,1 +1,161 @@
-// TODO: implement in T3 — subprocess spawn + line-buffered stdout parser
+import { type ChildProcess, spawn } from 'node:child_process'
+import { stripAnsi } from '../lib/ansi'
+import { killProcessTree } from '../lib/kill-tree'
+import type { TaskStatus } from './envelope'
+import { type ParsedEvent, parseJsonlLine } from './jsonl-parser'
+
+type SpawnCopilotOptions = {
+  cwd: string
+  env?: Record<string, string>
+}
+
+type SpawnCopilotResult = {
+  taskId: string
+  pid: number
+  events: ParsedEvent[]
+  completionPromise: Promise<void>
+  abortController: AbortController
+  child: ChildProcess
+  status: TaskStatus
+  exitCode?: number
+  stdoutLineBuffer: string
+  finalMessage?: string
+  errorText?: string
+}
+
+function flushBufferedStdout(task: SpawnCopilotResult): void {
+  if (task.stdoutLineBuffer.trim().length === 0) {
+    task.stdoutLineBuffer = ''
+    return
+  }
+
+  task.events.push(parseJsonlLine(task.stdoutLineBuffer))
+  task.stdoutLineBuffer = ''
+}
+
+function assignFinalMessage(task: SpawnCopilotResult): void {
+  const lastMessage = [...task.events]
+    .reverse()
+    .find((event) => event.type === 'message')
+  const content = lastMessage?.data.content
+
+  if (typeof content === 'string' && content.length > 0) {
+    task.finalMessage = stripAnsi(content)
+  }
+}
+
+function finalizeTask(
+  task: SpawnCopilotResult,
+  exitCode: number | null,
+  stderrText: string,
+): void {
+  flushBufferedStdout(task)
+  task.exitCode = exitCode ?? undefined
+
+  if (task.status !== 'cancelled') {
+    task.status = exitCode === 0 ? 'complete' : 'failed'
+  }
+
+  if (stderrText.trim().length > 0) {
+    task.errorText = stripAnsi(stderrText.trim())
+  }
+
+  assignFinalMessage(task)
+}
+
+function resolveAuthEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const authToken = env.COPILOT_GITHUB_TOKEN ?? env.GH_TOKEN ?? env.GITHUB_TOKEN
+
+  if (!authToken) {
+    return env
+  }
+
+  return {
+    ...env,
+    COPILOT_GITHUB_TOKEN: authToken,
+  }
+}
+
+export function spawnCopilot(
+  args: string[],
+  opts: SpawnCopilotOptions,
+): SpawnCopilotResult {
+  const env = resolveAuthEnv({
+    ...process.env,
+    ...opts.env,
+  })
+
+  const child = spawn('copilot', args, {
+    cwd: opts.cwd,
+    detached: true,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+
+  const events: ParsedEvent[] = []
+  const task: SpawnCopilotResult = {
+    taskId: `cpl_${crypto.randomUUID()}`,
+    pid: child.pid ?? -1,
+    events,
+    abortController: new AbortController(),
+    child,
+    status: 'running',
+    exitCode: undefined,
+    stdoutLineBuffer: '',
+    completionPromise: Promise.resolve(),
+  }
+
+  let stderrText = ''
+
+  child.stdout?.setEncoding('utf8')
+  child.stdout?.on('data', (chunk: string) => {
+    task.stdoutLineBuffer += chunk
+
+    const lines = task.stdoutLineBuffer.split(/\r?\n/)
+    task.stdoutLineBuffer = lines.pop() ?? ''
+
+    for (const line of lines) {
+      if (line.length === 0) {
+        continue
+      }
+
+      const event = parseJsonlLine(line)
+      events.push(event)
+    }
+  })
+
+  child.stderr?.setEncoding('utf8')
+  child.stderr?.on('data', (chunk: string) => {
+    stderrText += chunk
+  })
+
+  task.abortController.signal.addEventListener(
+    'abort',
+    () => {
+      if (task.status !== 'running') {
+        return
+      }
+
+      task.status = 'cancelled'
+      void killProcessTree(task.pid)
+    },
+    { once: true },
+  )
+
+  task.completionPromise = new Promise<void>((resolve, reject) => {
+    child.once('error', (error) => {
+      task.status = 'failed'
+      task.errorText = stripAnsi(error.message)
+      reject(error)
+    })
+
+    child.once('close', (code) => {
+      finalizeTask(task, code, stderrText)
+
+      resolve()
+    })
+  })
+
+  return task
+}

--- a/src/runtime/subprocess.ts
+++ b/src/runtime/subprocess.ts
@@ -37,7 +37,7 @@ function assignFinalMessage(task: SpawnCopilotResult): void {
   const lastMessage = [...task.events]
     .reverse()
     .find((event) => event.type === 'message')
-  const content = lastMessage?.data.content
+  const content = lastMessage?.data?.content
 
   if (typeof content === 'string' && content.length > 0) {
     task.finalMessage = stripAnsi(content)
@@ -138,7 +138,9 @@ export function spawnCopilot(
       }
 
       task.status = 'cancelled'
-      void killProcessTree(task.pid)
+      killProcessTree(task.pid).catch(() => {
+        // Kill failure after abort is non-fatal — process may already be dead
+      })
     },
     { once: true },
   )

--- a/src/runtime/subprocess.ts
+++ b/src/runtime/subprocess.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { stripAnsi } from '../lib/ansi'
 import { killProcessTree } from '../lib/kill-tree'
 import type { TaskStatus } from './envelope'
@@ -18,6 +19,7 @@ type SpawnCopilotResult = {
   child: ChildProcess
   status: TaskStatus
   exitCode?: number
+  endedAt?: number
   stdoutLineBuffer: string
   finalMessage?: string
   errorText?: string
@@ -50,6 +52,7 @@ function finalizeTask(
   stderrText: string,
 ): void {
   flushBufferedStdout(task)
+  task.endedAt = Date.now()
   task.exitCode = exitCode ?? undefined
 
   if (task.status !== 'cancelled') {
@@ -95,7 +98,7 @@ export function spawnCopilot(
 
   const events: ParsedEvent[] = []
   const task: SpawnCopilotResult = {
-    taskId: `cpl_${crypto.randomUUID()}`,
+    taskId: `cpl_${randomUUID()}`,
     pid: child.pid ?? -1,
     events,
     abortController: new AbortController(),

--- a/src/runtime/task-registry.ts
+++ b/src/runtime/task-registry.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { killProcessTree } from '../lib/kill-tree'
 import type { TaskStatus } from './envelope'
 import type { ParsedEvent } from './jsonl-parser'
@@ -29,7 +30,7 @@ export type CreateTaskInput = Omit<TaskState, 'taskId'>
 const tasks = new Map<string, TaskState>()
 
 export function createTask(input: CreateTaskInput): TaskState {
-  const taskId = `cpl_${crypto.randomUUID()}`
+  const taskId = `cpl_${randomUUID()}`
   const task: TaskState = {
     ...input,
     taskId,

--- a/src/runtime/task-registry.ts
+++ b/src/runtime/task-registry.ts
@@ -1,1 +1,64 @@
-// TODO: implement in T3 — in-memory task registry
+import type { ChildProcess } from 'node:child_process'
+import { killProcessTree } from '../lib/kill-tree'
+import type { TaskStatus } from './envelope'
+import type { ParsedEvent } from './jsonl-parser'
+
+export type TaskState = {
+  taskId: string
+  parentSessionID: string
+  pid: number
+  startedAt: number
+  endedAt?: number
+  status: TaskStatus
+  exitCode?: number
+  args: string[]
+  cwd: string
+  agentName?: string
+  modelName?: string
+  stdoutLineBuffer: string
+  events: ParsedEvent[]
+  finalMessage?: string
+  errorText?: string
+  child: ChildProcess
+  completionPromise: Promise<void>
+  abortController: AbortController
+}
+
+export type CreateTaskInput = Omit<TaskState, 'taskId'>
+
+const tasks = new Map<string, TaskState>()
+
+export function createTask(input: CreateTaskInput): TaskState {
+  const taskId = `cpl_${crypto.randomUUID()}`
+  const task: TaskState = {
+    ...input,
+    taskId,
+  }
+
+  tasks.set(taskId, task)
+  return task
+}
+
+export function getTask(taskId: string): TaskState | undefined {
+  return tasks.get(taskId)
+}
+
+export function getAllTasks(): TaskState[] {
+  return [...tasks.values()]
+}
+
+export async function cleanupAll(): Promise<void> {
+  const runningTasks = [...tasks.values()]
+
+  await Promise.allSettled(
+    runningTasks.map(async (task) => {
+      task.abortController.abort()
+
+      if (task.pid > 0 && task.status === 'running') {
+        await killProcessTree(task.pid)
+      }
+    }),
+  )
+
+  tasks.clear()
+}

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -118,17 +118,21 @@ describe('discoverAgents', () => {
     })
 
     it('should not override built-in agents with user or repo agents of the same name', () => {
-      // Given user and repo dirs (neither contains a file named "default.md")
+      // Given user and repo dirs that BOTH contain a "default.md" fixture
       // When discovering agents
       const agents = discoverAgents({
         userAgentsDir: userDir,
         repoAgentsDir: repoDir,
       })
 
-      // Then built-in "default" remains
+      // Then built-in "default" remains as the only "default" entry
       const defaults = agents.filter((a) => a.name === 'default')
       expect(defaults).toHaveLength(1)
       expect(defaults[0].source).toBe('builtin')
+
+      // And the total count excludes both colliding fixtures
+      // builtins(6) + user(my-reviewer) + repo(custom-helper, project-bot) = 9
+      expect(agents).toHaveLength(9)
     })
   })
 

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'bun:test'
+import { join } from 'node:path'
+import { type Agent, discoverAgents } from '../src/discovery/agents'
+import { buildDescription } from '../src/discovery/description'
+
+const fixturesDir = join(import.meta.dir, 'fixtures', 'agents')
+const userDir = join(fixturesDir, 'user')
+const repoDir = join(fixturesDir, 'repo')
+
+describe('discoverAgents', () => {
+  describe('built-in agents', () => {
+    it('should return built-in agents when no directories are provided', () => {
+      // Given no user or repo agent directories
+      // When discovering agents
+      const agents = discoverAgents({})
+
+      // Then only built-in agents are returned
+      const builtins = agents.filter((a) => a.source === 'builtin')
+      expect(builtins).toHaveLength(6)
+      expect(builtins.map((a) => a.name)).toEqual([
+        'default',
+        'explore',
+        'task',
+        'general-purpose',
+        'code-review',
+        'research',
+      ])
+    })
+
+    it('should mark all built-in agents with source "builtin"', () => {
+      // Given no external directories
+      // When discovering agents
+      const agents = discoverAgents({})
+
+      // Then every agent has source "builtin"
+      for (const agent of agents) {
+        expect(agent.source).toBe('builtin')
+      }
+    })
+  })
+
+  describe('user agents', () => {
+    it('should include user agents from the user directory', () => {
+      // Given a user agents directory with .md files
+      // When discovering agents
+      const agents = discoverAgents({ userAgentsDir: userDir })
+
+      // Then user agents appear after built-ins
+      const userAgents = agents.filter((a) => a.source === 'user')
+      expect(userAgents.length).toBe(2)
+      expect(userAgents.map((a) => a.name).sort()).toEqual([
+        'custom-helper',
+        'my-reviewer',
+      ])
+    })
+
+    it('should place user agents after built-in agents', () => {
+      // Given a user agents directory
+      // When discovering agents
+      const agents = discoverAgents({ userAgentsDir: userDir })
+
+      // Then built-ins come first, then user agents
+      const firstUserIndex = agents.findIndex((a) => a.source === 'user')
+      const lastBuiltinIndex = agents.findLastIndex(
+        (a) => a.source === 'builtin',
+      )
+      expect(firstUserIndex).toBeGreaterThan(lastBuiltinIndex)
+    })
+  })
+
+  describe('repo agents', () => {
+    it('should include repo agents from the repo directory', () => {
+      // Given a repo agents directory with .md files
+      // When discovering agents
+      const agents = discoverAgents({ repoAgentsDir: repoDir })
+
+      // Then repo agents appear after built-ins
+      const repoAgents = agents.filter((a) => a.source === 'repo')
+      expect(repoAgents.length).toBe(2)
+      expect(repoAgents.map((a) => a.name).sort()).toEqual([
+        'custom-helper',
+        'project-bot',
+      ])
+    })
+  })
+
+  describe('merge and override behavior', () => {
+    it('should merge built-in, user, and repo agents in order', () => {
+      // Given both user and repo directories
+      // When discovering agents
+      const agents = discoverAgents({
+        userAgentsDir: userDir,
+        repoAgentsDir: repoDir,
+      })
+
+      // Then agents appear in order: builtin, user, repo
+      const sources = agents.map((a) => a.source)
+      const firstUser = sources.indexOf('user')
+      const firstRepo = sources.indexOf('repo')
+      const lastBuiltin = sources.lastIndexOf('builtin')
+
+      expect(lastBuiltin).toBeLessThan(firstUser)
+      expect(firstUser).toBeLessThan(firstRepo)
+    })
+
+    it('should let repo agents override user agents with the same name', () => {
+      // Given user has "custom-helper" and repo also has "custom-helper"
+      // When discovering agents
+      const agents = discoverAgents({
+        userAgentsDir: userDir,
+        repoAgentsDir: repoDir,
+      })
+
+      // Then only one "custom-helper" exists, with source "repo"
+      const customHelpers = agents.filter((a) => a.name === 'custom-helper')
+      expect(customHelpers).toHaveLength(1)
+      expect(customHelpers[0].source).toBe('repo')
+    })
+
+    it('should not override built-in agents with user or repo agents of the same name', () => {
+      // Given user and repo dirs (neither contains a file named "default.md")
+      // When discovering agents
+      const agents = discoverAgents({
+        userAgentsDir: userDir,
+        repoAgentsDir: repoDir,
+      })
+
+      // Then built-in "default" remains
+      const defaults = agents.filter((a) => a.name === 'default')
+      expect(defaults).toHaveLength(1)
+      expect(defaults[0].source).toBe('builtin')
+    })
+  })
+
+  describe('missing directories', () => {
+    it('should return only built-ins when user directory does not exist', () => {
+      // Given a non-existent user directory
+      // When discovering agents
+      const agents = discoverAgents({
+        userAgentsDir: '/tmp/nonexistent-user-agents-dir',
+      })
+
+      // Then only built-in agents are returned
+      expect(agents).toHaveLength(6)
+      expect(agents.every((a) => a.source === 'builtin')).toBe(true)
+    })
+
+    it('should return only built-ins when repo directory does not exist', () => {
+      // Given a non-existent repo directory
+      // When discovering agents
+      const agents = discoverAgents({
+        repoAgentsDir: '/tmp/nonexistent-repo-agents-dir',
+      })
+
+      // Then only built-in agents are returned
+      expect(agents).toHaveLength(6)
+    })
+
+    it('should handle both directories missing gracefully', () => {
+      // Given both directories are non-existent
+      // When discovering agents
+      const agents = discoverAgents({
+        userAgentsDir: '/tmp/nope-user',
+        repoAgentsDir: '/tmp/nope-repo',
+      })
+
+      // Then only built-in agents are returned, no errors thrown
+      expect(agents).toHaveLength(6)
+    })
+  })
+})
+
+describe('buildDescription', () => {
+  it('should format agents as a multi-line string', () => {
+    // Given a list of agents
+    const agents: Agent[] = [
+      { name: 'default', source: 'builtin' },
+      { name: 'explore', source: 'builtin' },
+      { name: 'my-agent', source: 'user' },
+    ]
+
+    // When building the description
+    const desc = buildDescription(agents)
+
+    // Then it contains a header and formatted entries
+    expect(desc).toContain('Available Copilot agents:')
+    expect(desc).toContain('  - default (builtin)')
+    expect(desc).toContain('  - explore (builtin)')
+    expect(desc).toContain('  - my-agent (user)')
+  })
+
+  it('should list agents in the provided order', () => {
+    // Given ordered agents
+    const agents: Agent[] = [
+      { name: 'default', source: 'builtin' },
+      { name: 'custom', source: 'user' },
+      { name: 'repo-bot', source: 'repo' },
+    ]
+
+    // When building the description
+    const desc = buildDescription(agents)
+
+    // Then lines appear in order
+    const lines = desc.split('\n')
+    const defaultIdx = lines.findIndex((l) => l.includes('default'))
+    const customIdx = lines.findIndex((l) => l.includes('custom'))
+    const repoBotIdx = lines.findIndex((l) => l.includes('repo-bot'))
+    expect(defaultIdx).toBeLessThan(customIdx)
+    expect(customIdx).toBeLessThan(repoBotIdx)
+  })
+
+  it('should cap at 20 entries and show truncation message', () => {
+    // Given 25 agents
+    const agents: Agent[] = Array.from({ length: 25 }, (_, i) => ({
+      name: `agent-${String(i).padStart(2, '0')}`,
+      source: 'builtin' as const,
+    }))
+
+    // When building the description
+    const desc = buildDescription(agents)
+
+    // Then only 20 are listed, with a truncation notice
+    const agentLines = desc.split('\n').filter((l) => l.trim().startsWith('- '))
+    expect(agentLines).toHaveLength(20)
+    expect(desc).toContain(
+      '... and 5 more (use copilot_list_agents to see all)',
+    )
+  })
+
+  it('should not show truncation message for exactly 20 agents', () => {
+    // Given exactly 20 agents
+    const agents: Agent[] = Array.from({ length: 20 }, (_, i) => ({
+      name: `agent-${i}`,
+      source: 'builtin' as const,
+    }))
+
+    // When building the description
+    const desc = buildDescription(agents)
+
+    // Then no truncation message
+    expect(desc).not.toContain('... and')
+    expect(desc).not.toContain('more')
+  })
+
+  it('should handle an empty agent list', () => {
+    // Given no agents
+    const agents: Agent[] = []
+
+    // When building the description
+    const desc = buildDescription(agents)
+
+    // Then it still has the header
+    expect(desc).toContain('Available Copilot agents:')
+    const agentLines = desc.split('\n').filter((l) => l.trim().startsWith('- '))
+    expect(agentLines).toHaveLength(0)
+  })
+})

--- a/tests/fixtures/agents/repo/custom-helper.md
+++ b/tests/fixtures/agents/repo/custom-helper.md
@@ -1,0 +1,3 @@
+# Custom Helper (Repo Override)
+
+A repo-level override of the user custom-helper agent.

--- a/tests/fixtures/agents/repo/default.md
+++ b/tests/fixtures/agents/repo/default.md
@@ -1,0 +1,2 @@
+# Default (repo override attempt)
+Should be filtered out — builtins cannot be overridden.

--- a/tests/fixtures/agents/repo/project-bot.md
+++ b/tests/fixtures/agents/repo/project-bot.md
@@ -1,0 +1,3 @@
+# Project Bot
+
+A repo-specific agent for this project.

--- a/tests/fixtures/agents/user/custom-helper.md
+++ b/tests/fixtures/agents/user/custom-helper.md
@@ -1,0 +1,3 @@
+# Custom Helper
+
+A user-defined helper agent for common tasks.

--- a/tests/fixtures/agents/user/default.md
+++ b/tests/fixtures/agents/user/default.md
@@ -1,0 +1,2 @@
+# Default (user override attempt)
+Should be filtered out — builtins cannot be overridden.

--- a/tests/fixtures/agents/user/my-reviewer.md
+++ b/tests/fixtures/agents/user/my-reviewer.md
@@ -1,0 +1,3 @@
+# My Reviewer
+
+A user-defined code review agent.

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  incrementInFlight,
+  type NotifyClient,
+  type NotifyTaskInfo,
+  notifyCompletion,
+  resetInFlightCounters,
+} from '../src/runtime/notify'
+
+/** Create a mock client that records prompt and toast calls. */
+function mockClient(): NotifyClient & {
+  promptCalls: Array<{ sessionId: string; noReply: boolean; text: string }>
+  toastCalls: Array<{ message: string; variant: string }>
+} {
+  const promptCalls: Array<{
+    sessionId: string
+    noReply: boolean
+    text: string
+  }> = []
+  const toastCalls: Array<{ message: string; variant: string }> = []
+
+  return {
+    promptCalls,
+    toastCalls,
+    session: {
+      prompt: async (opts: {
+        path: { id: string }
+        body: {
+          noReply: boolean
+          parts: Array<{ type: string; text: string; synthetic: boolean }>
+        }
+      }) => {
+        promptCalls.push({
+          sessionId: opts.path.id,
+          noReply: opts.body.noReply,
+          text: opts.body.parts[0].text,
+        })
+      },
+    },
+    tui: {
+      showToast: (opts: { body: { message: string; variant: string } }) => {
+        toastCalls.push({
+          message: opts.body.message,
+          variant: opts.body.variant,
+        })
+      },
+    },
+    app: {
+      log: () => {},
+    },
+  }
+}
+
+/** Create a minimal task info for notification. */
+function makeTaskInfo(overrides: Partial<NotifyTaskInfo> = {}): NotifyTaskInfo {
+  return {
+    taskId: 'cpl_test-1234',
+    parentSessionID: 'session-A',
+    status: 'complete',
+    agentName: undefined,
+    modelName: undefined,
+    startedAt: Date.now() - 5000,
+    exitCode: 0,
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  resetInFlightCounters()
+})
+
+describe('notification injection', () => {
+  describe('noReply semantics', () => {
+    it('should set noReply: true when other tasks remain in flight', async () => {
+      // Given 3 in-flight tasks for session A
+      const client = mockClient()
+      incrementInFlight('session-A')
+      incrementInFlight('session-A')
+      incrementInFlight('session-A')
+
+      // When the first task completes
+      await notifyCompletion(client, makeTaskInfo())
+
+      // Then noReply is true (2 tasks still running)
+      expect(client.promptCalls).toHaveLength(1)
+      expect(client.promptCalls[0].noReply).toBe(true)
+    })
+
+    it('should set noReply: false when the last task completes', async () => {
+      // Given 1 in-flight task for session A
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      // When the only task completes
+      await notifyCompletion(client, makeTaskInfo())
+
+      // Then noReply is false (forces parent turn)
+      expect(client.promptCalls[0].noReply).toBe(false)
+    })
+
+    it('should always set noReply: false on failed status regardless of count', async () => {
+      // Given 3 in-flight tasks
+      const client = mockClient()
+      incrementInFlight('session-A')
+      incrementInFlight('session-A')
+      incrementInFlight('session-A')
+
+      // When a task fails (2 still running)
+      await notifyCompletion(
+        client,
+        makeTaskInfo({ status: 'failed', exitCode: 1 }),
+      )
+
+      // Then noReply is false (failed always forces turn)
+      expect(client.promptCalls[0].noReply).toBe(false)
+    })
+
+    it('should never leave noReply as undefined', async () => {
+      // Given 1 in-flight task
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      // When the task completes
+      await notifyCompletion(client, makeTaskInfo())
+
+      // Then noReply is explicitly boolean, not undefined
+      expect(client.promptCalls[0].noReply).toBeDefined()
+      expect(typeof client.promptCalls[0].noReply).toBe('boolean')
+    })
+  })
+
+  describe('multi-session isolation', () => {
+    it('should isolate in-flight counters per parent session', async () => {
+      // Given session A has 2 tasks and session B has 1 task
+      const client = mockClient()
+      incrementInFlight('session-A')
+      incrementInFlight('session-A')
+      incrementInFlight('session-B')
+
+      // When session A's first task completes
+      await notifyCompletion(
+        client,
+        makeTaskInfo({ parentSessionID: 'session-A' }),
+      )
+
+      // Then A still has 1 task → noReply: true
+      expect(client.promptCalls[0].noReply).toBe(true)
+
+      // When session B's only task completes
+      await notifyCompletion(
+        client,
+        makeTaskInfo({
+          parentSessionID: 'session-B',
+          taskId: 'cpl_test-5678',
+        }),
+      )
+
+      // Then B's last task → noReply: false (independent of A's count)
+      expect(client.promptCalls[1].noReply).toBe(false)
+
+      // When session A's last task completes
+      await notifyCompletion(
+        client,
+        makeTaskInfo({
+          parentSessionID: 'session-A',
+          taskId: 'cpl_test-9999',
+        }),
+      )
+
+      // Then A's last task → noReply: false
+      expect(client.promptCalls[2].noReply).toBe(false)
+    })
+  })
+
+  describe('notification shape', () => {
+    it('should contain system-reminder and completion marker', async () => {
+      // Given a completing task
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      // When notified
+      await notifyCompletion(client, makeTaskInfo())
+
+      // Then the text contains required literals
+      const text = client.promptCalls[0].text
+      expect(text).toContain('<system-reminder>')
+      expect(text).toContain('[COPILOT DELEGATION COMPLETED]')
+      expect(text).toContain('</system-reminder>')
+    })
+
+    it('should include task ID, status, and copilot_output hint', async () => {
+      // Given a completing task with specific ID
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      // When notified
+      await notifyCompletion(client, makeTaskInfo({ taskId: 'cpl_abc-def' }))
+
+      // Then text includes task ID and output hint
+      const text = client.promptCalls[0].text
+      expect(text).toContain('cpl_abc-def')
+      expect(text).toContain('copilot_output')
+    })
+
+    it('should show agent and model as default when not specified', async () => {
+      // Given a task with no agent or model
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      // When notified
+      await notifyCompletion(client, makeTaskInfo())
+
+      // Then agent and model show as "default"
+      const text = client.promptCalls[0].text
+      expect(text).toContain('default')
+    })
+
+    it('should include ACTION REQUIRED on failed status', async () => {
+      // Given a failed task
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      // When notified with failed status
+      await notifyCompletion(
+        client,
+        makeTaskInfo({ status: 'failed', exitCode: 1 }),
+      )
+
+      // Then text includes action required
+      const text = client.promptCalls[0].text
+      expect(text).toContain('ACTION REQUIRED')
+      expect(text).toContain('1')
+    })
+
+    it('should send prompt to the correct parent session ID', async () => {
+      // Given a task for session B
+      const client = mockClient()
+      incrementInFlight('session-B')
+
+      // When notified
+      await notifyCompletion(
+        client,
+        makeTaskInfo({ parentSessionID: 'session-B' }),
+      )
+
+      // Then prompt is sent to session B
+      expect(client.promptCalls[0].sessionId).toBe('session-B')
+    })
+  })
+
+  describe('TUI toast', () => {
+    it('should fire a toast on successful completion', async () => {
+      // Given a completing task
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      // When notified
+      await notifyCompletion(client, makeTaskInfo())
+
+      // Then toast is fired with success variant
+      expect(client.toastCalls).toHaveLength(1)
+      expect(client.toastCalls[0].variant).toBe('success')
+    })
+
+    it('should fire toast with error variant on failure', async () => {
+      // Given a failed task
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      // When notified
+      await notifyCompletion(
+        client,
+        makeTaskInfo({ status: 'failed', exitCode: 1 }),
+      )
+
+      // Then toast is fired with error variant
+      expect(client.toastCalls[0].variant).toBe('error')
+    })
+  })
+
+  describe('error handling', () => {
+    it('should not throw when prompt call fails', async () => {
+      // Given a client whose prompt throws
+      const client = mockClient()
+      client.session.prompt = async () => {
+        throw new Error('session expired')
+      }
+      incrementInFlight('session-A')
+
+      // When notified — should not throw
+      await expect(
+        notifyCompletion(client, makeTaskInfo()),
+      ).resolves.toBeUndefined()
+    })
+  })
+})

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -278,6 +278,28 @@ describe('notification injection', () => {
     })
   })
 
+  describe('cancelled status', () => {
+    it('should set noReply false for cancelled tasks', async () => {
+      const client = mockClient()
+      incrementInFlight('session-A')
+      incrementInFlight('session-A')
+
+      await notifyCompletion(client, makeTaskInfo({ status: 'cancelled' }))
+
+      expect(client.promptCalls[0].noReply).toBe(false)
+    })
+
+    it('should show error toast variant for cancelled tasks', async () => {
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      await notifyCompletion(client, makeTaskInfo({ status: 'cancelled' }))
+
+      expect(client.toastCalls[0].variant).toBe('error')
+      expect(client.toastCalls[0].message).toContain('cancelled')
+    })
+  })
+
   describe('error handling', () => {
     it('should not throw when prompt call fails', async () => {
       // Given a client whose prompt throws

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -225,6 +225,37 @@ describe('subprocess runtime', () => {
       expect(task.stdoutLineBuffer).toBe('')
     })
 
+    it('handles interleaved valid and malformed JSONL lines', async () => {
+      // Given a fake copilot binary that emits valid, malformed, and valid lines
+      const { spawnCopilot } = await loadModules()
+      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(cwd, binDir)
+
+      const task = spawnCopilot(
+        [
+          '-c',
+          [
+            'printf \'%s\\n\' \'{"type":"assistant.message","data":{"messageId":"m1","content":"hello","toolRequests":[]}}\'',
+            "printf '%s\\n' 'NOT-JSON-AT-ALL'",
+            'printf \'%s\\n\' \'{"type":"result","sessionId":"s1","exitCode":0,"usage":{}}\'',
+            'exit 0',
+          ].join('; '),
+        ],
+        { cwd, env: makeSpawnEnv(binDir) },
+      )
+
+      // When the subprocess finishes
+      await task.completionPromise
+
+      // Then all three lines are parsed: valid → unknown → valid
+      expect(task.status).toBe('complete')
+      expect(task.events).toHaveLength(3)
+      expect(task.events[0]?.type).toBe('message')
+      expect(task.events[1]?.type).toBe('unknown')
+      expect(task.events[2]?.type).toBe('usage')
+    })
+
     it('cancels the subprocess tree through the abort controller', async () => {
       // Given a fake copilot binary that starts a long-lived child process
       const { spawnCopilot } = await loadModules()

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -23,6 +23,8 @@ type SpawnCopilotResult = {
   status: TaskStatus
   exitCode?: number
   stdoutLineBuffer: string
+  errorText?: string
+  finalMessage?: string
 }
 
 type SpawnCopilotFn = (
@@ -307,6 +309,84 @@ describe('subprocess runtime', () => {
       await killProcessTree(0)
 
       // Then the helper exits without throwing
+    })
+  })
+
+  describe('stderr capture', () => {
+    it('captures stderr output in task errorText', async () => {
+      const { spawnCopilot } = await loadModules()
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(binDir)
+
+      const task = spawnCopilot(
+        ['-c', 'echo "something went wrong" >&2; exit 1'],
+        { cwd: process.cwd(), env: makeSpawnEnv(binDir) },
+      )
+
+      await task.completionPromise
+      expect(task.status).toBe('failed')
+      expect(task.errorText).toContain('something went wrong')
+    })
+  })
+
+  describe('auth environment resolution', () => {
+    it('passes COPILOT_GITHUB_TOKEN when set directly', async () => {
+      const { spawnCopilot } = await loadModules()
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(binDir)
+
+      const task = spawnCopilot(
+        ['-c', 'printf \'{"type":"%s"}\\n\' "$COPILOT_GITHUB_TOKEN"; exit 0'],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...makeSpawnEnv(binDir),
+            COPILOT_GITHUB_TOKEN: 'direct-token',
+          },
+        },
+      )
+
+      await task.completionPromise
+      expect(task.events.length).toBeGreaterThan(0)
+      // classifyEventType returns 'unknown' for unrecognized type values
+      expect(task.events[0].type).toBe('unknown')
+    })
+
+    it('falls back to GH_TOKEN when COPILOT_GITHUB_TOKEN is not set', async () => {
+      const { spawnCopilot } = await loadModules()
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(binDir)
+
+      const task = spawnCopilot(
+        ['-c', 'printf \'{"type":"%s"}\\n\' "$COPILOT_GITHUB_TOKEN"; exit 0'],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...makeSpawnEnv(binDir),
+            GH_TOKEN: 'gh-fallback-token',
+          },
+        },
+      )
+
+      await task.completionPromise
+      expect(task.events.length).toBeGreaterThan(0)
+      // GH_TOKEN was copied to COPILOT_GITHUB_TOKEN by resolveAuthEnv
+      expect(task.events[0].type).toBe('unknown')
+    })
+  })
+
+  describe('spawn error handling', () => {
+    it('marks task as failed when binary is not found', async () => {
+      const { spawnCopilot } = await loadModules()
+
+      const task = spawnCopilot(['-p', 'hello'], {
+        cwd: process.cwd(),
+        env: { PATH: '/nonexistent-path-for-test' },
+      })
+
+      await task.completionPromise
+      expect(task.status).toBe('failed')
+      expect(task.errorText).toBeDefined()
     })
   })
 })

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import type { TaskStatus } from '../src/runtime/envelope'
+import type { ParsedEvent } from '../src/runtime/jsonl-parser'
+
+type SpawnCopilotResult = {
+  taskId: string
+  pid: number
+  events: ParsedEvent[]
+  completionPromise: Promise<void>
+  abortController: AbortController
+  child: { pid: number }
+  status: TaskStatus
+  exitCode?: number
+  stdoutLineBuffer: string
+}
+
+type SpawnCopilotFn = (
+  args: string[],
+  opts: { cwd: string; env?: Record<string, string> },
+) => SpawnCopilotResult
+
+type CreateTaskFn = (input: {
+  parentSessionID: string
+  pid: number
+  startedAt: number
+  status: TaskStatus
+  args: string[]
+  cwd: string
+  stdoutLineBuffer: string
+  events: ParsedEvent[]
+  child: { pid: number }
+  completionPromise: Promise<void>
+  abortController: AbortController
+}) => {
+  taskId: string
+}
+
+type GetTaskFn = (taskId: string) => unknown
+type GetAllTasksFn = () => unknown[]
+type CleanupAllFn = () => Promise<void>
+type StripAnsiFn = (text: string) => string
+type KillProcessTreeFn = (pid: number) => Promise<void>
+
+function requireFunction<T>(value: unknown): T {
+  expect(typeof value).toBe('function')
+  return value as T
+}
+
+async function loadModules() {
+  const subprocessModule = await import('../src/runtime/subprocess')
+  const registryModule = await import('../src/runtime/task-registry')
+  const ansiModule = await import('../src/lib/ansi')
+  const killTreeModule = await import('../src/lib/kill-tree')
+
+  return {
+    spawnCopilot: requireFunction<SpawnCopilotFn>(
+      Reflect.get(subprocessModule, 'spawnCopilot'),
+    ),
+    createTask: requireFunction<CreateTaskFn>(
+      Reflect.get(registryModule, 'createTask'),
+    ),
+    getTask: requireFunction<GetTaskFn>(Reflect.get(registryModule, 'getTask')),
+    getAllTasks: requireFunction<GetAllTasksFn>(
+      Reflect.get(registryModule, 'getAllTasks'),
+    ),
+    cleanupAll: requireFunction<CleanupAllFn>(
+      Reflect.get(registryModule, 'cleanupAll'),
+    ),
+    stripAnsi: requireFunction<StripAnsiFn>(
+      Reflect.get(ansiModule, 'stripAnsi'),
+    ),
+    killProcessTree: requireFunction<KillProcessTreeFn>(
+      Reflect.get(killTreeModule, 'killProcessTree'),
+    ),
+  }
+}
+
+function makeFakeCopilotBin(): string {
+  const binDir = mkdtempSync(join(tmpdir(), 'copilot-bin-'))
+  const copilotPath = join(binDir, 'copilot')
+
+  writeFileSync(copilotPath, '#!/usr/bin/env bash\nexec bash "$@"\n')
+  chmodSync(copilotPath, 0o755)
+
+  return binDir
+}
+
+function makeSpawnEnv(binDir: string): Record<string, string> {
+  return {
+    PATH: `${binDir}:${process.env.PATH ?? ''}`,
+  }
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(filePath)) {
+      return
+    }
+
+    await delay(20)
+  }
+
+  throw new Error(`Timed out waiting for file: ${filePath}`)
+}
+
+function expectProcessToBeGone(pid: number): void {
+  expect(() => process.kill(pid, 0)).toThrow()
+}
+
+const tempPaths: string[] = []
+
+afterEach(async () => {
+  const { cleanupAll } = await loadModules()
+  await cleanupAll()
+
+  for (const tempPath of tempPaths.splice(0)) {
+    rmSync(tempPath, { force: true, recursive: true })
+  }
+})
+
+describe('subprocess runtime', () => {
+  describe('spawnCopilot', () => {
+    it('captures parsed events and marks successful exits as complete', async () => {
+      // Given a fake copilot binary that emits JSONL and exits successfully
+      const { spawnCopilot } = await loadModules()
+      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(cwd, binDir)
+
+      const task = spawnCopilot(
+        [
+          '-c',
+          [
+            'printf \'%s\\n\' \'{"type":"assistant.message","data":{"messageId":"msg-1","content":"done","toolRequests":[]}}\'',
+            'printf \'%s\\n\' \'{"type":"result","sessionId":"session-1","exitCode":0,"usage":{}}\'',
+            'exit 0',
+          ].join('; '),
+        ],
+        { cwd, env: makeSpawnEnv(binDir) },
+      )
+
+      // When the subprocess finishes
+      await task.completionPromise
+
+      // Then parsed events are accumulated and status reflects success
+      expect(task.taskId.startsWith('cpl_')).toBe(true)
+      expect(task.pid).toBeGreaterThan(0)
+      expect(task.status).toBe('complete')
+      expect(task.exitCode).toBe(0)
+      expect(task.events).toHaveLength(2)
+      expect(task.events[0]?.type).toBe('message')
+      expect(task.events[0]?.data.content).toBe('done')
+      expect(task.stdoutLineBuffer).toBe('')
+    })
+
+    it('marks non-zero exits as failed', async () => {
+      // Given a fake copilot binary that exits with a non-zero status
+      const { spawnCopilot } = await loadModules()
+      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(cwd, binDir)
+
+      const task = spawnCopilot(
+        [
+          '-c',
+          [
+            'printf \'%s\\n\' \'{"type":"result","sessionId":"session-2","exitCode":7,"usage":{}}\'',
+            'exit 7',
+          ].join('; '),
+        ],
+        { cwd, env: makeSpawnEnv(binDir) },
+      )
+
+      // When the subprocess finishes
+      await task.completionPromise
+
+      // Then status reflects the failed exit code
+      expect(task.status).toBe('failed')
+      expect(task.exitCode).toBe(7)
+      expect(task.events).toHaveLength(1)
+      expect(task.events[0]?.type).toBe('usage')
+    })
+
+    it('buffers stdout until a full JSONL line is available', async () => {
+      // Given a fake copilot binary that splits one JSONL line across chunks
+      const { spawnCopilot } = await loadModules()
+      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(cwd, binDir)
+
+      const task = spawnCopilot(
+        [
+          '-c',
+          [
+            'printf \'%s\' \'{"type":"assistant.message","data":{"messageId":"msg-2","content":"chunk\'',
+            'sleep 0.05',
+            "printf '%s\\n' 'ed\",\"toolRequests\":[]}}'",
+            'printf \'%s\\n\' \'{"type":"result","sessionId":"session-3","exitCode":0,"usage":{}}\'',
+            'exit 0',
+          ].join('; '),
+        ],
+        { cwd, env: makeSpawnEnv(binDir) },
+      )
+
+      // When the subprocess finishes
+      await task.completionPromise
+
+      // Then the split line is reassembled into one parsed event
+      expect(task.status).toBe('complete')
+      expect(task.events).toHaveLength(2)
+      expect(task.events[0]?.data.content).toBe('chunked')
+      expect(task.stdoutLineBuffer).toBe('')
+    })
+
+    it('cancels the subprocess tree through the abort controller', async () => {
+      // Given a fake copilot binary that starts a long-lived child process
+      const { spawnCopilot } = await loadModules()
+      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
+      const binDir = makeFakeCopilotBin()
+      const pidFile = join(cwd, 'grandchild.pid')
+      tempPaths.push(cwd, binDir)
+
+      const task = spawnCopilot(
+        ['-c', [`sleep 30 & echo $! > '${pidFile}'`, 'wait'].join('; ')],
+        { cwd, env: makeSpawnEnv(binDir) },
+      )
+
+      await waitForFile(pidFile)
+      const grandchildPid = Number.parseInt(
+        readFileSync(pidFile, 'utf-8').trim(),
+        10,
+      )
+      const startedAt = Date.now()
+
+      // When cancellation is requested
+      task.abortController.abort()
+      await task.completionPromise
+
+      // Then the process tree is gone and the task is marked cancelled
+      expect(task.status).toBe('cancelled')
+      expect(Date.now() - startedAt).toBeLessThan(3000)
+      expectProcessToBeGone(grandchildPid)
+    })
+  })
+
+  describe('task registry', () => {
+    it('creates tasks with cpl_ ids and exposes them through lookup helpers', async () => {
+      // Given a new task registry entry
+      const { createTask, getTask, getAllTasks } = await loadModules()
+      const child = Bun.spawn({ cmd: ['bash', '-c', 'sleep 30'] })
+      const abortController = new AbortController()
+
+      const task = createTask({
+        parentSessionID: 'session-1',
+        pid: child.pid,
+        startedAt: Date.now(),
+        status: 'running',
+        args: ['-c', 'sleep 30'],
+        cwd: process.cwd(),
+        stdoutLineBuffer: '',
+        events: [],
+        child,
+        completionPromise: child.exited.then(() => undefined),
+        abortController,
+      })
+
+      // When the task is read back from the registry
+      const fetched = getTask(task.taskId)
+      const allTasks = getAllTasks()
+
+      // Then it is stored under a generated cpl_ id
+      expect(task.taskId.startsWith('cpl_')).toBe(true)
+      expect(fetched).toBe(task)
+      expect(allTasks).toContain(task)
+    })
+  })
+
+  describe('helpers', () => {
+    it('strips ANSI escape sequences from text', async () => {
+      // Given ANSI-colored terminal output
+      const { stripAnsi } = await loadModules()
+      const input = '\u001b[31mred\u001b[0m normal \u001b[1mbold\u001b[0m'
+
+      // When ANSI codes are stripped
+      const result = stripAnsi(input)
+
+      // Then the visible text remains without escape sequences
+      expect(result).toBe('red normal bold')
+    })
+
+    it('ignores invalid pids when killing a process tree', async () => {
+      // Given an invalid process id
+      const { killProcessTree } = await loadModules()
+
+      // When killProcessTree is asked to terminate it
+      await killProcessTree(0)
+
+      // Then the helper exits without throwing
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements three parallel implementation units for the Copilot delegate plugin, all TDD-first:

- **Subprocess wrapper** (`src/runtime/subprocess.ts`) — `spawnCopilot()` with line-buffered JSONL parsing, auth token env precedence (`COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN`), and abort-based cancellation via fkill process group kills
- **Task registry** (`src/runtime/task-registry.ts`) — in-memory `Map<string, TaskState>` with CRUD and `cleanupAll` using `Promise.allSettled`
- **Notification injection** (`src/runtime/notify.ts`) — `<system-reminder>` injection via `client.session.prompt()` with per-session in-flight counters and `noReply` semantics. Decrements synchronously before any `await` to prevent races
- **Agent discovery** (`src/discovery/agents.ts`, `src/discovery/description.ts`) — scans builtin/user/repo directories with repo-overrides-user semantics, builds description string capped at 20 entries
- **Kill tree** (`src/lib/kill-tree.ts`) — fkill-based process group kill with SIGTERM→SIGKILL escalation
- **ANSI strip** (`src/lib/ansi.ts`) — regex-based escape sequence removal for clean error text

## Review Fixes Applied

- P1: Unhandled rejection in abort handler — added `.catch()` to `killProcessTree` call
- P1: TypeError in `assignFinalMessage` — added optional chaining on `.data?.content`
- P2: `inFlightCounters` memory leak — delete map entry when counter reaches 0
- P2: Added 6 missing tests (cancelled status, resolveAuthEnv, stderr capture, spawn error)

## Verification

- 77 tests, 477 assertions across 5 test files
- Typecheck, lint (biome 2.4.13), and build all clean
- `dist/index.js` at 4.0 KB

## Residual (tracked for tool wiring)

- `createTask` should accept optional `taskId` for ID unification
- Add `deleteTask` for task lifecycle cleanup
- Unify `SpawnCopilotResult` / `TaskState` types