### PR TITLE
Cache bun install and share dist between CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,15 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           experimental: true
+          cache: true
+
+      - name: Cache bun install
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -40,6 +49,14 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Unit tests
         run: bun run test:unit
@@ -61,12 +78,24 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           experimental: true
+          cache: true
+
+      - name: Cache bun install
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build
-        run: bun run build
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
 
       - name: Verify tool versions
         run: |


### PR DESCRIPTION
## Summary

Two CI iteration improvements, both surfaced as non-blocking review notes on the original CI PR:

- **Cache `~/.bun/install/cache`** across runs, keyed on `bun.lock` with a branch fallback. Cold runs re-download every package; warm runs skip the download phase entirely.
- **Share `dist/` between jobs.** The `check` job uploads `dist/` as an artifact (1-day retention) and the `integration` job downloads it instead of running `bun run build` a second time. Guarantees both jobs test the exact same build artifact and removes ~5–10s of redundant work per CI run.

## Action SHAs

All pinned to the **exact-version tag** (not the major-version pointer, which can drift):

- `actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5`
- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
- `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`

## Notes

- `jdx/mise-action@v4.0.1` already caches mise tools (including `npm:opencode-ai` and `npm:@github/copilot`) by default. `cache: true` is set explicitly for documentation.
- `if-no-files-found: error` on the upload guarantees a build regression (empty `dist/`) fails CI immediately rather than silently producing an empty integration test environment.
- The bun cache fallback via `restore-keys: bun-${{ runner.os }}-` lets a `bun.lock` change still pick up most packages from cache instead of starting cold.

The next CI run on this PR is the verification — first run primes the cache (cold), subsequent runs should show measurable speedup.