### PR TITLE
docs: integration-test rebuild and opencode debug-log diagnostic recipe

### DIFF
--- a/docs/solutions/best-practices/reliable-cli-integration-testing-2026-04-26.md
+++ b/docs/solutions/best-practices/reliable-cli-integration-testing-2026-04-26.md
@@ -72,6 +72,8 @@ export function runOpencode(args: RunArgs): SpawnSyncReturns<string> {
     OPENCODE_CONFIG_DIR: configDir,
     OPENCODE_CONFIG_CONTENT: JSON.stringify({plugin: [args.pluginUrl]}),
   }
+  // copilotPat is forwarded as GH_TOKEN — see auth precedence in README
+  // (COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN > ~/.copilot/auth).
   if (args.copilotPat) env.GH_TOKEN = args.copilotPat
   return spawnSync('opencode', ['run', '--model', model, args.prompt], {
     env,

--- a/docs/solutions/best-practices/reliable-cli-integration-testing-2026-04-26.md
+++ b/docs/solutions/best-practices/reliable-cli-integration-testing-2026-04-26.md
@@ -1,0 +1,136 @@
+---
+title: Reliable integration testing for OpenCode plugins via CLI invocations
+date: 2026-04-26
+category: best-practices
+module: integration_tests
+problem_type: best_practice
+component: testing_framework
+severity: medium
+applies_when:
+  - Building integration tests for an OpenCode plugin that exercises tool execution end-to-end
+  - Choosing between an SDK harness (`opencode serve` + `createOpencodeClient`) and a CLI subprocess
+  - Diagnosing test timeouts that look like plugin-loading or tool-calling regressions
+  - Selecting a default model for a CI test suite
+tags:
+  - opencode
+  - integration-testing
+  - cli-invocations
+  - rate-limits
+  - isolation
+  - spawn-sync
+  - model-selection
+---
+
+# Reliable integration testing for OpenCode plugins via CLI invocations
+
+## Context
+
+The first integration suite for this plugin was SDK-based: a `helpers/server.ts` module spawned `opencode serve --port 0`, parsed the ephemeral port from stdout, polled `/global/health`, then helpers wrapped `createOpencodeClient` and `session.prompt`/`session.promptAsync`. To prevent user-config bleed-through from plugins like Magic Context or OMO, the harness grew heavy isolation: `HOME` redirect, all `XDG_*` dirs, `OPENCODE_TEST_HOME`, `OPENCODE_TEST_MANAGED_CONFIG_DIR`, `OPENCODE_DISABLE_DEFAULT_PLUGINS`, `OPENCODE_CONFIG_CONTENT`, native opencode binary resolver. After all that, tests against the free `opencode/big-pickle` model returned `assistant[]` arrays with no tool parts and no errors, and several hours were lost theorizing about upstream tool-calling regressions, plugin-loading hangs, and isolation bugs. The actual cause was a `429 Rate limit exceeded` from `https://opencode.ai/zen/v1/messages` — invisible because opencode silently retries on `isRetryable: true` until the test framework times out. The correct primitive turned out to be much simpler: invoke `opencode run` as a subprocess with a paid model, use the minimum isolation that actually matters, and stay out of the SDK harness business entirely.
+
+## Guidance
+
+For integration tests of an OpenCode plugin:
+
+- **Drive `opencode run` directly via `node:child_process.spawnSync`** instead of `opencode serve` + the SDK. No port management, no health polling, no SDK version coupling.
+- **Default to a paid model** (`opencode/minimax-m2.5`) for reliability. Free models on `opencode.ai/zen` (e.g., `opencode/big-pickle`) have per-account rate limits that get burned through quickly during failing test loops, surfacing as opaque test timeouts. Allow override via `OPENCODE_TEST_MODEL` env var so individual developers can use free models when their per-account quota is fresh.
+- **Minimum isolation**: `OPENCODE_CONFIG_DIR=<empty temp dir>` skips the user's `~/.config/opencode/opencode.json` (which is what was loading Magic Context / OMO). `OPENCODE_CONFIG_CONTENT` registers `dist/index.js` as a plugin via a `file://` URL. Avoid HOME / XDG redirection unless you have evidence of needing more — the heavy harness was solving the wrong problem.
+- **ENOBUFS guardrail**: do not leave `--print-logs` on inside test commands. `spawnSync`'s default 1 MB stdout/stderr buffer overflows fast under DEBUG logging and the OS kills the process with `ENOBUFS` / `SIGTERM`. If you need logs temporarily for debugging, bump `maxBuffer` to ~50 MB. See the sibling learning [Diagnosing OpenCode failures with debug logs](../developer-experience/opencode-debug-diagnostics-2026-04-26.md) for the recipe.
+- **Auth forwarding**: pass `COPILOT_PAT` (or `GH_TOKEN`) via the `env` option on `spawnSync` rather than mutating `process.env`. Mutating the parent process leaks state across tests.
+- **Assertion shape**: regex on `result.stdout` works for the simple case but is vulnerable to LLM-text false positives. Future improvement: parse `opencode run --format json` event stream for actual tool-invocation parts. Tracked separately.
+
+## Why This Matters
+
+The SDK rabbit hole burned roughly six hours and many tokens chasing isolation, plugin-loading, and tool-calling-regression theories — none of which were the cause. The CLI primitive has fewer moving parts (no port management, no health endpoint, no SDK version coupling), repeats reliably across local/CI/cousin repos (Systematic, fro-bot/agent), and survives OpenCode upgrades that would otherwise break the SDK harness. Picking a paid model as the default removes the single highest source of CI flakiness: free-model rate limiting that masquerades as everything else.
+
+## When to Apply
+
+- Writing integration tests for an OpenCode plugin that need end-to-end coverage of tool execution.
+- Choosing between an SDK harness and a CLI subprocess for test automation.
+- Diagnosing test timeouts that resemble plugin-loading issues, tool-calling regressions, or isolation bugs — switch to the CLI shape and run `opencode run --print-logs --log-level DEBUG` first to surface API-level errors before forming theories.
+- Selecting a default model for a CI test suite where reliability outweighs per-run cost.
+
+## Examples
+
+### Minimal test helper
+
+```ts
+import {spawnSync, type SpawnSyncReturns} from 'node:child_process'
+import {dirSync} from 'tmp'
+
+interface RunArgs {
+  model?: string
+  prompt: string
+  pluginUrl: string
+  copilotPat?: string
+}
+
+export function runOpencode(args: RunArgs): SpawnSyncReturns<string> {
+  const model = args.model ?? process.env.OPENCODE_TEST_MODEL ?? 'opencode/minimax-m2.5'
+  const configDir = dirSync({unsafeCleanup: true}).name
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCODE_CONFIG_DIR: configDir,
+    OPENCODE_CONFIG_CONTENT: JSON.stringify({plugin: [args.pluginUrl]}),
+  }
+  if (args.copilotPat) env.GH_TOKEN = args.copilotPat
+  return spawnSync('opencode', ['run', '--model', model, args.prompt], {
+    env,
+    encoding: 'utf8',
+    timeout: 60_000,
+    // Default 1MB. Bump to 50_000_000 only if you add --print-logs --log-level DEBUG.
+  })
+}
+
+export function assertOk(result: SpawnSyncReturns<string>): void {
+  if (result.status !== 0) {
+    throw new Error(`opencode run exited ${result.status}; stderr tail:\n${result.stderr.slice(-2_000)}`)
+  }
+}
+```
+
+### Before / after
+
+Before (SDK harness, simplified):
+
+```ts
+const server = await startServer({port: 0, isolation: deepIsolation()})
+const client = makeClient(server.baseUrl)
+const session = await client.session.create()
+await client.session.prompt({path: {id: session.id}, body: {parts: [{type: 'text', text: 'PING'}]}})
+const messages = await client.session.messages({path: {id: session.id}})
+expect(extractText(messages)).toMatch(/PONG/)
+await server.stop()
+```
+
+After (CLI subprocess):
+
+```ts
+const result = runOpencode({prompt: 'Reply with exactly PONG.', pluginUrl: `file://${distPath}/index.js`})
+assertOk(result)
+expect(result.stdout).toMatch(/PONG/)
+```
+
+### Cancel-running test (avoiding LLM false positives)
+
+The cancel test asks the LLM to delegate then cancel in a single prompt. To avoid false positives where chatty LLM prose contains the word "cancelled" or "true" without the tool actually running, assert on **both**:
+
+```ts
+const result = runOpencode({
+  prompt:
+    'Use copilot_delegate to start a task that runs "sleep 30 && echo done", then immediately use copilot_cancel ' +
+    'on the returned task_id. After cancellation, confirm by stating exactly: cancelled true',
+  pluginUrl: `file://${distPath}/index.js`,
+  copilotPat: process.env.COPILOT_PAT,
+})
+assertOk(result)
+expect(result.stdout).toMatch(/cancel(led|ed)/i)
+expect(result.stdout).toMatch(/\btrue\b/)
+```
+
+The `\btrue\b` boundary requires `true` as a standalone token, not embedded in prose like "the truest test of …".
+
+## Related
+
+- Sibling learning: [Diagnosing OpenCode failures with debug logs](../developer-experience/opencode-debug-diagnostics-2026-04-26.md) — the diagnostic recipe that surfaced the rate-limit root cause behind this rebuild.
+- Implementation: `tests/integration/opencode.test.ts`
+- Tracking issue: re-add integration tests to CI once the cost-vs-signal call is settled (#38).

--- a/docs/solutions/developer-experience/opencode-debug-diagnostics-2026-04-26.md
+++ b/docs/solutions/developer-experience/opencode-debug-diagnostics-2026-04-26.md
@@ -1,0 +1,124 @@
+---
+title: Diagnosing OpenCode failures with debug logs
+date: 2026-04-26
+category: developer-experience
+module: opencode_runtime
+problem_type: developer_experience
+component: development_workflow
+severity: medium
+applies_when:
+  - An opencode test or invocation hangs or times out without an obvious local cause
+  - "build · model" stalls without progress, or `assistant[]` comes back empty
+  - You suspect an upstream regression, plugin-loading bug, or isolation problem
+  - Anytime you find yourself forming a theory before reading logs
+tags:
+  - opencode
+  - debugging
+  - print-logs
+  - log-level
+  - rate-limit
+  - api-errors
+  - troubleshooting
+---
+
+# Diagnosing OpenCode failures with debug logs
+
+## Context
+
+OpenCode hides API-level errors behind silent retries: any response marked `isRetryable: true` (rate limits, transient 5xx, provider blips) is reattempted internally without surfacing to the caller. Test frameworks compound the problem by killing spawned `opencode` processes at their timeout boundary (typically 60–120s), discarding whatever the runtime would have logged. The result is a stream of misleading symptoms — empty `assistant[]` arrays, `build · <model>` stalls, opaque test timeouts — that look like everything except the rate limit, auth failure, or provider outage that's actually responsible. The escape hatch is `--print-logs --log-level DEBUG`, which redirects opencode's structured logs to stdout/stderr where the test framework (or a shell redirect) can capture them. Used as the first move on any opencode failure, it cuts diagnosis time from hours to minutes.
+
+## Guidance
+
+When investigating any opencode failure that doesn't have an obvious local cause:
+
+1. **Capture full DEBUG output to a file** (it's verbose; never pipe straight to a terminal you'll have to scroll):
+
+   ```sh
+   opencode run --print-logs --log-level DEBUG --model <model> "<prompt>" > /tmp/opencode.log 2>&1
+   ```
+
+2. **Grep for API-level errors first** — these are the highest-signal failure mode and the most commonly missed cause:
+
+   ```sh
+   grep -E 'service=llm.*ERROR|statusCode|isRetryable' /tmp/opencode.log
+   ```
+
+3. **Decode common status codes**:
+   - `statusCode: 429` → rate limit. Free models on `opencode.ai/zen` (`opencode/big-pickle`, `opencode/minimax-m2.5-free`) have per-account quotas that get burned through fast during failing test loops. Switch to a paid model (`opencode/minimax-m2.5`) or wait out the window.
+   - `statusCode: 401` / `403` → auth. Missing `GH_TOKEN` for the Copilot CLI subprocess, missing OpenCode auth, or wrong OIDC scope.
+   - `isRetryable: true` repeating in the log → upstream provider issue. opencode is silently retrying; the test will eventually time out without surfacing the cause.
+
+4. **If no API errors surface**, look at plugin/config loading next:
+
+   ```sh
+   grep -E 'plugin.*ERROR|config.*ERROR' /tmp/opencode.log
+   ```
+
+5. **For tool-calling investigations**, trace the interaction timing:
+
+   ```sh
+   grep -E 'session\.(prompt|message)|tool_use|tool_result' /tmp/opencode.log
+   ```
+
+**Important**: don't leave `--print-logs --log-level DEBUG` enabled inside test commands without bumping `spawnSync`'s `maxBuffer` to ~50 MB. The default 1 MB buffer overflows under DEBUG logging and the OS kills the process with `ENOBUFS`/`SIGTERM`. Capture-to-file via shell redirect is the safe default; in-process buffering is the trap. See the sibling learning [Reliable integration testing for OpenCode plugins](../best-practices/reliable-cli-integration-testing-2026-04-26.md).
+
+## Why This Matters
+
+opencode produces detailed structured logs precisely so you don't have to reverse-engineer behavior from black-box symptoms. Skipping that and theorizing first wastes hours and tokens — the rebuild that produced this learning involved roughly six hours of work chasing isolation bugs, plugin-loading hangs, and `OPENCODE_DISABLE_MODELS_FETCH` theories before someone ran the same prompt with `--print-logs --log-level DEBUG` and saw `HTTP 429: Rate limit exceeded` in the second line of output. API and auth errors should be ruled out before any isolation, plugin, or runtime hypothesis — they're cheaper to check, more likely to be the cause, and the runtime tells you about them directly if you ask.
+
+## When to Apply
+
+- Any opencode test timeout or hang exceeding the framework's limit.
+- "build · <model>" processes stalling without progress or output.
+- Empty `assistant[]` messages returned from `session.prompt`.
+- Suspected tool-calling regression, plugin-loading bug, or test isolation problem.
+- Anytime you're tempted to form a theory before reading logs.
+
+## Examples
+
+### Diagnostic command
+
+```sh
+opencode run --print-logs --log-level DEBUG --model opencode/big-pickle "PING" > /tmp/opencode.log 2>&1
+grep -E 'service=llm.*ERROR|statusCode|isRetryable' /tmp/opencode.log
+```
+
+### Real log excerpt revealing rate limit
+
+```
+service=llm ERROR  HTTP 429: Rate limit exceeded
+url=https://opencode.ai/zen/v1/messages
+statusCode=429
+isRetryable=true
+```
+
+This was the actual cause behind ~6 hours of misdirected investigation into upstream regressions. One grep would have found it immediately.
+
+### Counterexample with paid model
+
+Same prompt, paid model:
+
+```sh
+opencode run --print-logs --log-level DEBUG --model opencode/minimax-m2.5 "PING" > /tmp/opencode.log 2>&1
+grep -E 'service=llm.*ERROR|statusCode|isRetryable' /tmp/opencode.log
+# (no matches — clean run)
+
+tail -1 /tmp/opencode.log
+# PONG
+```
+
+### Counterexample with auth error
+
+```
+service=llm ERROR  HTTP 401: Unauthorized
+url=https://api.githubcopilot.com/...
+statusCode=401
+isRetryable=false
+```
+
+`isRetryable: false` here means opencode surfaces the failure quickly rather than hanging — but unless `--print-logs` is on, the test framework will report `exit code 1` with no other context. The grep finds the cause in the first line.
+
+## Related
+
+- Sibling learning: [Reliable integration testing for OpenCode plugins via CLI invocations](../best-practices/reliable-cli-integration-testing-2026-04-26.md) — the integration-test rebuild that this diagnostic recipe enabled, including the `spawnSync`/`maxBuffer` interaction with `--print-logs`.
+- opencode CLI reference: https://opencode.ai/docs/cli/ (`--print-logs`, `--log-level` flags).

--- a/docs/solutions/workflow-issues/bootstrap-missing-github-release-2026-04-26.md
+++ b/docs/solutions/workflow-issues/bootstrap-missing-github-release-2026-04-26.md
@@ -1,7 +1,7 @@
 ---
 title: Missing GitHub Release for already-published npm package
 date: 2026-04-26
-category: docs/solutions/workflow-issues/
+category: workflow-issues
 module: release_pipeline
 problem_type: workflow_issue
 component: development_workflow
@@ -47,14 +47,14 @@ git push origin v0.1.0
 # Create GitHub Release with the matching CHANGELOG.md section as body
 gh release create v0.1.0 \
   --title "v0.1.0" \
-  --notes "$(awk '/^## 0\.1\.0/,/^## 0\.0\./' CHANGELOG.md | sed '$d' | tail -n +2)" \
+  --notes "$(awk '/^## 0\.1\.0/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)" \
   --verify-tag
 ```
 
 When `gh release create` hits a GraphQL rate limit, fall back to the REST endpoint (which uses a different quota):
 
 ```sh
-NOTES=$(awk '/^## 0\.1\.0/,/^## 0\.0\./' CHANGELOG.md | sed '$d' | tail -n +2)
+NOTES=$(awk '/^## 0\.1\.0/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)
 gh api -X POST /repos/<org>/<repo>/releases \
   -f tag_name=v0.1.0 -f name=v0.1.0 \
   -f body="$NOTES" -F draft=false -F prerelease=false
@@ -93,7 +93,7 @@ git tag -a v0.1.0 <version-packages-merge-sha> -m "v0.1.0"
 git push origin v0.1.0
 gh release create v0.1.0 \
   --title "v0.1.0" \
-  --notes "$(awk '/^## 0\.1\.0/,/^## 0\.0\./' CHANGELOG.md | sed '$d' | tail -n +2)" \
+  --notes "$(awk '/^## 0\.1\.0/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)" \
   --verify-tag
 ```
 
@@ -122,7 +122,7 @@ git tag -a v0.1.0 06dec48 -m "v0.1.0"
 git push origin v0.1.0
 gh api -X POST /repos/marcusrbrown/opencode-copilot-delegate/releases \
   -f tag_name=v0.1.0 -f name=v0.1.0 \
-  -f body="$(awk '/^## 0\.1\.0/,/^## 0\.0\./' CHANGELOG.md | sed '$d' | tail -n +2)" \
+  -f body="$(awk '/^## 0\.1\.0/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)" \
   -F draft=false -F prerelease=false
 ```
 


### PR DESCRIPTION
Two knowledge-track learnings landed in the same PR because they're tightly complementary — one is the rebuild, the other is the diagnostic recipe that would have made the rebuild a 10-minute job instead of a 6-hour one. Each doc cross-references the other.

## `docs/solutions/best-practices/reliable-cli-integration-testing-2026-04-26.md`

The integration-test design choice. Drive `opencode run` directly via `node:child_process.spawnSync` instead of running an `opencode serve` + SDK-client harness. Default to a paid model (`opencode/minimax-m2.5`) because free models on `opencode.ai/zen` (`opencode/big-pickle`, `opencode/minimax-m2.5-free`) have per-account rate limits that get burned through during failing test loops and surface as opaque test timeouts. Use minimum isolation: `OPENCODE_CONFIG_DIR=<empty temp dir>` + `OPENCODE_CONFIG_CONTENT` registering the plugin via `file://` URL. Skip the heavy `HOME` / `XDG_*` / native-binary-resolver harness — it solved the wrong problem. Includes the `runOpencode` / `assertOk` helper shape, before/after sketches, and the cancel-running test pattern with `\btrue\b` boundary asserts to avoid false positives from chatty LLM prose.

## `docs/solutions/developer-experience/opencode-debug-diagnostics-2026-04-26.md`

The diagnostic recipe. When investigating any opencode failure (test timeout, "build · model" stall, empty `assistant[]` array, suspected tool-calling regression), run with `--print-logs --log-level DEBUG` redirected to a file first and `grep -E 'service=llm.*ERROR|statusCode|isRetryable'`. Decodes the common failure modes (`429` rate limit, `401`/`403` auth, `isRetryable: true` upstream blip) and explains why test frameworks compound the problem (they kill the spawned process at timeout, discarding the logs that would have answered the question in two seconds). Includes real log excerpts from the rate-limit case and counterexamples for paid model + auth error.

## Cross-references

Each doc links the other. The integration-tests doc cites the diagnostic doc for the `--print-logs` recipe and the `spawnSync` ENOBUFS interaction. The diagnostic doc cites the integration-tests doc for `maxBuffer` guidance.

Docs-only change; no changeset. AGENTS.md was already updated in #41 to surface `docs/solutions/`.