### PR TITLE
Add integration tests with ephemeral-port OpenCode server

### DIFF
--- a/.changeset/integration-tests.md
+++ b/.changeset/integration-tests.md
@@ -1,0 +1,5 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Add integration test scaffolding that spawns a real OpenCode server subprocess on an ephemeral port, verifies the plugin's three tools (`copilot_delegate`, `copilot_output`, `copilot_cancel`) appear in the tool catalog, and confirms clean teardown without zombie processes. Adds a `test:integration` script that runs only `tests/integration/`.

--- a/biome.json
+++ b/biome.json
@@ -31,6 +31,6 @@
     }
   },
   "files": {
-    "includes": ["**", "!dist", "!node_modules", "!.changeset"]
+    "includes": ["**", "!dist", "!node_modules", "!.changeset", "!.context"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "build": "bun run clean && bun build src/index.ts --outdir dist --target bun --external @opencode-ai/plugin --external @opencode-ai/sdk && tsc --emitDeclarationOnly --noEmit false",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
+    "test:integration": "bun test tests/integration/",
     "lint": "biome check .",
     "fix": "biome check . --write",
     "prepublishOnly": "bun run build"

--- a/tests/integration/helpers/client.ts
+++ b/tests/integration/helpers/client.ts
@@ -1,0 +1,7 @@
+import { createOpencodeClient } from '@opencode-ai/sdk'
+
+export type OpencodeClient = ReturnType<typeof createOpencodeClient>
+
+export function makeClient(baseUrl: string): OpencodeClient {
+  return createOpencodeClient({ baseUrl, throwOnError: true })
+}

--- a/tests/integration/helpers/server.ts
+++ b/tests/integration/helpers/server.ts
@@ -1,0 +1,225 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+import fkill from 'fkill'
+
+export interface ServerHandle {
+  baseUrl: string
+  pid: number
+  stop(): Promise<void>
+  stderrTail(): string[]
+}
+
+export interface StartOptions {
+  cwd?: string
+  /** Maximum time to wait for `/global/health` to return ok (default 10000). */
+  timeoutMs?: number
+  /** Extra args appended after `serve --port 0 --print-logs`. */
+  extraArgs?: string[]
+}
+
+const STDERR_BUFFER_CAP = 200
+const LISTENING_RE = /listening on (https?:\/\/[^\s]+)/i
+const HEALTH_POLL_INTERVAL_MS = 100
+const HEALTH_FETCH_TIMEOUT_MS = 500
+
+interface DrainState {
+  stderrLines: string[]
+  setBaseUrl: (url: string) => void
+}
+
+function attachStreamDrain(
+  stream: NodeJS.ReadableStream,
+  sink: 'stdout' | 'stderr',
+  state: DrainState,
+): void {
+  let buffer = ''
+  stream.setEncoding('utf8')
+  stream.on('data', (chunk: string) => {
+    buffer += chunk
+    let idx = buffer.indexOf('\n')
+    while (idx !== -1) {
+      const line = buffer.slice(0, idx)
+      buffer = buffer.slice(idx + 1)
+      if (sink === 'stderr') {
+        state.stderrLines.push(line)
+        if (state.stderrLines.length > STDERR_BUFFER_CAP)
+          state.stderrLines.shift()
+      }
+      const m = line.match(LISTENING_RE)
+      if (m?.[1]) state.setBaseUrl(m[1])
+      idx = buffer.indexOf('\n')
+    }
+  })
+  stream.on('error', () => {})
+}
+
+async function probeHealth(baseUrl: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/global/health`, {
+      signal: AbortSignal.timeout(HEALTH_FETCH_TIMEOUT_MS),
+    })
+    if (!res.ok) return false
+    const body = (await res.json().catch(() => null)) as {
+      healthy?: boolean
+    } | null
+    return body?.healthy === true
+  } catch {
+    return false
+  }
+}
+
+async function readPsTable(): Promise<string> {
+  const proc = Bun.spawn(['ps', '-axo', 'pid,ppid'], {
+    stdout: 'pipe',
+    stderr: 'ignore',
+  })
+  const text = await new Response(proc.stdout).text()
+  await proc.exited
+  return text
+}
+
+async function collectDescendants(rootPid: number): Promise<number[]> {
+  const text = await readPsTable()
+  const childrenByParent = new Map<number, number[]>()
+  for (const line of text.split('\n').slice(1)) {
+    const parts = line.trim().split(/\s+/)
+    const pidStr = parts[0]
+    const ppidStr = parts[1]
+    if (!pidStr || !ppidStr) continue
+    const pid = Number.parseInt(pidStr, 10)
+    const ppid = Number.parseInt(ppidStr, 10)
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue
+    const arr = childrenByParent.get(ppid) ?? []
+    arr.push(pid)
+    childrenByParent.set(ppid, arr)
+  }
+  const out: number[] = []
+  const stack = [rootPid]
+  while (stack.length > 0) {
+    const current = stack.pop() as number
+    const kids = childrenByParent.get(current) ?? []
+    for (const kid of kids) {
+      out.push(kid)
+      stack.push(kid)
+    }
+  }
+  return out
+}
+
+function safeKill(pid: number, signal: NodeJS.Signals | 0): boolean {
+  try {
+    process.kill(pid, signal)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Kill the entire process tree rooted at `pid`. The `opencode` shim spawns a `.opencode`
+ * child; in practice a single SIGTERM to the process group is not always sufficient because
+ * the child can outlive the shim. We snapshot descendants before signalling, hit the group
+ * via `fkill(-pid, ...)`, then sweep any descendants still alive with SIGKILL.
+ */
+async function killTreeAggressive(pid: number): Promise<void> {
+  if (!Number.isFinite(pid) || pid <= 0) return
+  const descendants = await collectDescendants(pid)
+  try {
+    await fkill(-pid, {
+      force: false,
+      forceAfterTimeout: 2_000,
+      waitForExit: 5_000,
+    })
+  } catch {
+    // process may already be gone; sweep below
+  }
+  for (const target of [...descendants, pid]) {
+    if (safeKill(target, 0)) {
+      safeKill(target, 'SIGKILL')
+    }
+  }
+}
+
+/**
+ * Spawn `opencode serve --port 0 --print-logs` and resolve once the server is listening
+ * and `/global/health` reports `healthy: true`. Rejects if the subprocess exits before
+ * the health check succeeds, including the last 20 lines of stderr in the error message.
+ */
+export async function startServer(
+  opts: StartOptions = {},
+): Promise<ServerHandle> {
+  const timeoutMs = opts.timeoutMs ?? 10_000
+  const args = [
+    'serve',
+    '--port',
+    '0',
+    '--print-logs',
+    ...(opts.extraArgs ?? []),
+  ]
+
+  const child: ChildProcessWithoutNullStreams = spawn('opencode', args, {
+    cwd: opts.cwd,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      OPENCODE_SERVER_PASSWORD: '',
+    },
+  })
+  const pid = child.pid ?? -1
+
+  const stderrLines: string[] = []
+  let baseUrl: string | undefined
+  let exitCode: number | null = null
+  let exited = false
+
+  child.once('exit', (code: number | null) => {
+    exited = true
+    exitCode = code
+  })
+  child.once('error', () => {
+    exited = true
+  })
+
+  const drainState: DrainState = {
+    stderrLines,
+    setBaseUrl: (url) => {
+      if (!baseUrl) baseUrl = url
+    },
+  }
+  attachStreamDrain(child.stdout, 'stdout', drainState)
+  attachStreamDrain(child.stderr, 'stderr', drainState)
+
+  const stop = async (): Promise<void> => {
+    if (pid <= 0) return
+    await killTreeAggressive(pid)
+  }
+
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (exited) {
+      const tail = stderrLines.slice(-20).join('\n')
+      throw new Error(
+        `opencode exited with code ${exitCode} before health check\n` +
+          `stderr tail (${Math.min(stderrLines.length, 20)} lines):\n${tail}`,
+      )
+    }
+    if (baseUrl && (await probeHealth(baseUrl))) {
+      return {
+        baseUrl,
+        pid,
+        stop,
+        stderrTail: () => stderrLines.slice(),
+      }
+    }
+    await sleep(HEALTH_POLL_INTERVAL_MS)
+  }
+
+  await stop()
+  const tail = stderrLines.slice(-20).join('\n')
+  throw new Error(
+    `opencode health check timed out after ${timeoutMs}ms\n` +
+      `baseUrl=${baseUrl ?? '(not parsed)'}\n` +
+      `stderr tail:\n${tail}`,
+  )
+}

--- a/tests/integration/helpers/server.ts
+++ b/tests/integration/helpers/server.ts
@@ -15,12 +15,44 @@ export interface StartOptions {
   timeoutMs?: number
   /** Extra args appended after `serve --port 0 --print-logs`. */
   extraArgs?: string[]
+  /** Override the binary to spawn. Test seam; defaults to `opencode`. */
+  command?: string
 }
 
 const STDERR_BUFFER_CAP = 200
 const LISTENING_RE = /listening on (https?:\/\/[^\s]+)/i
 const HEALTH_POLL_INTERVAL_MS = 100
 const HEALTH_FETCH_TIMEOUT_MS = 500
+const PS_READ_TIMEOUT_MS = 1_000
+
+// Env vars whose values, if present at spawn time, should be redacted from
+// child stderr before being interpolated into thrown error messages. Defense
+// in depth: the trust model already isolates env passthrough to the trusted
+// local subprocess chain, but failure-path stderr surfaces in CI logs.
+const KNOWN_TOKEN_ENV_VARS = [
+  'GH_TOKEN',
+  'GITHUB_TOKEN',
+  'COPILOT_GITHUB_TOKEN',
+  'NPM_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+] as const
+
+const TOKEN_PREFIX_RE =
+  /\b(?:ghp_|ghs_|ghu_|ghr_|gho_|github_pat_)[A-Za-z0-9_]{16,}/g
+
+function buildRedactor(env: NodeJS.ProcessEnv): (text: string) => string {
+  const exactValues: string[] = []
+  for (const name of KNOWN_TOKEN_ENV_VARS) {
+    const v = env[name]
+    if (typeof v === 'string' && v.length >= 16) exactValues.push(v)
+  }
+  return (text: string): string => {
+    let out = text
+    for (const v of exactValues) out = out.split(v).join('<redacted>')
+    return out.replace(TOKEN_PREFIX_RE, '<redacted>')
+  }
+}
 
 interface DrainState {
   stderrLines: string[]
@@ -34,24 +66,42 @@ function attachStreamDrain(
 ): void {
   let buffer = ''
   stream.setEncoding('utf8')
+
+  const processLine = (line: string): void => {
+    if (sink === 'stderr') {
+      state.stderrLines.push(line)
+      if (state.stderrLines.length > STDERR_BUFFER_CAP)
+        state.stderrLines.shift()
+    } else {
+      // The listening URL is logged to stdout; only match there to avoid a
+      // stderr warning latching the wrong baseUrl.
+      const m = line.match(LISTENING_RE)
+      if (m?.[1]) state.setBaseUrl(m[1])
+    }
+  }
+
   stream.on('data', (chunk: string) => {
     buffer += chunk
     let idx = buffer.indexOf('\n')
     while (idx !== -1) {
-      const line = buffer.slice(0, idx)
+      processLine(buffer.slice(0, idx))
       buffer = buffer.slice(idx + 1)
-      if (sink === 'stderr') {
-        state.stderrLines.push(line)
-        if (state.stderrLines.length > STDERR_BUFFER_CAP)
-          state.stderrLines.shift()
-      }
-      const m = line.match(LISTENING_RE)
-      if (m?.[1]) state.setBaseUrl(m[1])
       idx = buffer.indexOf('\n')
     }
   })
-  // Capture stream errors into the stderr ring buffer so they surface in diagnostics
-  // rather than being silently swallowed.
+
+  // Flush any remaining partial line on stream end/close. Without this, the
+  // most useful diagnostic line (or the listening URL) can be lost if opencode
+  // exits without a trailing newline.
+  const flush = (): void => {
+    if (buffer.length > 0) {
+      processLine(buffer)
+      buffer = ''
+    }
+  }
+  stream.on('end', flush)
+  stream.on('close', flush)
+
   stream.on('error', (err: Error) => {
     state.stderrLines.push(`[${sink} stream error] ${err.message}`)
     if (state.stderrLines.length > STDERR_BUFFER_CAP) state.stderrLines.shift()
@@ -78,13 +128,27 @@ async function readPsTable(): Promise<string> {
     stdout: 'pipe',
     stderr: 'ignore',
   })
-  const text = await new Response(proc.stdout).text()
+  // Bound the read so a wedged `ps` cannot hang teardown. On timeout we kill
+  // the subprocess and skip descendant enumeration; the fkill(-pid, ...) group
+  // signal in the caller still terminates the tree.
+  const textPromise = new Response(proc.stdout).text()
+  let timer: NodeJS.Timeout | undefined
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), PS_READ_TIMEOUT_MS)
+  })
+  const result = await Promise.race([textPromise, timeoutPromise])
+  if (timer) clearTimeout(timer)
+  if (result === null) {
+    proc.kill('SIGKILL')
+    return ''
+  }
   await proc.exited
-  return text
+  return result
 }
 
 async function collectDescendants(rootPid: number): Promise<number[]> {
   const text = await readPsTable()
+  if (text.length === 0) return []
   const childrenByParent = new Map<number, number[]>()
   for (const line of text.split('\n').slice(1)) {
     const parts = line.trim().split(/\s+/)
@@ -150,12 +214,14 @@ async function killTreeAggressive(pid: number): Promise<void> {
 /**
  * Spawn `opencode serve --port 0 --print-logs` and resolve once the server is listening
  * and `/global/health` reports `healthy: true`. Rejects if the subprocess exits before
- * the health check succeeds, including the last 20 lines of stderr in the error message.
+ * the health check succeeds, including the last 20 lines of stderr (with token values
+ * redacted) in the error message.
  */
 export async function startServer(
   opts: StartOptions = {},
 ): Promise<ServerHandle> {
   const timeoutMs = opts.timeoutMs ?? 10_000
+  const command = opts.command ?? 'opencode'
   const args = [
     'serve',
     '--port',
@@ -164,7 +230,9 @@ export async function startServer(
     ...(opts.extraArgs ?? []),
   ]
 
-  const child: ChildProcessWithoutNullStreams = spawn('opencode', args, {
+  const redact = buildRedactor(process.env)
+
+  const child: ChildProcessWithoutNullStreams = spawn(command, args, {
     cwd: opts.cwd,
     detached: true,
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -180,13 +248,15 @@ export async function startServer(
   let baseUrl: string | undefined
   let exitCode: number | null = null
   let exited = false
+  let spawnError: NodeJS.ErrnoException | undefined
 
   child.once('exit', (code: number | null) => {
     exited = true
     exitCode = code
   })
-  child.once('error', () => {
+  child.once('error', (err: NodeJS.ErrnoException) => {
     exited = true
+    spawnError = err
   })
 
   const drainState: DrainState = {
@@ -207,10 +277,18 @@ export async function startServer(
     await killTreeAggressive(pid)
   }
 
+  const formatTail = (): string => redact(stderrLines.slice(-20).join('\n'))
+
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
+    if (spawnError) {
+      const code = spawnError.code ?? 'unknown'
+      throw new Error(
+        `failed to spawn '${command}' (${code}): ${spawnError.message}`,
+      )
+    }
     if (exited) {
-      const tail = stderrLines.slice(-20).join('\n')
+      const tail = formatTail()
       throw new Error(
         `opencode exited with code ${exitCode} before health check\n` +
           `stderr tail (${Math.min(stderrLines.length, 20)} lines):\n${tail}`,
@@ -228,7 +306,7 @@ export async function startServer(
   }
 
   await stop()
-  const tail = stderrLines.slice(-20).join('\n')
+  const tail = formatTail()
   throw new Error(
     `opencode health check timed out after ${timeoutMs}ms\n` +
       `baseUrl=${baseUrl ?? '(not parsed)'}\n` +

--- a/tests/integration/helpers/server.ts
+++ b/tests/integration/helpers/server.ts
@@ -50,7 +50,12 @@ function attachStreamDrain(
       idx = buffer.indexOf('\n')
     }
   })
-  stream.on('error', () => {})
+  // Capture stream errors into the stderr ring buffer so they surface in diagnostics
+  // rather than being silently swallowed.
+  stream.on('error', (err: Error) => {
+    state.stderrLines.push(`[${sink} stream error] ${err.message}`)
+    if (state.stderrLines.length > STDERR_BUFFER_CAP) state.stderrLines.shift()
+  })
 }
 
 async function probeHealth(baseUrl: string): Promise<boolean> {
@@ -96,7 +101,8 @@ async function collectDescendants(rootPid: number): Promise<number[]> {
   const out: number[] = []
   const stack = [rootPid]
   while (stack.length > 0) {
-    const current = stack.pop() as number
+    const current = stack.pop()
+    if (current === undefined) break
     const kids = childrenByParent.get(current) ?? []
     for (const kid of kids) {
       out.push(kid)
@@ -133,10 +139,11 @@ async function killTreeAggressive(pid: number): Promise<void> {
   } catch {
     // process may already be gone; sweep below
   }
+  // Sweep descendants from the pre-fkill snapshot. We don't probe with signal 0 first because
+  // safeKill already swallows ESRCH on already-dead processes, and a probe-then-kill sequence
+  // introduces a TOCTOU race where the PID could be reused between the probe and the SIGKILL.
   for (const target of [...descendants, pid]) {
-    if (safeKill(target, 0)) {
-      safeKill(target, 'SIGKILL')
-    }
+    safeKill(target, 'SIGKILL')
   }
 }
 
@@ -167,6 +174,7 @@ export async function startServer(
     },
   })
   const pid = child.pid ?? -1
+  let stopped = false
 
   const stderrLines: string[] = []
   let baseUrl: string | undefined
@@ -190,8 +198,12 @@ export async function startServer(
   attachStreamDrain(child.stdout, 'stdout', drainState)
   attachStreamDrain(child.stderr, 'stderr', drainState)
 
+  // Idempotent: a second stop() on the same handle is a no-op. This prevents the rare but
+  // dangerous case where the original PID is reused by an unrelated process between the first
+  // stop() and a follow-up stop() in a finally block, causing us to SIGKILL the wrong process.
   const stop = async (): Promise<void> => {
-    if (pid <= 0) return
+    if (stopped || pid <= 0) return
+    stopped = true
     await killTreeAggressive(pid)
   }
 

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -69,10 +69,74 @@ describe('opencode-copilot-delegate plugin (integration)', () => {
     expect(ids).toContain('copilot_output')
     expect(ids).toContain('copilot_cancel')
   }, 10_000)
+
+  it('exposes correct schemas for each plugin tool via tool.list()', async () => {
+    // Given a client connected to the running server
+    const client = makeClient(server.baseUrl)
+    // When we list tools for the always-available `opencode/big-pickle` model
+    // (a free model bundled with OpenCode that requires no auth, suitable for CI).
+    const response = await client.tool.list({
+      query: { provider: 'opencode', model: 'big-pickle' },
+    })
+    const tools = response.data ?? []
+
+    // Then each plugin tool appears with a non-empty description and a JSON-schema
+    // parameters object whose `required` and `properties` keys match the source-of-truth
+    // shapes defined in src/tools/*.ts.
+    const byId = new Map(tools.map((t) => [t.id, t]))
+
+    const delegate = byId.get('copilot_delegate')
+    expect(delegate).toBeDefined()
+    expect(delegate?.description).toMatch(/copilot/i)
+    const delegateSchema = asObjectSchema(delegate?.parameters)
+    expect(Object.keys(delegateSchema.properties ?? {}).sort()).toEqual([
+      'add_dir',
+      'agent',
+      'allow_tool',
+      'deny_tool',
+      'model',
+      'prompt',
+    ])
+    expect(delegateSchema.required).toEqual(['prompt'])
+
+    const output = byId.get('copilot_output')
+    expect(output).toBeDefined()
+    expect(output?.description).toMatch(/copilot|output|task/i)
+    const outputSchema = asObjectSchema(output?.parameters)
+    expect(Object.keys(outputSchema.properties ?? {}).sort()).toEqual([
+      'block',
+      'task_id',
+      'timeout_ms',
+    ])
+    expect(outputSchema.required).toEqual(['task_id'])
+
+    const cancel = byId.get('copilot_cancel')
+    expect(cancel).toBeDefined()
+    expect(cancel?.description).toMatch(/cancel/i)
+    const cancelSchema = asObjectSchema(cancel?.parameters)
+    expect(Object.keys(cancelSchema.properties ?? {})).toEqual(['task_id'])
+    expect(cancelSchema.required).toEqual(['task_id'])
+  }, 15_000)
 })
 
+interface JsonObjectSchema {
+  properties?: Record<string, unknown>
+  required?: string[]
+}
+
+// Narrows an unknown JSON Schema parameters value to the subset we assert on.
+// One cast at the JSON boundary keeps the rest of the test type-safe.
+function asObjectSchema(parameters: unknown): JsonObjectSchema {
+  if (typeof parameters !== 'object' || parameters === null) {
+    throw new Error(
+      `expected parameters to be an object, got ${typeof parameters}`,
+    )
+  }
+  return parameters as JsonObjectSchema
+}
+
 describe('helpers/server resilience', () => {
-  it('shuts down within 5s after stop() and leaves no zombie process', async () => {
+  it('shuts down cleanly via stop() and leaves no zombie process', async () => {
     // Given a freshly started server
     const projectDir = makeProjectDir('opencode-stop')
     let handle: ServerHandle | undefined
@@ -81,54 +145,62 @@ describe('helpers/server resilience', () => {
       const pid = handle.pid
 
       // When we stop it
-      const start = Date.now()
       await handle.stop()
-      const elapsed = Date.now() - start
 
-      // Then it shuts down within 5s
-      expect(elapsed).toBeLessThan(5000)
-
-      // And the process is gone (kill(pid, 0) throws ESRCH)
+      // Then the process is gone (kill(pid, 0) throws ESRCH).
+      // We assert behavior, not wall-clock time — fkill's waitForExit upper bound
+      // already enforces the deadline, and the bun:test outer timeout below catches hangs.
       let stillAlive = false
       try {
         process.kill(pid, 0)
         stillAlive = true
       } catch (err) {
-        const e = err as NodeJS.ErrnoException
-        expect(e.code).toBe('ESRCH')
+        expect(err).toBeInstanceOf(Error)
+        expect(err).toHaveProperty('code', 'ESRCH')
       }
       expect(stillAlive).toBe(false)
     } finally {
+      // stop() is idempotent — a second call after PID reuse would otherwise be dangerous,
+      // but the helper guards against this internally with a `stopped` flag.
       if (handle) await handle.stop().catch(() => {})
       rmSync(projectDir, { force: true, recursive: true })
     }
   }, 20_000)
 
   it('rejects with stderr tail if server exits before health', async () => {
-    // Given a project dir with no plugin (still valid) but spawned with a deliberately bad
-    // hostname that opencode will refuse to bind. Use --hostname with an invalid IP to trigger
-    // an early exit before health responds.
+    // Given a project dir spawned with a deliberately bad hostname so opencode refuses
+    // to bind and exits before health responds.
     const projectDir = makeProjectDir('opencode-fail')
     try {
       // When we try to start with an unbindable host
-      const promise = startServer({
-        cwd: projectDir,
-        extraArgs: ['--hostname', '256.256.256.256'],
-        timeoutMs: 8_000,
-      })
-      // Then it rejects with an error mentioning the early exit
-      await expect(promise).rejects.toThrow(
-        /exited|listen|EADDR|invalid|hostname/i,
-      )
+      let caught: unknown
+      try {
+        await startServer({
+          cwd: projectDir,
+          extraArgs: ['--hostname', '256.256.256.256'],
+          timeoutMs: 8_000,
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      // Then the rejection is an Error whose message contains BOTH:
+      //   1. the early-exit marker (proves the exit-before-health path was taken), AND
+      //   2. the stderr tail header (proves stderr capture is wired up — protects against
+      //      regressions that would silently drop diagnostic content).
+      expect(caught).toBeInstanceOf(Error)
+      const message = (caught as Error).message
+      expect(message).toMatch(/exited with code/)
+      expect(message).toMatch(/stderr tail/)
     } finally {
       rmSync(projectDir, { force: true, recursive: true })
     }
   }, 15_000)
 })
 
-describe.skip('Deferred to T7 (manual E2E) — requires real LLM session', () => {
-  // The following plan scenarios cannot be automated without a configured LLM provider
-  // and API key in CI. They live in `VERIFICATION.md` (T7) instead:
+describe.skip('Deferred to T7 (manual E2E) — full LLM-driven flows', () => {
+  // The following plan scenarios are deferred to T7 (manual E2E in VERIFICATION.md) because
+  // they require an LLM to invoke the plugin tools through a real session prompt:
   //
   // - Given a prompt that invokes copilot_delegate, the assistant message contains
   //   a task_id matching /^cpl_[0-9a-f-]+$/.
@@ -136,5 +208,12 @@ describe.skip('Deferred to T7 (manual E2E) — requires real LLM session', () =>
   // - Given a running task, copilot_cancel returns { cancelled: true, was_running: true }.
   // - Given a nonexistent task_id, copilot_output returns { status: 'unknown' }.
   // - <system-reminder> appears as a subsequent assistant turn after delegation completes.
+  //
+  // The underlying tool-execute logic is already covered at the unit level:
+  //   - tests/tools.test.ts — task_id format, blocking timeout, cancel-running,
+  //                            unknown task_id, structured error envelopes
+  //   - tests/notify.test.ts — system-reminder injection and noReply semantics
+  // What's deferred is end-to-end orchestration through the OpenCode session prompt path,
+  // which the SDK only exposes via LLM invocation.
   it('requires LLM — see VERIFICATION.md', () => {})
 })

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -120,19 +120,33 @@ describe('opencode-copilot-delegate plugin (integration)', () => {
 })
 
 interface JsonObjectSchema {
+  type?: unknown
   properties?: Record<string, unknown>
   required?: string[]
 }
 
 // Narrows an unknown JSON Schema parameters value to the subset we assert on.
 // One cast at the JSON boundary keeps the rest of the test type-safe.
+// We assert `type === 'object'` so a future SDK revision that returned an
+// array schema (or any non-object discriminant) would fail loudly here
+// instead of silently passing with empty properties.
 function asObjectSchema(parameters: unknown): JsonObjectSchema {
-  if (typeof parameters !== 'object' || parameters === null) {
+  if (
+    typeof parameters !== 'object' ||
+    parameters === null ||
+    Array.isArray(parameters)
+  ) {
     throw new Error(
-      `expected parameters to be an object, got ${typeof parameters}`,
+      `expected parameters to be a non-array object, got ${typeof parameters}`,
     )
   }
-  return parameters as JsonObjectSchema
+  const schema = parameters as JsonObjectSchema
+  if (schema.type !== 'object') {
+    throw new Error(
+      `expected parameters.type === 'object', got ${String(schema.type)}`,
+    )
+  }
+  return schema
 }
 
 describe('helpers/server resilience', () => {
@@ -196,6 +210,27 @@ describe('helpers/server resilience', () => {
       rmSync(projectDir, { force: true, recursive: true })
     }
   }, 15_000)
+
+  it('throws an actionable error when the binary is missing (ENOENT)', async () => {
+    // Given a non-existent binary path is passed to startServer
+    const missing = '/nonexistent/path/to/opencode-test-binary-9d8f3c'
+    let caught: unknown
+    try {
+      // When we try to start
+      await startServer({ command: missing, timeoutMs: 4_000 })
+    } catch (err) {
+      caught = err
+    }
+
+    // Then the rejection is an Error whose message identifies the spawn failure
+    // (with the ENOENT code) and includes the binary path. This protects the
+    // diagnostic path against silent timeouts when opencode is not installed.
+    expect(caught).toBeInstanceOf(Error)
+    const message = (caught as Error).message
+    expect(message).toMatch(/failed to spawn/i)
+    expect(message).toMatch(/ENOENT/)
+    expect(message).toContain(missing)
+  }, 8_000)
 })
 
 describe.skip('Deferred to T7 (manual E2E) — full LLM-driven flows', () => {

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { makeClient } from './helpers/client'
+import { type ServerHandle, startServer } from './helpers/server'
+
+const REPO_ROOT = resolve(import.meta.dir, '..', '..')
+const PLUGIN_DIST = join(REPO_ROOT, 'dist', 'index.js')
+
+function makeProjectDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `${prefix}-`))
+  const pluginDir = join(dir, '.opencode', 'plugins')
+  mkdirSync(pluginDir, { recursive: true })
+  copyFileSync(PLUGIN_DIST, join(pluginDir, 'copilot-delegate.js'))
+  writeFileSync(
+    join(dir, 'package.json'),
+    `${JSON.stringify({ name: 'integration-fixture', version: '0.0.0', type: 'module' }, null, 2)}\n`,
+  )
+  return dir
+}
+
+describe('opencode-copilot-delegate plugin (integration)', () => {
+  let server: ServerHandle
+  let projectDir: string
+
+  beforeAll(async () => {
+    if (!existsSync(PLUGIN_DIST)) {
+      throw new Error(
+        `Plugin dist not found at ${PLUGIN_DIST}. Run: bun run build`,
+      )
+    }
+    projectDir = makeProjectDir('opencode-integration')
+    server = await startServer({ cwd: projectDir })
+  }, 30_000)
+
+  afterAll(async () => {
+    if (server) await server.stop()
+    if (projectDir) rmSync(projectDir, { force: true, recursive: true })
+  }, 10_000)
+
+  it('starts and reports healthy', async () => {
+    // Given the server has started in beforeAll
+    // When we call /global/health
+    const res = await fetch(`${server.baseUrl}/global/health`)
+    // Then the response body indicates a healthy server with a version string
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { healthy: boolean; version: string }
+    expect(body.healthy).toBe(true)
+    expect(typeof body.version).toBe('string')
+  }, 10_000)
+
+  it('exposes copilot_delegate, copilot_output, copilot_cancel in tool ids', async () => {
+    // Given a client connected to the running server
+    const client = makeClient(server.baseUrl)
+    // When we list tool ids
+    const response = await client.tool.ids()
+    const ids = response.data
+    // Then all three plugin tool ids are present
+    expect(ids).toBeDefined()
+    expect(ids).toContain('copilot_delegate')
+    expect(ids).toContain('copilot_output')
+    expect(ids).toContain('copilot_cancel')
+  }, 10_000)
+})
+
+describe('helpers/server resilience', () => {
+  it('shuts down within 5s after stop() and leaves no zombie process', async () => {
+    // Given a freshly started server
+    const projectDir = makeProjectDir('opencode-stop')
+    let handle: ServerHandle | undefined
+    try {
+      handle = await startServer({ cwd: projectDir })
+      const pid = handle.pid
+
+      // When we stop it
+      const start = Date.now()
+      await handle.stop()
+      const elapsed = Date.now() - start
+
+      // Then it shuts down within 5s
+      expect(elapsed).toBeLessThan(5000)
+
+      // And the process is gone (kill(pid, 0) throws ESRCH)
+      let stillAlive = false
+      try {
+        process.kill(pid, 0)
+        stillAlive = true
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException
+        expect(e.code).toBe('ESRCH')
+      }
+      expect(stillAlive).toBe(false)
+    } finally {
+      if (handle) await handle.stop().catch(() => {})
+      rmSync(projectDir, { force: true, recursive: true })
+    }
+  }, 20_000)
+
+  it('rejects with stderr tail if server exits before health', async () => {
+    // Given a project dir with no plugin (still valid) but spawned with a deliberately bad
+    // hostname that opencode will refuse to bind. Use --hostname with an invalid IP to trigger
+    // an early exit before health responds.
+    const projectDir = makeProjectDir('opencode-fail')
+    try {
+      // When we try to start with an unbindable host
+      const promise = startServer({
+        cwd: projectDir,
+        extraArgs: ['--hostname', '256.256.256.256'],
+        timeoutMs: 8_000,
+      })
+      // Then it rejects with an error mentioning the early exit
+      await expect(promise).rejects.toThrow(
+        /exited|listen|EADDR|invalid|hostname/i,
+      )
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true })
+    }
+  }, 15_000)
+})
+
+describe.skip('Deferred to T7 (manual E2E) — requires real LLM session', () => {
+  // The following plan scenarios cannot be automated without a configured LLM provider
+  // and API key in CI. They live in `VERIFICATION.md` (T7) instead:
+  //
+  // - Given a prompt that invokes copilot_delegate, the assistant message contains
+  //   a task_id matching /^cpl_[0-9a-f-]+$/.
+  // - Given a task_id, copilot_output with block: true returns within timeout_ms.
+  // - Given a running task, copilot_cancel returns { cancelled: true, was_running: true }.
+  // - Given a nonexistent task_id, copilot_output returns { status: 'unknown' }.
+  // - <system-reminder> appears as a subsequent assistant turn after delegation completes.
+  it('requires LLM — see VERIFICATION.md', () => {})
+})


### PR DESCRIPTION
## Summary

Adds the first integration-test layer for the plugin: a real `opencode serve` subprocess on an ephemeral port, the plugin loaded from `dist/index.js`, and assertions through the OpenCode SDK client. Establishes the harness for everything T7 and beyond.

## What's covered

- **Server lifecycle** \u2014 spawn `opencode serve --port 0 --print-logs` in a temp project dir, parse the assigned port from stdout, poll `/global/health` at 100ms intervals, capture a 200-line stderr ring buffer for diagnostics, and tear down the full process tree on stop.
- **Plugin presence** \u2014 verify all three tools (`copilot_delegate`, `copilot_output`, `copilot_cancel`) appear in `tool.ids()` and that each one has the correct description and parameter schema via `tool.list()`. The schema test uses the always-available `opencode/big-pickle` model so no provider auth is required in CI.
- **Resilience** \u2014 verify `stop()` leaves no zombie process (kill(pid, 0) returns ESRCH), verify the early-exit error message contains both an exit-code marker and a stderr tail when opencode refuses to bind.

## Out of scope

Five plan scenarios that require an LLM session to invoke the plugin tools through a real prompt (task_id round-trip, blocking output, cancel-running, unknown task_id, system-reminder injection) are deferred to T7 manual E2E. The `describe.skip` block cross-references the unit tests in `tests/tools.test.ts` and `tests/notify.test.ts` that already cover the underlying logic; what's deferred is the end-to-end orchestration through the session prompt path.

## Test counts

\`98 tests, 594 expect() calls, 0 fail, 1 intentional skip.\` Three consecutive runs leave zero zombie processes. Typecheck, lint, and build all clean.

## Notes

- New script: \`bun run test:integration\` runs only the new suite.
- The full \`bun test\` continues to run both unit + integration tests.
- Process-tree teardown snapshots descendants from \`ps -axo pid,ppid\` before signalling to handle the case where the \`opencode\` shim's child outlives the shim. Unix-only at the moment; Windows CI would need a different strategy.
- Plan documented \`/global/health\` as returning \`{ ok: true }\` but the actual response is \`{ healthy: true, version: '...' }\` \u2014 the test asserts the real shape.