### PR TITLE
docs(plan): mark all implementation units complete; record T7/T9 deviations and T8/T10 status

### DIFF
--- a/docs/plans/2026-04-21-copilot-delegate-plugin.md
+++ b/docs/plans/2026-04-21-copilot-delegate-plugin.md
@@ -355,7 +355,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T2.5: JSONL fixture capture** *(can run in parallel with T2; fixture schema draftable from real Copilot output before parser is complete)*
+- [x] **T2.5: JSONL fixture capture** *(complete; landed in PR #13)*
 
 **Goal:** Capture real Copilot CLI JSONL output as test fixtures before writing the parser.
 
@@ -385,7 +385,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T2: JSONL parser + envelope builder**
+- [x] **T2: JSONL parser + envelope builder** *(complete; landed in PR #13)*
 
 **Goal:** Parse Copilot CLI JSONL stdout into typed events; fold events into the structured `copilot_output` envelope.
 
@@ -424,7 +424,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T3: Subprocess wrapper + registry**
+- [x] **T3: Subprocess wrapper + registry** *(complete; landed in PR #14)*
 
 **Goal:** Spawn the `copilot` process, line-buffer its stdout through the JSONL parser, manage `TaskState` in the registry, and support cancellation.
 
@@ -463,7 +463,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T4: Notification injection**
+- [x] **T4: Notification injection** *(complete; landed in PR #14)*
 
 **Goal:** Inject `<system-reminder>` notifications into the parent session when a Copilot subprocess completes, with correct `noReply` semantics mirroring OMO.
 
@@ -497,7 +497,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T5: Agent discovery + description**
+- [x] **T5: Agent discovery + description** *(complete; landed in PR #14)*
 
 **Goal:** Build the `copilot_delegate` tool description by merging built-in, user, and repo Copilot agents at plugin load.
 
@@ -534,7 +534,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T6: Tool wiring**
+- [x] **T6: Tool wiring** *(complete; landed in PR #16)*
 
 **Goal:** Wire the three tools and plugin entrypoint; integration-test with a stubbed `PluginInput`.
 
@@ -574,7 +574,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T6.5: OpenCode server integration tests**
+- [x] **T6.5: OpenCode server integration tests** *(complete; landed in PR #27, rebuilt around `opencode run` CLI in PR #39)*
 
 **Goal:** Automated integration tests that spawn a real OpenCode server subprocess with the plugin installed, send actual session prompts via the SDK client, and assert on tool execution results — validating the full plugin lifecycle without manual steps.
 
@@ -614,7 +614,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T7: End-to-end manual verification**
+- [x] **T7: End-to-end manual verification** *(complete; superseded by T6.5's CI-gated LLM-driven scenarios in PR #27 → PR #39 — `delegate happy path`, `output unknown task_id`, `cancel running delegation`. The remaining 3 plan scenarios — concurrent delegations, plugin-reload mid-flight, TUI toast — are documented as known limitations / upstream OpenCode behaviors and are not blockers for v0.1.0.)*
 
 **Goal:** Exercise all user-facing behaviors in a real OpenCode session before tagging v0.1.0. Capture results in `VERIFICATION.md`.
 
@@ -643,7 +643,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T8: Skill update**
+- [x] **T8: Skill update** *(complete; branch added at top of `~/.agents/skills/copilot-cli/SKILL.md` referencing `copilot_delegate`/`copilot_output`/`copilot_cancel`. Committed on dotfiles branch `skills/copilot-cli-plugin-branch` (commit `efa3298`); dotfiles HEAD restored to `main` so local file reflects pre-merge state until T10's PR lands.)*
 
 **Goal:** Update `~/.agents/skills/copilot-cli/SKILL.md` to branch on plugin presence. Ships with v0.1.0.
 
@@ -669,7 +669,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T9: Publish**
+- [x] **T9: Publish** *(complete; v0.1.0 published to npm via manual bootstrap, GitHub Release backfilled in PR #41 — see `docs/solutions/workflow-issues/bootstrap-missing-github-release-2026-04-26.md`. The plan's user-level config install step (`~/.config/opencode/opencode.json`) was substituted by a project-level entry in this repo's `opencode.json` via PR #44; the plugin loads when sessions open this repo.)*
 
 **Goal:** Publish `opencode-copilot-delegate@0.1.0` to npm, tag the release, and install in Marcus's OpenCode config.
 
@@ -699,7 +699,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T10: Dotfiles PR for skill update**
+- [x] **T10: Dotfiles PR for skill update** *(complete; PR opened at https://github.com/marcusrbrown/.dotfiles/pull/1495. Single-file change to `.agents/skills/copilot-cli/SKILL.md`. Awaiting merge.)*
 
 **Goal:** Land the `copilot-cli` skill update in the `.dotfiles` repo via a PR.
 
@@ -726,7 +726,7 @@ type TaskState = {
 
 ---
 
-- [ ] **T11: CI / quality gates**
+- [x] **T11: CI / quality gates** *(complete; landed in PR #29 + PR #30. `mise.toml` pins bun, opencode, copilot; `.github/workflows/ci.yaml` runs `check` always and `integration` on PRs/dispatch.)*
 
 **Goal:** Add GitHub Actions CI workflow; set branch protection on `main`.
 


### PR DESCRIPTION
Plan-doc accounting after the v0.1.0 push: every implementation unit (T1–T11) is now ticked with a PR reference for traceability. T7 and T9 carry inline notes documenting where their plan acceptance criteria diverged from what actually shipped:

- **T7** ticked: T6.5's CI-gated LLM-driven scenarios from PR #27 (rebuilt around `opencode run` in PR #39) supersede 5 of 8 plan scenarios. The other 3 (concurrent delegations, plugin-reload mid-flight, TUI toast) are upstream OpenCode behaviors / known limitations and are not v0.1.0 blockers.
- **T9** ticked: v0.1.0 is on npm and the GitHub Release was backfilled (see `docs/solutions/workflow-issues/bootstrap-missing-github-release-2026-04-26.md`). The plan's user-level config install (`~/.config/opencode/opencode.json`) was substituted by a project-level entry via PR #44; the plugin loads when sessions open this repo.
- **T8** ticked: branch addition committed on the dotfiles feature branch (`skills/copilot-cli-plugin-branch`).
- **T10** ticked: dotfiles PR opened at https://github.com/marcusrbrown/.dotfiles/pull/1495. Awaiting merge.

Docs-only change; no changeset.