### PR TITLE
docs(v0.2-prep): Copilot CLI capabilities reference + v0.2.x ideation

### DIFF
--- a/docs/ideation/2026-04-27-copilot-delegate-v0.2.md
+++ b/docs/ideation/2026-04-27-copilot-delegate-v0.2.md
@@ -1,0 +1,248 @@
+---
+title: opencode-copilot-delegate v0.2.x — ideation
+date: 2026-04-27
+status: ranked
+focus: |
+  Two streams: (a) plugin features seeded by docs/research/copilot-cli-capabilities-2026-04-27.md;
+  (b) TUI/desktop visibility for in-flight delegations — render JSONL event stream like an
+  OpenCode subagent session, surfaced via slash commands like /copilot-status (cf. Magic
+  Context's /ctx-status modal).
+volume: default (~30 raw, ~22 deduped, 7 survivors)
+frames: pain & friction · inversion/automation · assumption-breaking · leverage/compounding
+handoff: ce:brainstorm on a single chosen survivor
+related:
+  - docs/research/copilot-cli-capabilities-2026-04-27.md
+  - docs/plans/2026-04-21-copilot-delegate-plugin.md (closed, all T1–T11 ticked)
+  - docs/solutions/best-practices/reliable-cli-integration-testing-2026-04-26.md
+  - docs/solutions/developer-experience/opencode-debug-diagnostics-2026-04-26.md
+---
+
+# v0.2.x Ideation — opencode-copilot-delegate
+
+## Context
+
+v0.1.0 shipped: three tools (`copilot_delegate`, `copilot_output`, `copilot_cancel`), JSONL
+parsing, in-memory task registry, agent discovery, completion notifications. The plugin works
+end-to-end (verified this session: 4076 events parsed across a 5m19s opus 4.7 delegation).
+
+Two concrete signals shape v0.2.x:
+
+1. The **research doc** (`docs/research/copilot-cli-capabilities-2026-04-27.md`) catalogs a
+   12-pattern delegation playbook in §10 and 13 plugin-level limitations in §11. Most §10
+   patterns require capabilities the plugin doesn't yet expose: ACP, `--resume`/`--connect`,
+   `--share`, hooks, tool-permission templates.
+2. The **TUI visibility focus** asks for the JSONL event stream to surface the way OpenCode
+   renders a subagent session, with slash-command access (`/copilot-status` modeled on Magic
+   Context's `/ctx-status`). No documented precedent in the OpenCode ecosystem — net-new
+   territory; viability is part of what brainstorming will resolve.
+
+The plugin itself is a small, focused TypeScript package (~1200 LOC source); the v0.2.x bar
+is "compound investments that ripple into multiple shipped features," not "ship every flag."
+
+## Survivors (7)
+
+### S1. In-flight delegation visibility platform — `/copilot-status` modal + lifecycle toasts
+
+**Bundle**: streaming event bus (parser hook) + event-sourced task registry + slash-command
+TUI surface. The user-stated focus, expressed as a concrete deliverable.
+
+- Live modal renders active and recent delegations as a subagent-style panel: live `tool_call`
+  timeline, current model, elapsed time, status, agent. Ties into `tool_calls_summary` data
+  the envelope already captures.
+- `client.tui.showToast()` (defined but unused in v0.1) wired into spawn / complete / fail /
+  timeout transitions. Cheap addition; no new APIs needed.
+- Foundation: a typed event emitter on `jsonl-parser.ts` so live UI, audit log, and OTel are
+  all subscribers on one bus.
+- Foundation: append-only event log replacing the in-memory `Map` in `task-registry.ts` —
+  unlocks resume, audit, cross-session visibility, and crash recovery from one primitive.
+
+**Why this survives**: directly answers the explicit user focus; combines four frames; every
+sub-investment compounds into multiple shipped features (status UI, audit, OTel, recovery).
+No precedent in OpenCode is risk, but the `client.tui` surface already exists — the brainstorm
+phase resolves the technical viability question with a small spike.
+
+**Rejected alternatives folded in**: F1.4 toasts standalone, F4.5 toast-first notifications,
+F4.7 slash-command surface, F1.7 in-flight tool-call timeline, F3.2/F3.8 native tool-call
+rendering, F4.2 streaming event bus, F4.1 event-sourced registry, F4.9 audit log sidecar,
+F3.6 cross-session pool. (Standalone they were thin; bundled they're the right v0.2 shape.)
+
+---
+
+### S2. `CopilotProcess` abstraction with `--acp` / `--resume` / `--connect` strategies
+
+Refactor `subprocess.ts` into a `CopilotProcess` class that accepts a spawn strategy:
+`direct` (today), `acp` (long-lived stdio server), `connect` (attach to existing session),
+`resume` (continue prior session). The wrapper handles JSONL streaming, process-group
+cleanup, and envelope building uniformly across strategies. New tools `copilot_resume` and
+`copilot_connect` become trivial layers on top.
+
+**Why this survives**: ACP is the most architecturally consequential capability the plugin
+doesn't expose — persistent sessions cut per-call latency and cost (research doc §10.11).
+Even shipped behind an opt-in flag, the abstraction itself unlocks resume + connect for free.
+Once stable, ACP can become the default.
+
+**Risks called out for brainstorm phase**: ACP is undocumented in `copilot help` (only
+`--acp` flag listed); the protocol may be unstable. Mitigation: ship `direct` strategy as
+default in v0.2.x, ACP as `experimental`; promote in v0.3.x.
+
+**Rejected alternatives folded in**: F2.2 ACP server, F3.1 Copilot daemon, F4.8 ACP-as-default,
+F1.3 resume/fork from UI, F2.3 delegate state to Copilot --resume IDs.
+
+---
+
+### S3. Permission profiles + agent manifest fusion
+
+Named permission profiles (`read-only`, `refactor`, `audit`, `doc-gen`, `unsafe`) replace
+hand-rolled `--allow-tool='shell(git:*),...'` strings on every call. Profiles compose with
+discovered `.agent.md` frontmatter into a single "agent manifest" object that feeds three
+surfaces: (a) tool description for the LLM, (b) pre-spawn validation that catches
+typos/conflicts before subprocess cost, (c) a `/copilot-agents` picker in TUI.
+
+**Why this survives**: research doc §10 prescribes per-pattern permission tuples; today every
+caller hand-rolls them. Profiles + manifest are the canonical reusable form. Compounds with
+S1's modal (manifest data → picker UX) and S4 below (manifest → tool registration).
+
+**Rejected alternatives folded in**: F2.6 permission profiles, F4.4 manifest fusion.
+
+---
+
+### S4. Per-agent tool registration
+
+At plugin load, discover all available Copilot agents (user `~/.copilot/agents/`, repo
+`.github/agents/`, plugin-installed `~/.copilot/installed-plugins/*/agents/`) and register
+each as a distinct OpenCode tool — `copilot_code_review`, `copilot_security_audit`, etc. —
+each with a description derived from the agent's frontmatter. The generic `copilot_delegate`
+remains as a fallback escape hatch.
+
+**Why this survives**: makes Copilot agents first-class tools the LLM can pick by intent
+rather than by passing an `agent` string. Pairs tightly with S3 (manifest → tool description).
+Also fixes the latent bug surfaced this session: the plugin's hardcoded `BUILTIN_AGENTS` list
+(`['default','explore','task','general-purpose','code-review','research']`) is wrong — Copilot
+CLI v1.0.36 ships zero built-ins. Per-agent discovery + registration replaces that list with
+empirical truth.
+
+**Risks for brainstorm**: dynamic tool registration may need an OpenCode plugin API surface
+the project hasn't validated yet; if registration is static-only, fall back to a single
+`copilot_delegate` with `agent` as an enum derived at load time.
+
+**Rejected alternatives folded in**: F3.4 agent-as-tool registry; closes KNOWN_ISSUE 1658.
+
+---
+
+### S5. Hung-task watchdog with lifetime timeout
+
+Subprocess lifetime cap (configurable, default e.g. 15 min) + heartbeat-based stale detection
+(no JSONL events for N seconds). On timeout: kill via existing `fkill(-pid)` path, set status
+`timed_out`, surface a plain-English reason via the same notification surface (toast + system
+reminder), and link the user to the offending task in `/copilot-status` (S1).
+
+**Why this survives**: this is the cleanest fix to a documented `KNOWN_ISSUE` ("No subprocess
+lifetime timeout — hung copilot stays 'running' forever; deferred to v1.x"). The "deferred to
+v1.x" framing was set before TUI visibility became the focus; once S1 ships, watchdog signals
+are first-class UI events rather than hidden state. Cheap to implement; pure quality
+investment.
+
+**Rejected alternatives folded in**: F1.2 watchdog standalone (now ties into S1's surface).
+
+---
+
+### S6. Transcript export + TUI replay
+
+On completion, optionally pass `--share=<path>` so Copilot writes the full session transcript
+to a known location. Add a `/copilot-replay <task_id>` command that renders the captured
+transcript via the same subagent-session viewer used by S1's live mode. Same renderer; live
+vs replay is the only difference.
+
+**Why this survives**: piggybacks on S1's renderer with no additional UI investment.
+Naturally answers the "what happened?" question after a delegation completes. Future-feeds
+the "knowledge-compounding loop" (every transcript → optional `ce:compound` entry); v0.2.x
+ships only the export + replay, not the loop.
+
+**Rejected alternatives folded in**: F4.6 transcript export, F3.7 transcript ingestion (the
+"inject as session messages" variant is more invasive; leave for v0.3+).
+
+---
+
+### S7. `/copilot-doctor` diagnostic command
+
+Single command that validates the local Copilot CLI environment the plugin assumes:
+
+- `copilot --version` matches the supported range (warn on drift; the JSONL parser is pinned
+  to 1.0.36's schema).
+- Auth token shape: detect classic `ghp_` PAT (silently rejected by Copilot) and warn with the
+  fix.
+- Agent discovery: list discovered agents and their sources; flag the BUILTIN_AGENTS regression
+  if v0.1 is still installed somewhere.
+- Active hooks: enumerate `~/.copilot/hooks/*` and `~/.copilot/settings.json:hooks` so users
+  know hooks will fire for every plugin-spawned subprocess.
+- JSONL contract sanity-check via a dry-run delegation that exercises the parser against
+  current Copilot CLI output.
+
+**Why this survives**: most of the silent failure modes documented in research doc §9 are
+environmental — auto-update breaks parsers, stale tokens, classic PATs, hook double-billing.
+A single command surfaces them before the user burns time. Compounds well: the LLM-facing tool
+description for `copilot_doctor` becomes a self-help surface for the assistant when delegations
+fail.
+
+**Rejected alternatives folded in**: F1.10 `/copilot-doctor`, F1.6 hook awareness, F1.5 secret
+risk preflight (rolled in as one diagnostic surface).
+
+## Rejected (with reason)
+
+Each rejection is one-line — preserved for future reconsideration.
+
+| Idea                                                          | Frame | Reason                                                                                                                                |
+| ------------------------------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Hook-based push to delete `copilot_output`** (F2.1, F2.4)   | F2    | Copilot user-level hooks fire for ALL spawned subprocesses, not just plugin-owned ones — wrong layer for a clean push API. Roll into S7's hook awareness instead. |
+| **OTel telemetry zero-instrumentation** (F4.10)               | F4    | Pre-mature for a 0.x plugin with no telemetry users. Comes free if S1's event bus ships; defer the OTel subscriber.                                                |
+| **Composable delegation pipelines / DAGs** (F3.3)             | F3    | Speculative; OpenCode itself orchestrates. Premature complexity.                                                                                                  |
+| **Bidirectional `--ask_user` relay** (F3.5)                   | F3    | Inverts the unattended-delegation value prop; introduces a deadlock-prone session-injection contract. Defer.                                                      |
+| **Plan-mode → OpenCode todos integration** (F3.9)             | F3    | Blurs the OpenCode-orchestrates / Copilot-delegates boundary. Niche.                                                                                              |
+| **Hook-driven auto-delegation on session events** (F3.10)     | F3    | Intrusive. Conflicts with explicit-invocation preference.                                                                                                          |
+| **Default-deny secrets + risk preflight** (F1.5, F2.9)        | F1/F2 | Documenting `--secret-env-vars` in README and forwarding the flag is enough; UI preflight is niche. Roll into S7.                                                  |
+| **Hook-awareness quarantine mode** (F1.6)                     | F1    | Hook-side-effects-on-spawn is a Copilot CLI design, not the plugin's job to "quarantine." Document; don't gate.                                                    |
+| **Non-interactive safety profile** (F1.8)                     | F1    | The plugin already passes `--no-ask-user --allow-all-tools`. Just naming the existing default.                                                                     |
+| **Auto-inferred `--add-dir` for workspace** (F2.7)            | F2    | Error-prone; sibling repos may pull in unrelated work, security boundary risk. Manual `--add-dir` is fine.                                                         |
+| **Agent fs.watch caching** (F2.8)                             | F2    | Per-spawn discovery is fast (one readdir); fs.watch adds cleanup and rename/delete edge cases. Premature.                                                          |
+| **Parameterized prompt macros** (F2.10)                       | F2    | OpenCode itself can do template expansion in user-space; not the plugin's role.                                                                                    |
+| **Workspace continuity guard for resume** (F1.9)              | F1    | Folded into S2: `CopilotProcess.resume` re-applies the original `--add-dir` set automatically.                                                                     |
+
+## Cross-cutting note
+
+S1 ⇄ S2 ⇄ S5 form a tight bundle: ACP-mode delegations (S2) emit JSONL events through the
+event bus (S1), produce structured transitions the watchdog (S5) consumes for stale
+detection, and the modal (S1) renders all of it. Brainstorming any one of S1/S2/S5 should
+explicitly ask whether a unified design or independent designs better serve v0.2.x scope.
+
+S3 ⇄ S4 form another tight bundle: the agent manifest (S3) is the natural input to per-agent
+tool registration (S4). Brainstorm them together.
+
+S6 ⇄ S1 share a renderer; ship S1 first, then S6 trivially.
+
+S7 stands alone — pure quality investment, scoped tightly enough to ship in any v0.2.x
+release without coupling to the others.
+
+## Open threads (not survivors, worth a note)
+
+- **Knowledge-compounding loop** (S6 + `ce:compound`): every transcript optionally feeds the
+  project's institutional knowledge. Promising but premature; revisit when the
+  `docs/solutions/` corpus has 10+ entries and the cost/value of automated capture is
+  clearer.
+- **Cross-session delegation pool with file-based registry** (CC-1 deepened): once persistence
+  ships (S1), the question of "should multiple OpenCode sessions on one machine see the same
+  pool?" becomes answerable. Defer the design until we know what S1's persistence layer looks
+  like.
+- **`copilot_list_agents` tool** (KNOWN_ISSUE): superseded by S4 if per-agent registration
+  ships.
+
+## Recommended handoff
+
+Take **S1 (visibility platform)** into `ce:brainstorm` next.
+
+- It's the explicit user focus and the v0.2.x signature feature.
+- Its sub-bundle (event bus + persistent registry + slash-modal) is the largest open design
+  question — multiple viable shapes, real technical viability question (no OpenCode precedent).
+- S2 is the next-largest investment but its design space is more constrained (the strategy
+  pattern is well-understood); brainstorm it second.
+- S3, S4, S5, S7 are smaller-scope; can be picked up via `ce:work` directly without a separate
+  brainstorm step once the foundation is in place.

--- a/docs/research/copilot-cli-capabilities-2026-04-27.md
+++ b/docs/research/copilot-cli-capabilities-2026-04-27.md
@@ -7,6 +7,8 @@ task_id: cpl_2c867887-eed5-4048-98d2-69a4a8f2a731
 runtime_minutes: 5
 premium_requests: 7.5
 purpose: Seed ideation for opencode-copilot-delegate v0.2.x feature work.
+errata:
+  - "§9 'Prompts visible in ps': the suggested temp-file wrapper does not address argv leakage. Copilot CLI 1.0.36 has no documented stdin or @file prompt mode; treat that bullet as 'no known workaround in 1.0.36' until upstream exposes one."
 ---
 
 # Copilot CLI Capabilities — Programmatic Delegation Reference

--- a/docs/research/copilot-cli-capabilities-2026-04-27.md
+++ b/docs/research/copilot-cli-capabilities-2026-04-27.md
@@ -1,0 +1,323 @@
+---
+title: Copilot CLI Capabilities — Programmatic Delegation Reference
+date: 2026-04-27
+copilot_version: 1.0.36
+delegated_to: copilot_delegate (model=claude-opus-4.7)
+task_id: cpl_2c867887-eed5-4048-98d2-69a4a8f2a731
+runtime_minutes: 5
+premium_requests: 7.5
+purpose: Seed ideation for opencode-copilot-delegate v0.2.x feature work.
+---
+
+# Copilot CLI Capabilities — Programmatic Delegation Reference
+
+**Subject:** `@github/copilot` standalone CLI (NOT `gh copilot`)
+**Pinned version:** `GitHub Copilot CLI 1.0.36` (`copilot --version`)
+**Sources:** `copilot help`, `copilot help <topic>` (commands, config, environment, logging, monitoring, permissions, providers), public docs at `docs.github.com/en/copilot/reference/copilot-cli-reference/*`, inspection of `~/.copilot/`. Where help and docs disagree, **help output wins** and the divergence is called out.
+
+---
+
+## 1. Programmatic flags reference
+
+Grouped table of `-p`-relevant flags. Source key: **H** = `copilot help`, **HP** = `copilot help permissions`, **HE** = `copilot help environment`, **HC** = `copilot help config`, **D** = public docs.
+
+| Category | Flag | Notes / Source |
+|---|---|---|
+| Invocation | `-p, --prompt <text>` | Non-interactive run; exits on completion. **H** |
+| Invocation | `-i, --interactive <prompt>` | Interactive but seeded with prompt. **H** |
+| Invocation | `--continue` / `--resume[=id\|name\|prefix]` | Resume by id, task id, name (case-insensitive exact), or 7+ hex prefix. **H** |
+| Invocation | `--connect[=sessionId]` | Connect to a remote session/task. **H** |
+| Invocation | `-n, --name <name>` | Name new session; recoverable via `--resume=<name>`. **H** |
+| Invocation | `--mode <interactive\|plan\|autopilot>`, `--plan`, `--autopilot`, `--max-autopilot-continues <n>` | Initial mode. **H** |
+| Invocation | `--acp` | Run as Agent Client Protocol server (stdin/stdout). **H** |
+| Permissions | `--allow-all` / `--yolo` | Equivalent: `--allow-all-tools --allow-all-paths --allow-all-urls`. **HP** |
+| Permissions | `--allow-all-tools` (env `COPILOT_ALLOW_ALL=true`) | Required for `-p` non-interactive. **H/HP** |
+| Permissions | `--allow-tool[=tools...]` / `--deny-tool[=tools...]` | Pattern: `kind(arg)`; deny wins. Kinds: `shell`, `write`, `read`*, `url`, `memory`*, `<mcp-server>`. *`read`/`memory` only documented in **D**, not in `help permissions`. |
+| Permissions | `--available-tools[=tools...]` / `--excluded-tools[=tools...]` | Hard model-visibility filter (independent of allow/deny). **HP** |
+| Permissions | `--allow-all-paths` / `--add-dir <dir>` (repeatable) / `--disallow-temp-dir` | Path sandbox. CWD + temp default; `--add-dir` extends. **HP** |
+| Permissions | `--allow-all-urls` / `--allow-url[=urls...]` / `--deny-url[=urls...]` | Protocol-aware; deny wins. **HP** |
+| Permissions | `--no-ask-user` | Disable `ask_user` tool — required for fully unattended runs. **H** |
+| Permissions | `--secret-env-vars[=vars...]` | Strip vars from shell/MCP env and redact in output. `GITHUB_TOKEN` and `COPILOT_GITHUB_TOKEN` redacted by default. **H/D** |
+| Auth | `--config-dir <dir>` | Override `~/.copilot`. **H** |
+| Auth (env) | `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN` | First match wins; classic `ghp_` PATs **not supported**; v2 fine-grained PATs need `Copilot Requests` permission. `copilot login --help` |
+| Auth (env) | `COPILOT_GH_HOST` / `GH_HOST`, `--host` | GHE.com data residency. **HE** |
+| Models | `--model <name>` (env `COPILOT_MODEL`) | See §2 for full list. **H/HC** |
+| Models | `--effort, --reasoning-effort <low\|medium\|high\|xhigh>` | OpenAI/Anthropic reasoning models; settings key `effortLevel`. **H/D** |
+| Models | `--enable-reasoning-summaries` | Request reasoning summaries (OpenAI). **H** |
+| Models (BYOK) | `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_TYPE` (`openai`/`azure`/`anthropic`), `…_API_KEY`, `…_BEARER_TOKEN`, `…_WIRE_API` (`completions`/`responses`), `…_MODEL_ID`, `…_WIRE_MODEL`, `…_MAX_PROMPT_TOKENS`, `…_MAX_OUTPUT_TOKENS`, `COPILOT_OFFLINE` | `copilot help providers` |
+| Output | `--output-format <text\|json>` | `json` = JSONL (one obj/line). **H** |
+| Output | `-s, --silent` | Suppresses stats/decoration; agent reply only. Pair with `-p`. **H/D** |
+| Output | `--stream <on\|off>` | Streaming reply mode. **H** |
+| Output | `--no-color`, `--plain-diff` (env `PLAIN_DIFF=true`) | TTY/diff rendering. **H/HE** |
+| Sharing | `--share[=path]` | Markdown transcript after `-p`. Default `./copilot-session-<id>.md`. **H/D** |
+| Sharing | `--share-gist` | Secret gist after `-p`. **H/D** |
+| Agents | `--agent <name>` | Resolve from `.github/agents/<name>.agent.md` then `~/.copilot/agents/<name>.agent.md`. **H/D** — see §3. |
+| MCP | `--additional-mcp-config <json\|@file>` (repeatable) | Augments `~/.copilot/mcp-config.json` for this session. **H** |
+| MCP | `--disable-builtin-mcps` / `--disable-mcp-server <name>` | Currently the only built-in is `github-mcp-server`. **H** |
+| MCP (built-in github) | `--add-github-mcp-tool <tool>` (`*` = all), `--add-github-mcp-toolset <name>` (`all`), `--enable-all-github-mcp-tools` | Default exposes only a CLI subset; these expand it. The `*`/`all` flags **override** the toolset/tool flags. **H** |
+| Plugins | `--plugin-dir <dir>` (repeatable) | Load plugin from local dir. **H** |
+| Lifecycle | `--no-custom-instructions` | Disable AGENTS.md / `copilot-instructions.md` loading. **H** |
+| Lifecycle | `--bash-env` / `--no-bash-env` | Persists to settings. **H/HC** |
+| Lifecycle | `--remote` / `--no-remote` | Allow GitHub web/mobile to drive the session. **H** |
+| Lifecycle | `--log-dir <dir>`, `--log-level <none\|error\|warning\|info\|debug\|all\|default>` | **H/HL** |
+| Lifecycle | `--experimental` / `--no-experimental` | Toggles experimental features. **H** |
+| Lifecycle | `--no-auto-update` (env `COPILOT_AUTO_UPDATE=false`) | Auto-disabled in CI (`CI`, `BUILD_NUMBER`, `RUN_ID`, `SYSTEM_COLLECTIONURI`). **H/HE** |
+
+**Help vs docs divergence:** docs list `read` and `memory` as `--allow-tool` kinds; `copilot help permissions` does not. Treat help as authoritative for syntax (`shell`, `write`, `url`, `<mcp>`); use docs as a hint that `read` and `memory` may be accepted in 1.0.36 but are undocumented in CLI help.
+
+---
+
+## 2. Models — namespace, selection, tradeoffs
+
+Model strings the CLI accepts (verbatim from `copilot help config` under `model`):
+
+```
+claude-sonnet-4.6        claude-sonnet-4.5         claude-haiku-4.5
+claude-opus-4.7          claude-opus-4.6           claude-opus-4.6-fast
+claude-opus-4.5          claude-sonnet-4
+gpt-5.4                  gpt-5.5                   gpt-5.3-codex
+gpt-5.2-codex            gpt-5.2                   gpt-5.1
+gpt-5.4-mini             gpt-5-mini                gpt-4.1
+```
+
+These are bare names — **not** the `github-copilot/<model>` namespace OpenCode uses for its own provider. Pass directly to `--model`.
+
+**Cost / latency / quality bands (qualitative, derived from family names — not from a published rate card):**
+
+| Tier | Models | Use for |
+|---|---|---|
+| Fast/cheap | `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini`, `gpt-4.1` | Summaries, code explanation, doc generation, classifications, single-file edits |
+| Standard | `claude-sonnet-4`, `claude-sonnet-4.5`, `claude-sonnet-4.6`, `gpt-5.1`, `gpt-5.2`, `gpt-5.4` | General delegation default |
+| Codex specialist | `gpt-5.2-codex`, `gpt-5.3-codex` | Multi-file refactors, debugging, race-condition hunting (per docs example) |
+| Premium reasoning | `claude-opus-4.5/4.6/4.6-fast/4.7`, `gpt-5.5` | Architecture decisions, deep research, cross-repo migrations |
+
+**`--effort` levels** (`low`/`medium`/`high`/`xhigh`, default `medium` via `effortLevel`): apply to extended-thinking models. Empirically the GPT-5 series and the Claude Opus / Sonnet 4.x reasoning variants honor it; lower-end models (`gpt-4.1`, mini variants, haiku) ignore it. `--enable-reasoning-summaries` is OpenAI-only per help text.
+
+**Precedence (docs):** custom-agent `model` > `--model` > `COPILOT_MODEL` > `settings.json:model` > CLI default.
+
+---
+
+## 3. Custom agents (`~/.copilot/agents/<name>.agent.md`)
+
+**File format** (`*.agent.md`, YAML frontmatter + Markdown body, body ≤30,000 chars):
+
+```markdown
+---
+name: security-auditor
+description: Security review specialist. Triggers on "seccheck" or audit requests.
+tools: ['read', 'search', 'shell', 'github/create_issue']   # omit = all tools; [] = none
+model: claude-opus-4.7                                      # optional override
+mcp-servers:
+  custom-mcp:
+    type: local
+    command: my-mcp
+    args: ['--flag']
+    tools: ['*']
+    env:
+      API_KEY: ${{ secrets.MY_KEY }}
+---
+You are a security auditor. Identify exposed secrets, XSS, SQLi,
+vulnerable deps, and auth bypasses. For each finding, file a single
+GitHub issue with risk level and recommended fix.
+```
+
+**Tool aliases** accepted in `tools:` (case-insensitive): `execute`/`shell`/`Bash`/`powershell`, `read`/`Read`/`NotebookRead`, `edit`/`Edit`/`MultiEdit`/`Write`/`NotebookEdit`, `search`/`Grep`/`Glob`, `agent`/`Task`, `web`/`WebSearch`/`WebFetch`, `todo`/`TodoWrite`. MCP tools are `<server>/<tool>` or `<server>/*`. Unknown names are silently ignored.
+
+**Precedence** (per docs): repo `.github/agents/<name>.agent.md` > user `~/.copilot/agents/<name>.agent.md`. (Note: docs say repo wins; the create-agent UI text reverses this — "the one in your home directory will be used, rather than the one in the repository." Help text does not adjudicate. Treat repo-wins as the documented contract; treat user-wins as a possible 1.0.36 quirk and verify before relying on it.)
+
+**Built-in agents accepted by `copilot --agent <name>`:** based on the docs ("This requires that a custom agent has been created with this name"), the `/agent` UI text ("if any"), and the user-reported rejection of `research`, **the CLI ships with no built-in agents**. Every name passed to `--agent` must resolve to a file. The plugin's current `BUILTIN_AGENTS = ['default','explore','task','general-purpose','code-review','research']` is **incorrect and stale** — these are conventions from VS Code Copilot Chat / OpenCode, not Copilot CLI. The fix: discover agents purely from `~/.copilot/agents/` + repo `.github/agents/` + plugin-installed agents (`copilot plugin install` deposits to `~/.copilot/installed-plugins/.../agents/`), and treat `--agent` without a discovered file as an error rather than offering a built-in fallback.
+
+---
+
+## 4. Hooks / lifecycle events
+
+Hooks **do exist**. Two surfaces:
+
+1. **`~/.copilot/hooks/`** (user-level scripts) and **`.github/hooks/<name>.json`** (repo-level, loaded from CWD for the CLI), schema:
+   ```json
+   {
+     "version": 1,
+     "hooks": {
+       "sessionStart": [...], "sessionEnd": [...],
+       "userPromptSubmitted": [...],
+       "preToolUse": [...], "postToolUse": [...],
+       "errorOccurred": [...]
+     }
+   }
+   ```
+   Each entry: `{ "type": "command", "bash": "...", "powershell": "...", "cwd": ".", "timeoutSec": 10, "env": {...} }`. Hooks receive a JSON event on stdin (e.g. `{"timestamp":...,"cwd":...,"toolName":...,"toolArgs":"..."}`).
+
+2. **Inline** under `hooks` key in `~/.copilot/settings.json` (user) or `.github/copilot/settings.json` (repo). Same schema. `disableAllHooks: true` kills both.
+
+**Event names available today (1.0.36):** `sessionStart`, `sessionEnd`, `userPromptSubmitted`, `preToolUse`, `postToolUse`, `errorOccurred`. Default per-hook timeout 30s.
+
+For the plugin: hooks are a viable injection point for telemetry/audit on every spawned `copilot` subprocess without modifying the prompt.
+
+---
+
+## 5. MCP integration
+
+**Config sources, in precedence order (per `copilot mcp --help`):** workspace `.mcp.json` > user `~/.copilot/mcp-config.json` > plugin-bundled. `--additional-mcp-config <json|@path>` augments for one session. Disable: `--disable-mcp-server <name>` or `--disable-builtin-mcps`. Settings keys `disabledMcpServers: []` and `enabledMcpServers: []` (the latter to opt into off-by-default built-ins like `computer-use`).
+
+**Transports:** `stdio` (default), `http`, `sse` (`copilot mcp add --transport`).
+**Env passthrough:** `--env KEY=VAL` (repeatable) on `mcp add`; values can be `${{ secrets.NAME }}` in YAML/JSON config; `--secret-env-vars` strips them from MCP child env.
+**Headers (HTTP/SSE):** `--header "K: V"` repeatable; `--timeout <ms>`; `--tools "*"|csv|""`.
+
+**Tool naming for `--allow-tool`/`--deny-tool`:** `<server-name>(<tool-name>?)`. Examples: `github(create_issue)`, `notion`. The bundled `github-mcp-server` is the only built-in MCP. Toolset granularity controlled by:
+- `--add-github-mcp-tool <name>` (repeatable; `*` for all)
+- `--add-github-mcp-toolset <toolset>` (repeatable; `all` for all)
+- `--enable-all-github-mcp-tools` (overrides the two above)
+
+Default exposed surface is a curated CLI subset; opt-in beyond it.
+
+---
+
+## 6. Multi-repo / `--add-dir`
+
+**Default sandbox:** CWD + all subdirectories + system tempdir (the latter removable with `--disallow-temp-dir`). Anything outside (sibling repos, `~/Documents`, `/etc`, etc.) is denied without a flag.
+
+**Expansion ladder:**
+1. `--add-dir <abs-path>` (repeatable) — surgical; whitelist exact roots. Preferred for cross-repo work.
+2. `--allow-all-paths` — disable verification entirely. Required when paths are unknown ahead of time.
+3. `--allow-all` / `--yolo` — superset (also enables tools and URLs).
+
+**Cross-repo patterns:**
+- *Coordinated dependency bump across N repos:*
+  ```bash
+  copilot -p "Bump @scope/lib to 2.0 in package.json, run codemods, update tests" \
+    --add-dir /repos/web --add-dir /repos/api --add-dir /repos/shared \
+    --allow-all-tools --no-ask-user -s --output-format json
+  ```
+- *Extract shared utility into a sibling library:* `--add-dir` source repo + target repo + monorepo root; pin `--model gpt-5.3-codex`.
+
+---
+
+## 7. Output formats and parsing
+
+| Mode | Stdout | Best for |
+|---|---|---|
+| Default text | Pretty-rendered turns + stats footer + ANSI | Human use only |
+| `-s, --silent` | Final assistant reply only, no stats | Quick scripting (`var=$(copilot -p '…' -s)`) |
+| `--output-format json` | **JSONL** — one JSON object per line | Programmatic consumption (the plugin's path) |
+
+**JSONL event schema** (observed in `~/.copilot/session-state/<id>/events.jsonl`; same shape exits to stdout under `--output-format json`):
+
+```json
+{"type":"session.start","data":{"sessionId":"…","version":1,"producer":"copilot-agent","copilotVersion":"1.0.36","startTime":"…","context":{"cwd":"…"},"alreadyInUse":false,"remoteSteerable":false},"id":"…","timestamp":"…","parentId":null}
+{"type":"session.model_change","data":{"newModel":"gpt-5.4"}, …}
+{"type":"system.message","data":{"role":"system","content":"…"}, …}
+```
+
+Common envelope fields: `type`, `data`, `id` (uuid), `timestamp` (ISO-8601), `parentId` (null at root).
+
+**Event types observed / inferable:** `session.start`, `session.end`, `session.model_change`, `system.message`, `user.message`, `assistant.message` (turn deltas under streaming), `tool.call.start`, `tool.call.end`, `tool.permission_request`, `error`, `notification`. Plugin parser must tolerate unknown `type` values.
+
+**stderr** carries banners, warnings, auth prompts, update notices, and CLI errors — never JSONL events. Always merge with `2>&1` only when you don't care about clean separation; for the plugin keep them split so user-facing errors aren't mistaken for agent output.
+
+**Parent-agent implications:** track `tool.call.*` to render live status; pair `id` with `parentId` to reconstruct the call tree for OTel propagation; capture `session.start.data.sessionId` so the parent can later `--connect=<id>` or `--resume=<id>`.
+
+---
+
+## 8. Auth and CI patterns
+
+**Token precedence** (`copilot login --help`, `copilot help environment`): `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN` > stored OAuth credential (system keychain or `~/.copilot/`). Environment tokens take precedence over stored creds.
+
+**Accepted token types:** v2 fine-grained PATs with the **`Copilot Requests`** permission, OAuth tokens from the GitHub Copilot CLI app, and OAuth tokens from the `gh` CLI app. **Classic `ghp_` PATs are explicitly unsupported** and silently fail.
+
+**CI auto-detection** (suppresses auto-update): one of `CI`, `BUILD_NUMBER`, `RUN_ID`, `SYSTEM_COLLECTIONURI` set. Belt-and-braces: also pass `--no-auto-update` and set `COPILOT_AUTO_UPDATE=false`.
+
+**Common CI invocation:**
+```bash
+COPILOT_GITHUB_TOKEN="$FG_PAT" copilot \
+  -p "$PROMPT" --allow-all-tools --no-ask-user \
+  --output-format json -s --no-auto-update \
+  --secret-env-vars=COPILOT_GITHUB_TOKEN,NPM_TOKEN
+```
+
+**GHE.com data residency:** set `COPILOT_GH_HOST=mycompany.ghe.com` (or `--host` to `copilot login`).
+
+**Pinning:** install via `npm i -g @github/copilot@1.0.36` (or mise `npm-github-copilot@1.0.36`) and disable auto-update so a transparent upgrade can't break the parent agent's parser.
+
+---
+
+## 9. Common pitfalls — silent failure modes
+
+- **`-p` without `--allow-all-tools`** → CLI hangs on the first tool permission prompt forever (no TTY = no answer). Always pair them, or use `--allow-tool` for a tight allowlist.
+- **Forgetting `--no-ask-user`** → if the agent decides it needs clarification, it invokes `ask_user` and stalls. Required for true unattended runs.
+- **No `-s` under `--output-format text`** → the trailing stats banner gets piped into your downstream parser as garbage.
+- **Mixing `--output-format json` with `-s`** → `-s` doesn't break JSONL, but `--no-color` is still useful; without it some events embed ANSI in `data.content`.
+- **Stale `GH_TOKEN` from `gh auth login`** → `COPILOT_GITHUB_TOKEN` not set means a stale `GH_TOKEN` wins silently. Plugin should explicitly set `COPILOT_GITHUB_TOKEN` (or unset others) for predictability.
+- **Classic `ghp_` PAT** → rejected with a generic auth error that doesn't mention the token-type restriction.
+- **Working dir outside `--add-dir` set** → file edits fail with "path not allowed" but the agent often retries the same path 3+ times before giving up, burning tokens.
+- **Auto-update mid-CI** → outside CI sentinels (custom CI?), `copilot` may download an update on first run; use `--no-auto-update`.
+- **`--allow-tool='shell'` (no parens)** → matches *all* shell. To restrict you need `shell(git:*)` etc. Accidentally permissive.
+- **Deny rules silently overridden by nothing** — deny always wins; if a tool seems blocked despite `--allow-all-tools`, check for an inherited `--deny-tool` from settings/agent file.
+- **`--agent <name>` typo** → exits with an error ("agent not found") rather than falling back to default. There are no built-in agent names to fall back to (see §3).
+- **`--add-github-mcp-toolset all` overridden by `--enable-all-github-mcp-tools`** — last-flag-wins is **not** the rule; `--enable-all-github-mcp-tools` overrides per `copilot help`. Easy to misconfigure.
+- **Secrets in transcripts** — `--share`/`--share-gist` may export prompts and tool output verbatim; pair with `--secret-env-vars` and assume nothing.
+- **Prompts visible in `ps`** — `copilot -p "<text>"` puts the prompt in argv. Pipe via stdin where possible (when supported) or use a wrapper that writes to a temp file and references it.
+- **`parentId: null` for root events** — if your parser assumes a string, it crashes on the very first event.
+
+---
+
+## 10. Delegation playbook — patterns for `copilot_delegate`
+
+Pattern matrix, each tuned for spawning from inside another agent (e.g. OpenCode primary):
+
+### 10.1 Sandboxed targeted refactor
+*When:* primary agent identified the change but wants isolation. *Prompt:* "Refactor `src/foo.ts::bar` to take a Result type; update call sites and tests; do not touch unrelated files."
+*Settings:* `--model gpt-5.3-codex --add-dir <repo> --allow-tool='shell(git:*),shell(npm test),write,read' --no-ask-user --output-format json -s`. *Runtime:* 1–4 min. *Consume:* tail JSONL for `assistant.message` final + `git diff`.
+
+### 10.2 Parallel test fixing
+*When:* primary is implementing feature A; tests in module B are red. Delegate B-fix in parallel.
+*Settings:* `--model gpt-5.2 --add-dir <repo> --allow-tool='shell(npm:*),shell(jest),write,read' --no-ask-user`. *Runtime:* 2–10 min. *Consume:* poll via `copilot_output`; merge result branch.
+
+### 10.3 Multi-repo coordinated change
+*When:* shared lib bump across services. *Settings:* repeated `--add-dir`; `--model gpt-5.3-codex`; allow `shell(git:*)`, `shell(pnpm:*)`. *Cost:* high — premium model, broad scope. *Consume:* per-repo summary blocks in final assistant turn.
+
+### 10.4 Diff code review
+*Prompt:* "Review the diff between `origin/main` and HEAD; surface only correctness, security, and concurrency issues; ignore style." *Settings:* `--agent code-review` if a custom agent exists, else `--model claude-opus-4.7 --effort high --allow-tool='shell(git diff),shell(git log),read'`. *Runtime:* 30–120 s. *Consume:* a single markdown report; no writes expected — set no `write` permission as a hard guard.
+
+### 10.5 Doc generation from a module
+*Prompt:* "Write a TSDoc-style overview of `src/runtime/`; include public surface table." *Settings:* `--model claude-haiku-4.5 --allow-tool='read,search,write(docs/runtime.md)' --no-ask-user -s`. *Runtime:* 20–60 s, low cost. *Consume:* the new file; primary agent can lint it.
+
+### 10.6 Dependency / supply-chain audit
+*Prompt:* "Audit `package.json` and `bun.lock` for advisories; cross-check via `gh api` and OSV." *Settings:* `--model gpt-5.4 --allow-tool='shell(npm audit),shell(bun:*),shell(gh api),url(api.github.com),url(api.osv.dev),read'`. Allow built-in github MCP for issue creation: `--add-github-mcp-tool create_issue`. *Runtime:* 1–3 min.
+
+### 10.7 Migration / codemod authoring
+*Prompt:* "Generate a jscodeshift transform that replaces `useState<T|null>(null)` with a custom `useNullable<T>` hook; include tests." *Settings:* `--model gpt-5.3-codex --effort high --add-dir <repo> --allow-tool='write,read,shell(node),shell(npx jscodeshift)'`. *Consume:* the transform script; primary applies it on demand.
+
+### 10.8 Custom-agent specialist workflow
+*When:* repo defines `.github/agents/security-auditor.agent.md`. *Settings:* `--agent security-auditor --add-dir <repo> --allow-tool='read,github(create_issue)' --deny-tool='write'`. *Consume:* GitHub issue URLs scraped from final turn.
+
+### 10.9 Long-running codebase indexing
+*When:* primary needs a structured map of an unfamiliar large repo and shouldn't block.
+*Prompt:* "Produce `docs/architecture/index.md` describing every package, public symbol, and inter-module dependency." *Settings:* `--model claude-sonnet-4.6 --add-dir <repo> --allow-tool='read,search,write(docs/architecture/*)'`. Spawn detached; primary polls with `copilot_output`. *Runtime:* 5–30 min.
+
+### 10.10 Plan-only delegation (no edits)
+*When:* primary wants a second opinion before acting. *Settings:* `--mode plan --model claude-opus-4.7 --effort xhigh --allow-tool='read,search,shell(git log),shell(git status)' --deny-tool='write'`. Returns plan markdown; primary executes.
+
+### 10.11 ACP-mediated long session
+*When:* multi-turn delegation where primary wants to feed follow-up prompts. Spawn `copilot --acp …` and speak Agent Client Protocol over stdio rather than relaunching `copilot -p` per turn. Lower cold-start cost; preserves context window across turns.
+
+### 10.12 Resume / fork pattern
+*When:* prior `cpl_*` task was promising but interrupted. New delegation with `--resume=<sessionId>` + new prompt. Or `--connect=<sessionId>` to attach to a still-running task elsewhere. Useful for "continue what failed CI started."
+
+---
+
+## 11. Limitations and gotchas the plugin should document
+
+- **Prompts leak via `ps`.** `copilot -p "<prompt>"` exposes the full prompt to anyone with `ps -ef` on the host. Structurally upstream; plugin should warn in the README and consider an stdin-prompt mode if/when Copilot CLI exposes one.
+- **Transcripts may leak secrets.** `--share`, `--share-gist`, and the on-disk `~/.copilot/session-state/<id>/events.jsonl` capture tool output verbatim, including env values not listed in `--secret-env-vars`. Document a default-deny posture and pre-populate `--secret-env-vars` with common names.
+- **Auto-update can break the JSONL parser.** The schema is stable in 1.0.36 but the CLI auto-updates outside CI. Plugin should default `--no-auto-update` and pin via mise/nvm.
+- **No built-in agents.** Plugin's `BUILTIN_AGENTS` list is wrong — `default`, `explore`, `task`, `general-purpose`, `code-review`, `research` are not shipped with `@github/copilot`. Discover only from `~/.copilot/agents/`, `.github/agents/`, and `~/.copilot/installed-plugins/*/agents/`.
+- **Agent precedence ambiguity.** Docs say repo > user; the in-CLI agent-creator UI text says user > repo. Verify by experiment; for now, when both exist, log a warning and let the CLI decide (do not pre-resolve in plugin).
+- **`--allow-tool=read` and `--allow-tool=memory`** are documented but not in `copilot help permissions`. Treat as best-effort; fall back to `--available-tools`/`--excluded-tools` for hard guarantees.
+- **Hooks fire for the spawned subprocess.** User-level hooks in `~/.copilot/hooks/` and inline `settings.json:hooks` will execute on every plugin-spawned session. Plugin should document this so users don't double-bill telemetry or trigger infinite loops.
+- **Path sandbox is process-local.** `--add-dir` only affects the current invocation. Cross-session resume (`--resume`) does **not** persist `--add-dir`; re-pass it.
+- **Tokens of type `ghp_` are silently rejected.** Plugin should detect and emit a clear `{ error: "Classic PAT not supported; use a fine-grained PAT with Copilot Requests permission." }`.
+- **stderr is not JSONL.** Update notices, banners, and auth prompts are stderr-only. Plugin should pipe stderr to logs separately, never merge with stdout.
+- **`--enable-all-github-mcp-tools` overrides `--add-github-mcp-toolset` / `--add-github-mcp-tool`.** Validate flag combinations before spawning; warn the caller.
+- **`--no-ask-user` is the only safety against blocked sessions.** Even with `--allow-all-tools`, if the agent issues `ask_user` (e.g. ambiguous prompt), the subprocess will deadlock. Plugin should always pass `--no-ask-user` for `copilot_delegate` and document that user-question-style prompts will fail.
+- **Working directory is inherited** (no `--cwd` flag). Plugin must `chdir`/`spawn({cwd})` to control where the agent operates; otherwise `--add-dir`-less invocations sandbox to wherever the parent OpenCode happened to be.
+- **`--connect`/`--remote` reachability.** Sessions started with `--remote` are steerable from GitHub web/mobile; the plugin's spawn defaults should set `--no-remote` unless the user explicitly opts in, to avoid third-party control of in-flight delegations.


### PR DESCRIPTION
Two related v0.2.x prep documents:

**`docs/research/copilot-cli-capabilities-2026-04-27.md`** — comprehensive Copilot CLI v1.0.36 reference for programmatic delegation. 11 sections: flag table, model strings, custom-agent format, hooks (`sessionStart`/`sessionEnd`/`preToolUse`/`postToolUse`/`userPromptSubmitted`/`errorOccurred`), MCP integration, multi-repo `--add-dir`, JSONL event schema, auth/CI patterns, silent failure modes, 12-pattern delegation playbook, plugin-level limitations.

Captured by self-delegating to `claude-opus-4.7` via `copilot_delegate` (5m19s, 4076 events, 7.5 premium requests). First end-to-end exercise of the v0.1.0 plugin's full surface — spawn, JSONL parse, `--deny-tool` forwarding, `--model` override, system-reminder injection, output retrieval. All worked; serves as both a reference document and an empirical verification.

Two findings surfaced from the run:

1. Copilot CLI ships **zero** built-in agents (`copilot --agent research` returns `No such agent: research, available:`). The plugin's hardcoded `BUILTIN_AGENTS = ['default','explore','task','general-purpose','code-review','research']` is stale — those names are conventions from VS Code Copilot Chat / OpenCode, not the standalone CLI. Queued for v0.2.x.
2. The model namespace is a flat list, not the OpenCode `github-copilot/<model>` form. Bare names go to `--model` directly.

**`docs/ideation/2026-04-27-copilot-delegate-v0.2.md`** — `ce:ideate` output grounded in the v0.1.0 codebase + the new capabilities reference.

Method: 4 parallel sub-agents on default frames (pain/friction, inversion/automation, assumption-breaking, leverage/compounding) generated 40 raw candidates; merged + deduped to 22; adversarial critique kept 7 survivors with explicit rejection reasons for the rest.

Survivors:

| #   | Title                                             | Type         |
| --- | ------------------------------------------------- | ------------ |
| S1  | In-flight delegation visibility platform          | Bundle       |
| S2  | `CopilotProcess` abstraction (ACP/resume/connect) | Architecture |
| S3  | Permission profiles + agent manifest fusion       | Foundation   |
| S4  | Per-agent tool registration                       | UX           |
| S5  | Hung-task watchdog + lifetime timeout             | Quality      |
| S6  | Transcript export + TUI replay                    | UX           |
| S7  | `/copilot-doctor` diagnostic                      | Quality      |

Tight bundles: S1⇄S2⇄S5 (shared event flow), S3⇄S4 (manifest feeds tool registration). Recommended handoff: brainstorm S1 first.

Docs-only; no changeset.