### PR TITLE
Document ps/prompt visibility, lifetime cap, versioning policy, notification API

### DIFF
--- a/.changeset/readme-polish.md
+++ b/.changeset/readme-polish.md
@@ -1,0 +1,5 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Document the upstream `ps`/prompt-visibility caveat, the absence of a subprocess lifetime cap, and the `0.x` versioning policy in the README. Correct the notification-injection description to match the implementation (`client.session.prompt` with `noReply`, not `promptAsync`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ tests/fixtures/
 - **Peer dependencies**: `@opencode-ai/plugin` and `@opencode-ai/sdk` are peers — the host OpenCode install provides them
 - **Single-line JSONL parser**: `parseJsonlLine` handles one line at a time and returns `{ type: 'unknown' }` for malformed input. Stream-level multiline accumulation belongs in the subprocess wrapper
 - **Task IDs**: prefixed with `cpl_` to distinguish from OpenCode-native task IDs
-- **Process cleanup**: uses `fkill` with `{ force: false, forceTimeout: 2000, waitForExit: 5000 }` and `.catch()` guards on all `killProcessTree` calls in abort handlers
-- **Notification safety**: in-flight counter is decremented synchronously (before any `await`) in close handlers; `isShuttingDown` checks gate `prompt` calls; counter map entries are deleted at zero to prevent memory leaks
+- **Process cleanup**: uses `fkill` with `{ force: false, forceAfterTimeout: 2000, waitForExit: 5000 }` and `.catch()` guards on all `killProcessTree` calls in abort handlers. On macOS, `tree: true` is Windows-only, so the kill targets the entire process group via `fkill(-pid, ...)` and the subprocess is spawned with `detached: true`.
+- **Notification safety**: in-flight counter is decremented synchronously (before any `await`) in close handlers; counter map entries are deleted at zero to prevent memory leaks over long-lived sessions.
 - **Agent discovery**: builtin agents (bundled with Copilot CLI) cannot be overridden by user or repo agents
 - **Structured errors**: tools return `{ error: string }` objects, never throw exceptions
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin registers three tools in OpenCode:
 - **`copilot_output`** — Retrieve the structured result envelope for a completed or running delegation.
 - **`copilot_cancel`** — Cancel a running delegation with SIGTERM → SIGKILL escalation.
 
-When the subprocess completes, a `<system-reminder>` notification is injected into the parent session via `client.session.promptAsync`, mirroring the async pattern used by OMO.
+When the subprocess completes, a `<system-reminder>` notification is injected into the parent session via `client.session.prompt` with `noReply: false` for the first notification per session and `noReply: true` for subsequent ones, so the agent sees the result without an unbounded reply chain.
 
 ## Installation
 
@@ -84,6 +84,20 @@ Task state is in-memory inside a single OpenCode process. Calling `copilot_outpu
 ## Known Limitations (v0.1.x)
 
 - **Orphaned subprocesses:** If OpenCode crashes mid-delegation, the `copilot` subprocess becomes orphaned. A PID-file reaper is planned for v1.x.
+- **Prompt visibility in `ps`:** The `copilot` CLI accepts the prompt as a command-line argument, which means the full prompt text appears in `ps` output for any user on the host. This is an upstream Copilot CLI behavior. Avoid delegating prompts that contain secrets or PII; pass sensitive material via files, env vars, or `--secret-env-vars` instead.
+- **No subprocess lifetime cap:** A hung `copilot` subprocess stays in the registry as `running` indefinitely. Cancel manually via `copilot_cancel`. A configurable timeout is planned for v1.x.
+
+## Versioning
+
+Releases under `0.x` are unstable and may include breaking changes between minor versions. Pin to an exact version in production:
+
+```json
+"dependencies": {
+  "opencode-copilot-delegate": "0.1.0"
+}
+```
+
+`1.0.0` will be cut once the public surface stabilizes.
 
 ## Privacy
 


### PR DESCRIPTION
## What

Documentation polish ahead of the first npm release.

### README

- Correct the notification-injection description: it uses `client.session.prompt` with `noReply`, not `promptAsync`.
- Document the upstream Copilot CLI behavior of exposing prompts in `ps` output, with guidance on passing sensitive material via files, env vars, or `--secret-env-vars`.
- Surface the absence of a subprocess lifetime cap as a known limitation (cancel manually via `copilot_cancel`; configurable timeout planned for v1.x).
- Add a versioning section explaining the `0.x` stability policy and recommending exact-version pinning.

### AGENTS.md

- Fix the fkill option name (`forceAfterTimeout`, not `forceTimeout`) and add the macOS process-group kill detail.
- Remove the stale `isShuttingDown` reference; that flag was deleted in PR #16 and the doc never caught up.

## Why

The `ps`/prompt-visibility caveat was tracked as a documentation TODO from the early subprocess implementation but never made it into the README. The notification-API description was wrong and would mislead anyone reading the README to understand the runtime. The fkill and `isShuttingDown` mismatches in AGENTS.md would have led future contributors to write code against APIs that no longer exist.

## Verification

- typecheck clean
- lint clean (25 files)
- build 0.33 MB
- 92 unit tests pass
