### PR TITLE
Add CI workflow with mise-managed tooling

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,9 +12,11 @@ branches:
     protection:
       required_status_checks:
         strict: true
-        # Expand this list once CI workflows exist (Build, Typecheck, Lint, Test, etc.)
+        # Note: Integration tests run on push and on same-repo PRs only — not required
+        # because they're skipped on PRs from forks where COPILOT_PAT is unavailable.
         contexts:
           - Fro Bot
+          - Lint, typecheck, build, unit tests
       enforce_admins: true
       required_pull_request_reviews: null
       restrictions: null

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,80 @@
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: Lint, typecheck, build, unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup mise (bun, opencode, copilot)
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v4.0.1
+        with:
+          experimental: true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Build
+        run: bun run build
+
+      - name: Unit tests
+        run: bun run test:unit
+
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: check
+    # Skip on PRs from forks (secrets unavailable)
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork == false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup mise (bun, opencode, copilot)
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v4.0.1
+        with:
+          experimental: true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Verify tool versions
+        run: |
+          bun --version
+          opencode --version
+          copilot --version
+
+      - name: Integration tests
+        run: bun run test:integration
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup mise (bun, opencode, copilot)
-        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v4.0.1
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           experimental: true
 
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup mise (bun, opencode, copilot)
-        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v4.0.1
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           experimental: true
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+bun = "1.3.13"
+"npm:opencode-ai" = "1.14.25"
+"npm:@github/copilot" = "1.0.36"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "build": "bun run clean && bun build src/index.ts --outdir dist --target bun --external @opencode-ai/plugin --external @opencode-ai/sdk && tsc --emitDeclarationOnly --noEmit false",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
+    "test:unit": "bun test tests/*.test.ts",
     "test:integration": "bun test tests/integration/",
     "lint": "biome check .",
     "fix": "biome check . --write",


### PR DESCRIPTION
## Summary

Adds the first CI workflow for the repo and pins all three external tools — bun, opencode, and the Copilot CLI — through a single `mise.toml`. Renovate's mise manager auto-tracks all three; Marcus's local dev environment uses the same pattern, so versions stay aligned across local and CI.

## Layout

- **`mise.toml`** — `bun = "1.3.13"`, `"npm:opencode-ai" = "1.14.25"`, `"npm:@github/copilot" = "1.0.36"`
- **`.github/workflows/ci.yaml`** — two jobs:
  - `check` runs on every push and PR: typecheck, lint, build, and unit tests via the new `test:unit` script. Required status check for `main`.
  - `integration` runs after `check` and is skipped on PRs from forks where `COPILOT_PAT` is unavailable. Sets `GH_TOKEN` from the `COPILOT_PAT` secret so the Copilot CLI auth chain is in place for the LLM-driven scenarios that will move into the integration suite later.
- **`package.json`** — new `test:unit` script (`bun test tests/*.test.ts`) so the integration suite runs only when the integration job spins up the full toolchain.
- **`.github/settings.yml`** — promotes the `check` job to a required status check alongside `Fro Bot`.

## Verified locally

- `mise install` resolves all three tools cleanly.
- `bun run test:unit`: 92 pass / 0 fail (excludes integration).
- `bun run test:integration`: 6 pass / 1 skip / 0 fail.
- `bun run typecheck`, `bun run lint`, `bun run build`: clean.
- `bun install --frozen-lockfile`: lockfile in sync.

## Notes for reviewers

- Integration tests don't yet call `copilot -p` — the auth wiring is forward-looking for the deferred LLM scenarios in `describe.skip` block.
- `cancel-in-progress` is true on PRs (rapid iteration), false on `main` pushes (full coverage).
- `experimental: true` on `jdx/mise-action` enables the `npm:` backend that mise uses for the two npm-published tools.
- All actions pinned to full SHAs.