### PR TITLE
fix(runtime): orphan subprocess reaper and cancel-race hardening

### DIFF
--- a/.changeset/runtime-hardening-orphan-reaper.md
+++ b/.changeset/runtime-hardening-orphan-reaper.md
@@ -1,0 +1,13 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Add an orphan subprocess reaper that runs at plugin init to clean up `copilot` subprocesses left behind when the plugin reloads or the OpenCode session exits unexpectedly.
+
+The reaper writes a per-instance PID file at `<XDG_STATE_HOME>/opencode-copilot-delegate/orphans/<plugin-pid>.pids` for every subprocess the plugin spawns and removes the entry on every terminal status transition (complete, failed, cancelled). On the next plugin init, the reaper scans the orphans directory, probes the owning plugin's liveness for each foreign file (`process.kill(<plugin-pid>, 0)`), reaps entries from files whose plugin has exited (and deletes those files), and skips entries from files whose plugin is still running.
+
+Identity gate is strict: each kill requires the live process's `comm` (kernel-tracked executable name from `ps -o comm=`) AND `lstart` (start-time string) to match values recorded at spawn time. Combined with the spawner-liveness probe, this prevents both PID-reuse-of-an-unrelated-process and cross-instance kill of a live foreign instance's children.
+
+Also fixes a parser cancel-race in the JSONL data handler — events buffered before the abort listener fired could previously be appended to `task.events` after `task.status` had been set to `cancelled`. The fix is a one-line `if (task.status !== 'running') break` guard at the top of the per-line loop, before `parseJsonlLine`.
+
+The new `setStatus` helper centralizes the three terminal status mutations in `subprocess.ts` (close event, abort listener, spawn error) along with the `removePidEntry` cleanup hook. It is idempotent on terminal state — once `task.status` is terminal, subsequent `setStatus` calls with another terminal value no-op, preserving the existing `finalizeTask` `if (task.status !== 'cancelled')` invariant automatically.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Task state is in-memory inside a single OpenCode process. Calling `copilot_outpu
 
 ## Known Limitations (v0.1.x)
 
-- **Orphaned subprocesses:** If OpenCode crashes mid-delegation, the `copilot` subprocess becomes orphaned. A PID-file reaper is planned for v1.x.
+- **Orphaned subprocesses (mitigated since v0.2.0):** If OpenCode crashes mid-delegation, the `copilot` subprocess becomes orphaned. A PID-file reaper now scans `<XDG_STATE_HOME>/opencode-copilot-delegate/orphans/` at every plugin init, probes the owning plugin's liveness, and reaps subprocesses whose plugin has exited. A strict identity gate (kernel-tracked `comm` + start time) prevents PID-reuse misfires.
 - **Prompt visibility in `ps`:** The `copilot` CLI accepts the prompt as a command-line argument, which means the full prompt text appears in `ps` output for any user on the host. This is an upstream Copilot CLI behavior. Avoid delegating prompts that contain secrets or PII; pass sensitive material via files, env vars, or `--secret-env-vars` instead.
 - **No subprocess lifetime cap:** A hung `copilot` subprocess stays in the registry as `running` indefinitely. Cancel manually via `copilot_cancel`. A configurable timeout is planned for v1.x.
 

--- a/docs/plans/2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md
+++ b/docs/plans/2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md
@@ -118,7 +118,7 @@ tests/
 
 ## Implementation Units
 
-- [ ] **Unit 1: PID-file helpers (`pid-file.ts`)**
+- [x] **Unit 1: PID-file helpers (`pid-file.ts`)**
 
 **Goal:** Atomic append + remove for the PID file.
 
@@ -155,7 +155,7 @@ tests/
 
 ---
 
-- [ ] **Unit 2: Orphan reaper (`orphan-reaper.ts`)**
+- [x] **Unit 2: Orphan reaper (`orphan-reaper.ts`)**
 
 **Goal:** Read the PID file at init time, reap survivors with PID-validate-before-kill.
 
@@ -215,7 +215,7 @@ tests/
 
 ---
 
-- [ ] **Unit 3: `setStatus` helper + wire pid-file hooks into spawn + plugin-init reap**
+- [x] **Unit 3: `setStatus` helper + wire pid-file hooks into spawn + plugin-init reap**
 
 **Goal:** Append on task spawn. Centralize the 3 inline status mutations through a new `setStatus` helper that also calls `removePidEntry`. Build the per-instance pid file path in `src/index.ts` and `await reapOrphans()` before returning Hooks.
 
@@ -279,7 +279,7 @@ tests/
 
 ---
 
-- [ ] **Unit 4: Parser cancel-race guard**
+- [x] **Unit 4: Parser cancel-race guard**
 
 **Goal:** Single-line guard at the top of the inline JSONL data handler in `spawnCopilot`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,12 @@ const CopilotDelegate: Plugin = async ({ client, directory }) => {
 
   const currentInstancePath = resolveInstancePidFilePath()
   const pidFileDir = dirname(currentInstancePath)
-  await mkdir(pidFileDir, { recursive: true, mode: 0o700 })
   try {
+    // mkdir is inside the try/catch so plugin init survives read-only
+    // filesystems (EROFS) or permission-denied state dirs (EACCES). Both
+    // failure modes degrade gracefully: reapOrphans's own readdir guard
+    // returns an empty result when the directory cannot be enumerated.
+    await mkdir(pidFileDir, { recursive: true, mode: 0o700 })
     await reapOrphans({
       pidFileDir,
       currentInstancePath,
@@ -40,7 +44,7 @@ const CopilotDelegate: Plugin = async ({ client, directory }) => {
       getPidStartTime,
     })
   } catch {
-    // Reap failure must not block plugin init.
+    // mkdir or reap failure must not block plugin init.
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
 import type { Plugin } from '@opencode-ai/plugin'
 import { discoverAgents } from './discovery/agents'
 import { buildDescription } from './discovery/description'
+import { killProcessTree } from './lib/kill-tree'
+import {
+  getPidComm,
+  getPidStartTime,
+  reapOrphans,
+} from './runtime/orphan-reaper'
+import { resolveInstancePidFilePath } from './runtime/pid-file'
 import { createCancelTool } from './tools/cancel'
 import { createDelegateTool } from './tools/delegate'
 import { createOutputTool } from './tools/output'
@@ -19,12 +28,28 @@ const CopilotDelegate: Plugin = async ({ client, directory }) => {
   const agents = discoverAgents(getAgentsDirectories(directory))
   const delegateDescription = buildDescription(agents)
 
+  const currentInstancePath = resolveInstancePidFilePath()
+  const pidFileDir = dirname(currentInstancePath)
+  await mkdir(pidFileDir, { recursive: true, mode: 0o700 })
+  try {
+    await reapOrphans({
+      pidFileDir,
+      currentInstancePath,
+      killProcessTree,
+      getPidComm,
+      getPidStartTime,
+    })
+  } catch {
+    // Reap failure must not block plugin init.
+  }
+
   return {
     tool: {
       copilot_delegate: createDelegateTool({
         client,
         description: delegateDescription,
         directory,
+        pidFilePath: currentInstancePath,
       }),
       copilot_output: createOutputTool(),
       copilot_cancel: createCancelTool(),

--- a/src/lib/errno.ts
+++ b/src/lib/errno.ts
@@ -1,0 +1,11 @@
+/**
+ * Type predicate that narrows `unknown` to `NodeJS.ErrnoException` for safe
+ * `.code` access on errors thrown by `node:fs` and similar Node APIs.
+ *
+ * Use this in catch blocks instead of casting `e as NodeJS.ErrnoException`
+ * — the cast is unsafe when the thrown value is a string, plain object, or
+ * any non-Error type.
+ */
+export function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
+  return e instanceof Error && 'code' in e
+}

--- a/src/lib/kill-tree.ts
+++ b/src/lib/kill-tree.ts
@@ -1,7 +1,15 @@
 import fkill from 'fkill'
 
 export async function killProcessTree(pid: number): Promise<void> {
-  if (!Number.isFinite(pid) || pid <= 0) {
+  // Refuse pid <= 1: pid 0 means "caller's process group" and pid 1 is init.
+  // Critically, fkill(-1) on Linux signals every process the caller has
+  // permission to send to (POSIX semantics for kill(-1, sig)) — in a
+  // container that is the entire container. The same concern applies if a
+  // copilot subprocess legitimately runs as PID 1 (container entrypoint):
+  // the orphan reaper's identity gate could pass and fkill(-1, ...) would
+  // tear down the container. Treat PID 1 as unmanageable rather than risk
+  // catastrophic blast radius.
+  if (!Number.isFinite(pid) || pid <= 1) {
     return
   }
 

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { basename, extname, join } from 'node:path'
+import { isErrnoException } from '../lib/errno'
 
 export interface ReapDeps {
   killProcessTree: (pid: number) => Promise<void>
@@ -21,8 +22,7 @@ export function defaultIsPluginAlive(pid: number): boolean {
     process.kill(pid, 0)
     return true
   } catch (e) {
-    const code = (e as NodeJS.ErrnoException).code
-    return code === 'EPERM'
+    return isErrnoException(e) && e.code === 'EPERM'
   }
 }
 
@@ -75,8 +75,11 @@ interface PidEntry {
 function parseLine(line: string): PidEntry | null {
   const parts = line.split('\t')
   if (parts.length !== 3) return null
-  const pid = parseInt(parts[0], 10)
-  if (Number.isNaN(pid)) return null
+  const pidStr = parts[0]
+  // Strict integer parse: rejects negative, zero, decimal, and partial parses
+  // like '1234abc' that parseInt would silently accept.
+  if (!/^[1-9]\d*$/.test(pidStr)) return null
+  const pid = Number(pidStr)
   return { pid, comm: parts[1], lstart: parts[2] }
 }
 
@@ -242,12 +245,14 @@ export async function reapOrphans(opts: {
     if (!file.endsWith('.pids')) continue
 
     const filePath = join(pidFileDir, file)
-    const filePid = parseInt(basename(file, extname(file)), 10)
-
-    if (Number.isNaN(filePid)) {
+    const stem = basename(file, extname(file))
+    // Strict integer parse: filename stem must be a positive integer; reject
+    // negative, zero, decimal, and partial-parse oddities like '1234abc'.
+    if (!/^[1-9]\d*$/.test(stem)) {
       console.warn(`[orphan-reaper] Skipping non-numeric PID file: ${file}`)
       continue
     }
+    const filePid = Number(stem)
 
     const outcome = await reapOneFile(
       filePath,

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -40,6 +40,10 @@ function psField(pid: number, field: string): Promise<string | null> {
     child.stdout?.on('data', (chunk: Buffer) => {
       stdout += chunk.toString('utf-8')
     })
+    // Drain stderr so the OS pipe buffer never fills under backpressure.
+    // An unread stderr pipe on a long-running or backlogged ps invocation
+    // can stall the subprocess, blocking plugin init.
+    child.stderr?.resume()
 
     child.on('close', (code) => {
       clearTimeout(timeout)

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -1,0 +1,221 @@
+import { spawn } from 'node:child_process'
+import { readdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import { basename, extname, join } from 'node:path'
+
+export interface ReapDeps {
+  killProcessTree: (pid: number) => Promise<void>
+  getPidComm: (pid: number) => Promise<string | null>
+  getPidStartTime: (pid: number) => Promise<string | null>
+  isPluginAlive: (pid: number) => boolean
+}
+
+export interface ReapResult {
+  reaped: number
+  skipped: number
+  scannedFiles: number
+  deletedFiles: number
+}
+
+export function defaultIsPluginAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code
+    return code === 'EPERM'
+  }
+}
+
+function psField(pid: number, field: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+    let stdout = ''
+    let timedOut = false
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+    }, 1000)
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf-8')
+    })
+
+    child.on('close', (code) => {
+      clearTimeout(timeout)
+      if (timedOut || code !== 0) {
+        resolve(null)
+      } else {
+        const trimmed = stdout.trim()
+        resolve(trimmed || null)
+      }
+    })
+
+    child.on('error', () => {
+      clearTimeout(timeout)
+      resolve(null)
+    })
+  })
+}
+
+export async function getPidComm(pid: number): Promise<string | null> {
+  return psField(pid, 'comm')
+}
+
+export async function getPidStartTime(pid: number): Promise<string | null> {
+  return psField(pid, 'lstart')
+}
+
+interface PidEntry {
+  pid: number
+  comm: string
+  lstart: string
+}
+
+function parseLine(line: string): PidEntry | null {
+  const parts = line.split('\t')
+  if (parts.length !== 3) return null
+  const pid = parseInt(parts[0], 10)
+  if (Number.isNaN(pid)) return null
+  return { pid, comm: parts[1], lstart: parts[2] }
+}
+
+async function processEntries(
+  entries: PidEntry[],
+  killProcessTree: ReapDeps['killProcessTree'],
+  getPidComm: ReapDeps['getPidComm'],
+  getPidStartTime: ReapDeps['getPidStartTime'],
+): Promise<{ reaped: number; skipped: number }> {
+  let reaped = 0
+  let skipped = 0
+
+  for (let i = 0; i < entries.length; i += 5) {
+    const chunk = entries.slice(i, i + 5)
+    const results = await Promise.all(
+      chunk.map(async (entry) => {
+        try {
+          process.kill(entry.pid, 0)
+        } catch {
+          return { reaped: false, skipped: true }
+        }
+
+        const [liveComm, liveLstart] = await Promise.all([
+          getPidComm(entry.pid),
+          getPidStartTime(entry.pid),
+        ])
+
+        if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+          return { reaped: false, skipped: true }
+        }
+
+        try {
+          await killProcessTree(entry.pid)
+          return { reaped: true, skipped: false }
+        } catch {
+          return { reaped: false, skipped: true }
+        }
+      }),
+    )
+
+    for (const r of results) {
+      if (r.reaped) reaped++
+      else if (r.skipped) skipped++
+    }
+  }
+
+  return { reaped, skipped }
+}
+
+export async function reapOrphans(opts: {
+  pidFileDir: string
+  currentInstancePath: string
+  killProcessTree: ReapDeps['killProcessTree']
+  getPidComm: ReapDeps['getPidComm']
+  getPidStartTime: ReapDeps['getPidStartTime']
+  isPluginAlive?: ReapDeps['isPluginAlive']
+}): Promise<ReapResult> {
+  const {
+    pidFileDir,
+    currentInstancePath,
+    killProcessTree,
+    getPidComm,
+    getPidStartTime,
+    isPluginAlive = defaultIsPluginAlive,
+  } = opts
+
+  let reaped = 0
+  let skipped = 0
+  let scannedFiles = 0
+  let deletedFiles = 0
+
+  let files: string[]
+  try {
+    files = await readdir(pidFileDir)
+  } catch {
+    return { reaped: 0, skipped: 0, scannedFiles: 0, deletedFiles: 0 }
+  }
+
+  const pidFiles = files.filter((f) => f.endsWith('.pids'))
+
+  for (const file of pidFiles) {
+    const filePath = join(pidFileDir, file)
+    const stem = basename(file, extname(file))
+    const filePid = parseInt(stem, 10)
+
+    if (Number.isNaN(filePid)) {
+      console.warn(`[orphan-reaper] Skipping non-numeric PID file: ${file}`)
+      continue
+    }
+
+    const isCurrent = filePid === process.pid
+
+    if (!isCurrent) {
+      if (isPluginAlive(filePid)) {
+        continue
+      }
+    }
+
+    scannedFiles++
+
+    let content: string
+    try {
+      content = await readFile(filePath, 'utf-8')
+    } catch {
+      continue
+    }
+
+    const lines = content.split('\n')
+    const entries: PidEntry[] = []
+    for (const line of lines) {
+      if (!line.trim()) continue
+      const entry = parseLine(line)
+      if (entry) entries.push(entry)
+    }
+
+    const result = await processEntries(
+      entries,
+      killProcessTree,
+      getPidComm,
+      getPidStartTime,
+    )
+    reaped += result.reaped
+    skipped += result.skipped
+
+    if (isCurrent) {
+      try {
+        await writeFile(currentInstancePath, '')
+      } catch {
+        // ignore
+      }
+    } else {
+      try {
+        await unlink(filePath)
+        deletedFiles++
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  return { reaped, skipped, scannedFiles, deletedFiles }
+}

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -126,6 +126,89 @@ async function processEntries(
   return { reaped, skipped }
 }
 
+async function readPidFileEntries(
+  filePath: string,
+): Promise<PidEntry[] | null> {
+  let content: string
+  try {
+    content = await readFile(filePath, 'utf-8')
+  } catch {
+    return null
+  }
+
+  const entries: PidEntry[] = []
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue
+    const entry = parseLine(line)
+    if (entry) entries.push(entry)
+  }
+  return entries
+}
+
+async function cleanupAfterReap(
+  filePath: string,
+  isCurrent: boolean,
+  currentInstancePath: string,
+): Promise<boolean> {
+  try {
+    if (isCurrent) {
+      await writeFile(currentInstancePath, '')
+      return false
+    }
+    await unlink(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+interface ReapFileOutcome {
+  reaped: number
+  skipped: number
+  scanned: boolean
+  deleted: boolean
+}
+
+async function reapOneFile(
+  filePath: string,
+  filePid: number,
+  isCurrent: boolean,
+  currentInstancePath: string,
+  isPluginAlive: ReapDeps['isPluginAlive'],
+  killProcessTree: ReapDeps['killProcessTree'],
+  getPidComm: ReapDeps['getPidComm'],
+  getPidStartTime: ReapDeps['getPidStartTime'],
+): Promise<ReapFileOutcome> {
+  const empty: ReapFileOutcome = {
+    reaped: 0,
+    skipped: 0,
+    scanned: false,
+    deleted: false,
+  }
+
+  if (!isCurrent && isPluginAlive(filePid)) {
+    return empty
+  }
+
+  const entries = await readPidFileEntries(filePath)
+  if (entries === null) {
+    return empty
+  }
+
+  const { reaped, skipped } = await processEntries(
+    entries,
+    killProcessTree,
+    getPidComm,
+    getPidStartTime,
+  )
+  const deleted = await cleanupAfterReap(
+    filePath,
+    isCurrent,
+    currentInstancePath,
+  )
+  return { reaped, skipped, scanned: true, deleted }
+}
+
 export async function reapOrphans(opts: {
   pidFileDir: string
   currentInstancePath: string
@@ -143,11 +226,6 @@ export async function reapOrphans(opts: {
     isPluginAlive = defaultIsPluginAlive,
   } = opts
 
-  let reaped = 0
-  let skipped = 0
-  let scannedFiles = 0
-  let deletedFiles = 0
-
   let files: string[]
   try {
     files = await readdir(pidFileDir)
@@ -155,66 +233,37 @@ export async function reapOrphans(opts: {
     return { reaped: 0, skipped: 0, scannedFiles: 0, deletedFiles: 0 }
   }
 
-  const pidFiles = files.filter((f) => f.endsWith('.pids'))
+  let reaped = 0
+  let skipped = 0
+  let scannedFiles = 0
+  let deletedFiles = 0
 
-  for (const file of pidFiles) {
+  for (const file of files) {
+    if (!file.endsWith('.pids')) continue
+
     const filePath = join(pidFileDir, file)
-    const stem = basename(file, extname(file))
-    const filePid = parseInt(stem, 10)
+    const filePid = parseInt(basename(file, extname(file)), 10)
 
     if (Number.isNaN(filePid)) {
       console.warn(`[orphan-reaper] Skipping non-numeric PID file: ${file}`)
       continue
     }
 
-    const isCurrent = filePid === process.pid
-
-    if (!isCurrent) {
-      if (isPluginAlive(filePid)) {
-        continue
-      }
-    }
-
-    scannedFiles++
-
-    let content: string
-    try {
-      content = await readFile(filePath, 'utf-8')
-    } catch {
-      continue
-    }
-
-    const lines = content.split('\n')
-    const entries: PidEntry[] = []
-    for (const line of lines) {
-      if (!line.trim()) continue
-      const entry = parseLine(line)
-      if (entry) entries.push(entry)
-    }
-
-    const result = await processEntries(
-      entries,
+    const outcome = await reapOneFile(
+      filePath,
+      filePid,
+      filePid === process.pid,
+      currentInstancePath,
+      isPluginAlive,
       killProcessTree,
       getPidComm,
       getPidStartTime,
     )
-    reaped += result.reaped
-    skipped += result.skipped
 
-    if (isCurrent) {
-      try {
-        await writeFile(currentInstancePath, '')
-      } catch {
-        // ignore
-      }
-    } else {
-      try {
-        await unlink(filePath)
-        deletedFiles++
-      } catch {
-        // ignore
-      }
-    }
+    reaped += outcome.reaped
+    skipped += outcome.skipped
+    if (outcome.scanned) scannedFiles++
+    if (outcome.deleted) deletedFiles++
   }
 
   return { reaped, skipped, scannedFiles, deletedFiles }

--- a/src/runtime/pid-file.ts
+++ b/src/runtime/pid-file.ts
@@ -1,0 +1,120 @@
+import { randomBytes } from 'node:crypto'
+import {
+  chmod,
+  constants as fsConstants,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  unlink,
+} from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+const writeChains = new Map<string, Promise<void>>()
+
+async function serializeWrite(
+  filePath: string,
+  work: () => Promise<void>,
+): Promise<void> {
+  const prev = writeChains.get(filePath) ?? Promise.resolve()
+  const next = prev.catch(() => {}).then(work)
+  writeChains.set(filePath, next)
+  try {
+    await next
+  } finally {
+    if (writeChains.get(filePath) === next) {
+      writeChains.delete(filePath)
+    }
+  }
+}
+
+export function resolveInstancePidFilePath(): string {
+  const stateDir =
+    process.env.XDG_STATE_HOME ?? join(homedir(), '.local', 'state')
+  return join(
+    stateDir,
+    'opencode-copilot-delegate',
+    'orphans',
+    `${process.pid}.pids`,
+  )
+}
+
+export async function appendPidEntry(
+  filePath: string,
+  pid: number,
+  comm: string,
+  lstart: string,
+): Promise<void> {
+  await serializeWrite(filePath, async () => {
+    await mkdir(dirname(filePath), { recursive: true, mode: 0o700 })
+
+    let existing = ''
+    try {
+      existing = await readFile(filePath, 'utf-8')
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
+    }
+
+    const line = `${pid}\t${comm}\t${lstart}\n`
+    const content = existing + line
+
+    const tempPath = `${filePath}.tmp.${randomBytes(8).toString('hex')}`
+    const fd = await open(
+      tempPath,
+      fsConstants.O_EXCL | fsConstants.O_CREAT | fsConstants.O_WRONLY,
+      0o600,
+    )
+    try {
+      await fd.writeFile(content, { encoding: 'utf-8' })
+    } finally {
+      await fd.close()
+    }
+
+    await rename(tempPath, filePath)
+    await chmod(filePath, 0o600)
+  })
+}
+
+export async function removePidEntry(
+  filePath: string,
+  pid: number,
+): Promise<void> {
+  await serializeWrite(filePath, async () => {
+    let existing = ''
+    try {
+      existing = await readFile(filePath, 'utf-8')
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
+      return
+    }
+
+    const prefix = `${pid}\t`
+    const lines = existing.split('\n')
+    const filtered = lines.filter((line) => !line.startsWith(prefix))
+
+    if (filtered.length === lines.length) {
+      return
+    }
+
+    const content = filtered.join('\n')
+    const tempPath = `${filePath}.tmp.${randomBytes(8).toString('hex')}`
+    const fd = await open(
+      tempPath,
+      fsConstants.O_EXCL | fsConstants.O_CREAT | fsConstants.O_WRONLY,
+      0o600,
+    )
+    try {
+      await fd.writeFile(content, { encoding: 'utf-8' })
+    } finally {
+      await fd.close()
+    }
+
+    await rename(tempPath, filePath)
+    await chmod(filePath, 0o600)
+
+    if (content.trim().length === 0) {
+      await unlink(filePath)
+    }
+  })
+}

--- a/src/runtime/pid-file.ts
+++ b/src/runtime/pid-file.ts
@@ -10,6 +10,7 @@ import {
 } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { isErrnoException } from '../lib/errno'
 
 const writeChains = new Map<string, Promise<void>>()
 
@@ -53,7 +54,7 @@ export async function appendPidEntry(
     try {
       existing = await readFile(filePath, 'utf-8')
     } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
+      if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
     }
 
     const line = `${pid}\t${comm}\t${lstart}\n`
@@ -85,7 +86,7 @@ export async function removePidEntry(
     try {
       existing = await readFile(filePath, 'utf-8')
     } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
+      if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
       return
     }
 

--- a/src/runtime/subprocess.ts
+++ b/src/runtime/subprocess.ts
@@ -119,6 +119,7 @@ export function spawnCopilot(
     task.stdoutLineBuffer = lines.pop() ?? ''
 
     for (const line of lines) {
+      if (task.status !== 'running') break
       if (line.length === 0) {
         continue
       }

--- a/src/runtime/subprocess.ts
+++ b/src/runtime/subprocess.ts
@@ -4,10 +4,12 @@ import { stripAnsi } from '../lib/ansi'
 import { killProcessTree } from '../lib/kill-tree'
 import type { TaskStatus } from './envelope'
 import { type ParsedEvent, parseJsonlLine } from './jsonl-parser'
+import { setStatus } from './task-status'
 
 type SpawnCopilotOptions = {
   cwd: string
   env?: Record<string, string>
+  pidFilePath?: string
 }
 
 export type SpawnCopilotResult = {
@@ -50,14 +52,13 @@ function finalizeTask(
   task: SpawnCopilotResult,
   exitCode: number | null,
   stderrText: string,
+  pidFilePath?: string,
 ): void {
   flushBufferedStdout(task)
   task.endedAt = Date.now()
   task.exitCode = exitCode ?? undefined
 
-  if (task.status !== 'cancelled') {
-    task.status = exitCode === 0 ? 'complete' : 'failed'
-  }
+  setStatus(task, exitCode === 0 ? 'complete' : 'failed', { pidFilePath })
 
   if (stderrText.trim().length > 0) {
     task.errorText = stripAnsi(stderrText.trim())
@@ -141,7 +142,7 @@ export function spawnCopilot(
         return
       }
 
-      task.status = 'cancelled'
+      setStatus(task, 'cancelled', { pidFilePath: opts.pidFilePath })
       killProcessTree(task.pid).catch(() => {
         // Kill failure after abort is non-fatal — process may already be dead
       })
@@ -151,13 +152,13 @@ export function spawnCopilot(
 
   task.completionPromise = new Promise<void>((resolve) => {
     child.once('error', (error) => {
-      task.status = 'failed'
+      setStatus(task, 'failed', { pidFilePath: opts.pidFilePath })
       task.errorText = stripAnsi(error.message)
       resolve()
     })
 
     child.once('close', (code) => {
-      finalizeTask(task, code, stderrText)
+      finalizeTask(task, code, stderrText, opts.pidFilePath)
       resolve()
     })
   })

--- a/src/runtime/subprocess.ts
+++ b/src/runtime/subprocess.ts
@@ -28,6 +28,14 @@ export type SpawnCopilotResult = {
 }
 
 function flushBufferedStdout(task: SpawnCopilotResult): void {
+  // Cancel-race guard: drop any post-cancel partial line. Without this,
+  // bytes that arrived after the abort listener fired could be parsed and
+  // pushed to task.events even though task.status is already 'cancelled'.
+  // Mirrors the per-line guard in the data handler below.
+  if (task.status !== 'running') {
+    task.stdoutLineBuffer = ''
+    return
+  }
   if (task.stdoutLineBuffer.trim().length === 0) {
     task.stdoutLineBuffer = ''
     return

--- a/src/runtime/task-registry.ts
+++ b/src/runtime/task-registry.ts
@@ -40,6 +40,16 @@ export function createTask(
       .then(([comm, lstart]) => {
         if (comm && lstart) {
           appendPidEntry(pidFilePath, task.pid, comm, lstart).catch(() => {})
+        } else {
+          // ps lookup returned null for at least one field. Most likely the
+          // process has already exited (e.g., copilot CLI failed to launch),
+          // but it could also mean the kernel hasn't surfaced the entry yet.
+          // Either way, we cannot append without both fields, so the
+          // subprocess is invisible to the orphan reaper. Surface a warning
+          // so degraded coverage is observable.
+          console.warn(
+            `[task-registry] ps lookup returned null for pid ${task.pid}; subprocess will not be tracked for orphan reaping`,
+          )
         }
       })
       .catch(() => {})

--- a/src/runtime/task-registry.ts
+++ b/src/runtime/task-registry.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { killProcessTree } from '../lib/kill-tree'
+import { getPidComm, getPidStartTime } from './orphan-reaper'
+import { appendPidEntry } from './pid-file'
 import type { SpawnCopilotResult } from './subprocess'
 
 export type TaskState = SpawnCopilotResult & {
@@ -18,6 +20,7 @@ export type CreateTaskInput = Omit<SpawnCopilotResult, 'taskId'> & {
   cwd: string
   agentName?: string
   modelName?: string
+  pidFilePath?: string
 }
 
 const tasks = new Map<string, TaskState>()
@@ -26,9 +29,20 @@ export function createTask(
   input: CreateTaskInput,
   taskId = `cpl_${randomUUID()}`,
 ): TaskState {
+  const { pidFilePath, ...rest } = input
   const task: TaskState = {
-    ...input,
+    ...rest,
     taskId,
+  }
+
+  if (task.pid > 0 && pidFilePath) {
+    Promise.all([getPidComm(task.pid), getPidStartTime(task.pid)])
+      .then(([comm, lstart]) => {
+        if (comm && lstart) {
+          appendPidEntry(pidFilePath, task.pid, comm, lstart).catch(() => {})
+        }
+      })
+      .catch(() => {})
   }
 
   tasks.set(taskId, task)

--- a/src/runtime/task-status.ts
+++ b/src/runtime/task-status.ts
@@ -1,0 +1,32 @@
+import type { TaskStatus } from './envelope'
+import { removePidEntry } from './pid-file'
+
+export interface SetStatusOptions {
+  pidFilePath?: string
+}
+
+const TERMINAL_STATUSES = new Set<TaskStatus>([
+  'complete',
+  'failed',
+  'cancelled',
+])
+
+function isTerminal(s: TaskStatus): boolean {
+  return TERMINAL_STATUSES.has(s)
+}
+
+export function setStatus(
+  task: { status: TaskStatus; pid: number },
+  newStatus: TaskStatus,
+  options?: SetStatusOptions,
+): void {
+  if (isTerminal(task.status) && isTerminal(newStatus)) {
+    return
+  }
+
+  task.status = newStatus
+
+  if (options?.pidFilePath && isTerminal(newStatus)) {
+    removePidEntry(options.pidFilePath, task.pid).catch(() => {})
+  }
+}

--- a/src/tools/delegate.ts
+++ b/src/tools/delegate.ts
@@ -13,6 +13,7 @@ type DelegateToolOptions = {
   client: PluginInput['client']
   description: string
   directory: string
+  pidFilePath?: string
 }
 
 function appendRepeatedFlag(
@@ -101,7 +102,10 @@ export function createDelegateTool(options: DelegateToolOptions) {
       let task: TaskState
 
       try {
-        spawnResult = spawnCopilot(cliArgs, { cwd: options.directory })
+        spawnResult = spawnCopilot(cliArgs, {
+          cwd: options.directory,
+          pidFilePath: options.pidFilePath,
+        })
         const { taskId: spawnTaskId, ...spawnFields } = spawnResult
 
         task = createTask(
@@ -113,6 +117,7 @@ export function createDelegateTool(options: DelegateToolOptions) {
             cwd: options.directory,
             agentName: args.agent,
             modelName: args.model,
+            pidFilePath: options.pidFilePath,
           },
           spawnTaskId,
         )

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -4,8 +4,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   defaultIsPluginAlive,
-  reapOrphans,
   type ReapResult,
+  reapOrphans,
 } from '../src/runtime/orphan-reaper'
 
 function makeTempDir(): string {
@@ -19,7 +19,7 @@ function writePidFile(
   const lines = entries
     .map((e) => `${e.pid}\t${e.comm}\t${e.lstart}`)
     .join('\n')
-  writeFileSync(filePath, lines ? lines + '\n' : '')
+  writeFileSync(filePath, lines ? `${lines}\n` : '')
 }
 
 function result(overrides: Partial<ReapResult> = {}): ReapResult {

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  defaultIsPluginAlive,
+  reapOrphans,
+  type ReapResult,
+} from '../src/runtime/orphan-reaper'
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'orphan-reaper-test-'))
+}
+
+function writePidFile(
+  filePath: string,
+  entries: Array<{ pid: number; comm: string; lstart: string }>,
+): void {
+  const lines = entries
+    .map((e) => `${e.pid}\t${e.comm}\t${e.lstart}`)
+    .join('\n')
+  writeFileSync(filePath, lines ? lines + '\n' : '')
+}
+
+function result(overrides: Partial<ReapResult> = {}): ReapResult {
+  return {
+    reaped: 0,
+    skipped: 0,
+    scannedFiles: 0,
+    deletedFiles: 0,
+    ...overrides,
+  }
+}
+
+describe('orphan-reaper', () => {
+  describe('happy path', () => {
+    it('should return zeros for empty pidFileDir', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => null,
+        getPidStartTime: async () => null,
+      })
+
+      expect(res).toEqual(result())
+    })
+
+    it('should reap alive-matching entry from current file and truncate', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      const killedPids: number[] = []
+
+      writePidFile(currentPath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async (pid) => {
+          killedPids.push(pid)
+        },
+        getPidComm: async () => 'copilot',
+        getPidStartTime: async () => 't1',
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 1, skipped: 0, scannedFiles: 1, deletedFiles: 0 }),
+      )
+      expect(killedPids).toEqual([process.pid])
+      expect(readFileSync(currentPath, 'utf-8')).toBe('')
+    })
+
+    it('should handle multi-file mixed-instance scenario', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      const foreignDeadPath = join(dir, '9999.pids')
+      const foreignAlivePath = join(dir, '8888.pids')
+      const killedPids: number[] = []
+
+      // Current file: 1 alive-match, 1 dead
+      writePidFile(currentPath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+        { pid: 99999, comm: 'copilot', lstart: 't2' },
+      ])
+
+      // Foreign dead spawner: 1 alive-match
+      writePidFile(foreignDeadPath, [
+        { pid: process.ppid, comm: 'copilot', lstart: 't3' },
+      ])
+
+      // Foreign alive spawner: 2 entries (skipped entirely at spawner gate)
+      writePidFile(foreignAlivePath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't4' },
+        { pid: process.pid, comm: 'copilot', lstart: 't5' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async (pid) => {
+          killedPids.push(pid)
+        },
+        getPidComm: async (pid) => {
+          if (pid === process.pid || pid === process.ppid) return 'copilot'
+          return null
+        },
+        getPidStartTime: async (pid) => {
+          if (pid === process.pid) return 't1'
+          if (pid === process.ppid) return 't3'
+          return null
+        },
+        isPluginAlive: (pid) => {
+          if (pid === 9999) return false
+          if (pid === 8888) return true
+          return defaultIsPluginAlive(pid)
+        },
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 2, skipped: 1, scannedFiles: 2, deletedFiles: 1 }),
+      )
+      expect(killedPids.sort((a, b) => a - b)).toEqual(
+        [process.pid, process.ppid].sort((a, b) => a - b),
+      )
+      expect(readFileSync(currentPath, 'utf-8')).toBe('')
+      expect(() => readFileSync(foreignDeadPath, 'utf-8')).toThrow()
+      expect(readFileSync(foreignAlivePath, 'utf-8')).toBeDefined()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should skip foreign file when isPluginAlive returns true (EPERM)', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      const foreignPath = join(dir, '7777.pids')
+      const killedPids: number[] = []
+
+      writePidFile(foreignPath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async (pid) => {
+          killedPids.push(pid)
+        },
+        getPidComm: async () => 'copilot',
+        getPidStartTime: async () => 't1',
+        isPluginAlive: () => true,
+      })
+
+      expect(res).toEqual(result())
+      expect(killedPids).toHaveLength(0)
+      expect(readFileSync(foreignPath, 'utf-8')).toBeDefined()
+    })
+
+    it('should warn and skip non-numeric foreign filename without deleting', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      const garbagePath = join(dir, 'garbage.pids')
+
+      writePidFile(garbagePath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+      ])
+
+      const warnings: string[] = []
+      const origWarn = console.warn
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.join(' '))
+      }
+
+      try {
+        const res = await reapOrphans({
+          pidFileDir: dir,
+          currentInstancePath: currentPath,
+          killProcessTree: async () => {},
+          getPidComm: async () => null,
+          getPidStartTime: async () => null,
+        })
+
+        expect(res).toEqual(result())
+        expect(warnings.some((w) => w.includes('garbage'))).toBe(true)
+        expect(readFileSync(garbagePath, 'utf-8')).toBeDefined()
+      } finally {
+        console.warn = origWarn
+      }
+    })
+
+    it('should delete foreign dead-spawner file when all entries are dead', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      const foreignPath = join(dir, '9999.pids')
+
+      writePidFile(foreignPath, [
+        { pid: 99991, comm: 'copilot', lstart: 't1' },
+        { pid: 99992, comm: 'copilot', lstart: 't2' },
+        { pid: 99993, comm: 'copilot', lstart: 't3' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => null,
+        getPidStartTime: async () => null,
+        isPluginAlive: (pid) => pid !== 9999,
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 0, skipped: 3, scannedFiles: 1, deletedFiles: 1 }),
+      )
+      expect(() => readFileSync(foreignPath, 'utf-8')).toThrow()
+    })
+
+    it('should skip mismatched identity in foreign dead file and still delete', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      const foreignPath = join(dir, '9999.pids')
+
+      writePidFile(foreignPath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => 'not-copilot',
+        getPidStartTime: async () => 't1',
+        isPluginAlive: (pid) => pid !== 9999,
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 0, skipped: 1, scannedFiles: 1, deletedFiles: 1 }),
+      )
+      expect(() => readFileSync(foreignPath, 'utf-8')).toThrow()
+    })
+
+    it('should skip comm mismatch on current file and truncate', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+
+      writePidFile(currentPath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => 'not-copilot',
+        getPidStartTime: async () => 't1',
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 0, skipped: 1, scannedFiles: 1, deletedFiles: 0 }),
+      )
+      expect(readFileSync(currentPath, 'utf-8')).toBe('')
+    })
+
+    it('should skip lstart mismatch on current file and truncate', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+
+      writePidFile(currentPath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => 'copilot',
+        getPidStartTime: async () => 'different-time',
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 0, skipped: 1, scannedFiles: 1, deletedFiles: 0 }),
+      )
+      expect(readFileSync(currentPath, 'utf-8')).toBe('')
+    })
+
+    it('should count dead PID as skipped and truncate current file', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+
+      writePidFile(currentPath, [{ pid: 99999, comm: 'copilot', lstart: 't1' }])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => null,
+        getPidStartTime: async () => null,
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 0, skipped: 1, scannedFiles: 1, deletedFiles: 0 }),
+      )
+      expect(readFileSync(currentPath, 'utf-8')).toBe('')
+    })
+  })
+
+  describe('concurrency', () => {
+    it('should cap concurrent getPidComm invocations at 5 for 10 entries', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      let maxConcurrent = 0
+      let currentConcurrent = 0
+
+      const entries = Array.from({ length: 10 }, () => ({
+        pid: process.pid,
+        comm: 'copilot',
+        lstart: 't0',
+      }))
+      writePidFile(currentPath, entries)
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => {
+          currentConcurrent++
+          maxConcurrent = Math.max(maxConcurrent, currentConcurrent)
+          await new Promise((r) => setTimeout(r, 30))
+          currentConcurrent--
+          return 'copilot'
+        },
+        getPidStartTime: async () => {
+          await new Promise((r) => setTimeout(r, 30))
+          return 't0'
+        },
+      })
+
+      expect(res.reaped).toBe(10)
+      expect(maxConcurrent).toBeLessThanOrEqual(5)
+    })
+  })
+
+  describe('error paths', () => {
+    it('should silently skip malformed lines', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+
+      writeFileSync(
+        currentPath,
+        'this-is-not-valid\n' +
+          `${process.pid}\tcopilot\tt1\n` +
+          '\n' +
+          'also-bad\n',
+      )
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => 'copilot',
+        getPidStartTime: async () => 't1',
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 1, skipped: 0, scannedFiles: 1, deletedFiles: 0 }),
+      )
+    })
+
+    it('should catch killProcessTree throw, count skipped, and continue', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      const killedPids: number[] = []
+
+      writePidFile(currentPath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+        { pid: process.ppid, comm: 'copilot', lstart: 't2' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async (pid) => {
+          if (pid === process.pid) throw new Error('kill failed')
+          killedPids.push(pid)
+        },
+        getPidComm: async (pid) => {
+          if (pid === process.pid || pid === process.ppid) return 'copilot'
+          return null
+        },
+        getPidStartTime: async (pid) => {
+          if (pid === process.pid) return 't1'
+          if (pid === process.ppid) return 't2'
+          return null
+        },
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 1, skipped: 1, scannedFiles: 1, deletedFiles: 0 }),
+      )
+      expect(killedPids).toEqual([process.ppid])
+    })
+
+    it('should skip when getPidStartTime returns null for alive PID', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+
+      writePidFile(currentPath, [
+        { pid: process.pid, comm: 'copilot', lstart: 't1' },
+      ])
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidComm: async () => 'copilot',
+        getPidStartTime: async () => null,
+      })
+
+      expect(res).toEqual(
+        result({ reaped: 0, skipped: 1, scannedFiles: 1, deletedFiles: 0 }),
+      )
+    })
+
+    it('should return zeros when fs.readdir throws (missing dir)', async () => {
+      const res = await reapOrphans({
+        pidFileDir: '/nonexistent/dir/for/sure',
+        currentInstancePath: '/nonexistent/dir/for/sure/test.pids',
+        killProcessTree: async () => {},
+        getPidComm: async () => null,
+        getPidStartTime: async () => null,
+      })
+
+      expect(res).toEqual(result())
+    })
+  })
+
+  describe('defaultIsPluginAlive', () => {
+    it('should return true for current process', () => {
+      expect(defaultIsPluginAlive(process.pid)).toBe(true)
+    })
+
+    it('should return false for non-existent PID', () => {
+      expect(defaultIsPluginAlive(99999)).toBe(false)
+    })
+  })
+})

--- a/tests/pid-file.test.ts
+++ b/tests/pid-file.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { mkdtempSync, readFileSync, statSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   appendPidEntry,
@@ -15,19 +15,26 @@ function makeTempDir(): string {
 describe('pid-file', () => {
   describe('path resolution', () => {
     it('should resolve to <state-dir>/opencode-copilot-delegate/orphans/<process.pid>.pids', () => {
-      const stateDir =
-        process.env.XDG_STATE_HOME ?? join(tmpdir(), '.local', 'state')
+      const original = process.env.XDG_STATE_HOME
+      delete process.env.XDG_STATE_HOME
 
-      const result = resolveInstancePidFilePath()
+      try {
+        const stateDir = join(homedir(), '.local', 'state')
+        const result = resolveInstancePidFilePath()
 
-      expect(result).toBe(
-        join(
-          stateDir,
-          'opencode-copilot-delegate',
-          'orphans',
-          `${process.pid}.pids`,
-        ),
-      )
+        expect(result).toBe(
+          join(
+            stateDir,
+            'opencode-copilot-delegate',
+            'orphans',
+            `${process.pid}.pids`,
+          ),
+        )
+      } finally {
+        if (original !== undefined) {
+          process.env.XDG_STATE_HOME = original
+        }
+      }
     })
 
     it('should use XDG_STATE_HOME when present', () => {

--- a/tests/pid-file.test.ts
+++ b/tests/pid-file.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  appendPidEntry,
+  removePidEntry,
+  resolveInstancePidFilePath,
+} from '../src/runtime/pid-file'
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'pid-file-test-'))
+}
+
+describe('pid-file', () => {
+  describe('path resolution', () => {
+    it('should resolve to <state-dir>/opencode-copilot-delegate/orphans/<process.pid>.pids', () => {
+      const stateDir =
+        process.env.XDG_STATE_HOME ?? join(tmpdir(), '.local', 'state')
+
+      const result = resolveInstancePidFilePath()
+
+      expect(result).toBe(
+        join(
+          stateDir,
+          'opencode-copilot-delegate',
+          'orphans',
+          `${process.pid}.pids`,
+        ),
+      )
+    })
+
+    it('should use XDG_STATE_HOME when present', () => {
+      const original = process.env.XDG_STATE_HOME
+      process.env.XDG_STATE_HOME = '/custom/state'
+
+      try {
+        const result = resolveInstancePidFilePath()
+        expect(result).toBe(
+          join(
+            '/custom/state',
+            'opencode-copilot-delegate',
+            'orphans',
+            `${process.pid}.pids`,
+          ),
+        )
+      } finally {
+        if (original !== undefined) {
+          process.env.XDG_STATE_HOME = original
+        } else {
+          delete process.env.XDG_STATE_HOME
+        }
+      }
+    })
+  })
+
+  describe('appendPidEntry happy path', () => {
+    it('should write a single tab-separated line to a fresh file', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+
+      await appendPidEntry(
+        filePath,
+        12345,
+        'copilot',
+        'Mon Jan 1 00:00:00 2024',
+      )
+
+      const content = readFileSync(filePath, 'utf-8')
+      expect(content).toBe('12345\tcopilot\tMon Jan 1 00:00:00 2024\n')
+
+      const stats = statSync(filePath)
+      expect(stats.mode & 0o777).toBe(0o600)
+    })
+
+    it('should create parent dir with 0o700 when missing', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'nested', 'deep', 'test.pids')
+
+      await appendPidEntry(
+        filePath,
+        12345,
+        'copilot',
+        'Mon Jan 1 00:00:00 2024',
+      )
+
+      const content = readFileSync(filePath, 'utf-8')
+      expect(content).toBe('12345\tcopilot\tMon Jan 1 00:00:00 2024\n')
+
+      const dirStats = statSync(join(dir, 'nested', 'deep'))
+      expect(dirStats.mode & 0o777).toBe(0o700)
+    })
+
+    it('should preserve three sequential appends in spawn order', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+
+      await appendPidEntry(filePath, 1, 'a', 't1')
+      await appendPidEntry(filePath, 2, 'b', 't2')
+      await appendPidEntry(filePath, 3, 'c', 't3')
+
+      const content = readFileSync(filePath, 'utf-8')
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(3)
+      expect(lines[0]).toBe('1\ta\tt1')
+      expect(lines[1]).toBe('2\tb\tt2')
+      expect(lines[2]).toBe('3\tc\tt3')
+    })
+  })
+
+  describe('removePidEntry happy path', () => {
+    it('should remove the matching entry and preserve order', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+
+      await appendPidEntry(filePath, 1, 'a', 't1')
+      await appendPidEntry(filePath, 2, 'b', 't2')
+      await appendPidEntry(filePath, 3, 'c', 't3')
+
+      await removePidEntry(filePath, 2)
+
+      const content = readFileSync(filePath, 'utf-8')
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(2)
+      expect(lines[0]).toBe('1\ta\tt1')
+      expect(lines[1]).toBe('3\tc\tt3')
+    })
+
+    it('should no-op when PID is not in file', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+
+      await appendPidEntry(filePath, 1, 'a', 't1')
+      await appendPidEntry(filePath, 2, 'b', 't2')
+
+      await removePidEntry(filePath, 999)
+
+      const content = readFileSync(filePath, 'utf-8')
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(2)
+    })
+
+    it('should no-op when file is missing', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'missing.pids')
+
+      await removePidEntry(filePath, 123)
+
+      expect(() => statSync(filePath)).toThrow()
+    })
+  })
+
+  describe('mode preservation', () => {
+    it('should keep file mode at 0o600 after append and remove', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+
+      await appendPidEntry(filePath, 1, 'a', 't1')
+      let stats = statSync(filePath)
+      expect(stats.mode & 0o777).toBe(0o600)
+
+      await appendPidEntry(filePath, 2, 'b', 't2')
+      stats = statSync(filePath)
+      expect(stats.mode & 0o777).toBe(0o600)
+
+      await removePidEntry(filePath, 1)
+      stats = statSync(filePath)
+      expect(stats.mode & 0o777).toBe(0o600)
+    })
+  })
+
+  describe('concurrency', () => {
+    it('should serialize 10 concurrent appends into exactly 10 entries', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'concurrent.pids')
+
+      const triples = Array.from({ length: 10 }, (_, i) => ({
+        pid: 1000 + i,
+        comm: `proc-${i}`,
+        lstart: `time-${i}`,
+      }))
+
+      await Promise.all(
+        triples.map((t) => appendPidEntry(filePath, t.pid, t.comm, t.lstart)),
+      )
+
+      const content = readFileSync(filePath, 'utf-8')
+      const lines = content
+        .trim()
+        .split('\n')
+        .filter((l) => l.length > 0)
+      expect(lines).toHaveLength(10)
+
+      const pids = new Set<number>()
+      for (const line of lines) {
+        const parts = line.split('\t')
+        expect(parts).toHaveLength(3)
+        expect(parts[0]).toMatch(/^\d+$/)
+        expect(parts[1]).toMatch(/^proc-\d+$/)
+        expect(parts[2]).toMatch(/^time-\d+$/)
+        pids.add(Number(parts[0]))
+      }
+      expect(pids.size).toBe(10)
+    })
+  })
+})

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -20,7 +20,7 @@ type SpawnCopilotResult = {
   events: ParsedEvent[]
   completionPromise: Promise<void>
   abortController: AbortController
-  child: { pid: number }
+  child: ChildProcess
   status: TaskStatus
   exitCode?: number
   stdoutLineBuffer: string
@@ -42,7 +42,7 @@ type CreateTaskFn = (input: {
   cwd: string
   stdoutLineBuffer: string
   events: ParsedEvent[]
-  child: { pid: number }
+  child: ChildProcess
   completionPromise: Promise<void>
   abortController: AbortController
 }) => {
@@ -324,7 +324,7 @@ describe('subprocess runtime', () => {
       ].join('\n')}\n`
 
       // Programmatically emit data on the child's stdout stream
-      ;(task.child as unknown as ChildProcess).stdout?.emit('data', extraLines)
+      task.child.stdout?.emit('data', extraLines)
 
       // Assert no new events were appended
       expect(task.events).toHaveLength(2)

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test'
+import type { ChildProcess } from 'node:child_process'
 import {
   chmodSync,
   existsSync,
@@ -284,6 +285,54 @@ describe('subprocess runtime', () => {
       expect(task.status).toBe('cancelled')
       expect(Date.now() - startedAt).toBeLessThan(3000)
       expectProcessToBeGone(grandchildPid)
+    })
+
+    it('does not append events after cancellation (cancel-race guard)', async () => {
+      // Given a fake copilot binary that emits 2 JSONL lines and then waits
+      const { spawnCopilot } = await loadModules()
+      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(cwd, binDir)
+
+      const task = spawnCopilot(
+        [
+          '-c',
+          [
+            'printf \'%s\\n\' \'{"type":"assistant.message","data":{"messageId":"msg-1","content":"line1","toolRequests":[]}}\'',
+            'printf \'%s\\n\' \'{"type":"assistant.message","data":{"messageId":"msg-2","content":"line2","toolRequests":[]}}\'',
+            'sleep 30',
+          ].join('; '),
+        ],
+        { cwd, env: makeSpawnEnv(binDir) },
+      )
+
+      // Wait for the first 2 lines to be parsed
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if (task.events.length >= 2) break
+        await delay(20)
+      }
+      expect(task.events).toHaveLength(2)
+
+      // When the task is cancelled
+      task.abortController.abort()
+
+      // Then additional data arriving on stdout should not append new events
+      const extraLines =
+        [
+          '{"type":"assistant.message","data":{"messageId":"msg-3","content":"line3","toolRequests":[]}}',
+          '{"type":"assistant.message","data":{"messageId":"msg-4","content":"line4","toolRequests":[]}}',
+          '{"type":"assistant.message","data":{"messageId":"msg-5","content":"line5","toolRequests":[]}}',
+        ].join('\n') + '\n'
+
+      // Programmatically emit data on the child's stdout stream
+      ;(task.child as unknown as ChildProcess).stdout?.emit('data', extraLines)
+
+      // Assert no new events were appended
+      expect(task.events).toHaveLength(2)
+
+      // Clean up: wait for the killed subprocess to close
+      await task.completionPromise
+      expect(task.status).toBe('cancelled')
     })
   })
 

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -317,12 +317,11 @@ describe('subprocess runtime', () => {
       task.abortController.abort()
 
       // Then additional data arriving on stdout should not append new events
-      const extraLines =
-        [
-          '{"type":"assistant.message","data":{"messageId":"msg-3","content":"line3","toolRequests":[]}}',
-          '{"type":"assistant.message","data":{"messageId":"msg-4","content":"line4","toolRequests":[]}}',
-          '{"type":"assistant.message","data":{"messageId":"msg-5","content":"line5","toolRequests":[]}}',
-        ].join('\n') + '\n'
+      const extraLines = `${[
+        '{"type":"assistant.message","data":{"messageId":"msg-3","content":"line3","toolRequests":[]}}',
+        '{"type":"assistant.message","data":{"messageId":"msg-4","content":"line4","toolRequests":[]}}',
+        '{"type":"assistant.message","data":{"messageId":"msg-5","content":"line5","toolRequests":[]}}',
+      ].join('\n')}\n`
 
       // Programmatically emit data on the child's stdout stream
       ;(task.child as unknown as ChildProcess).stdout?.emit('data', extraLines)
@@ -332,6 +331,41 @@ describe('subprocess runtime', () => {
 
       // Clean up: wait for the killed subprocess to close
       await task.completionPromise
+      expect(task.status).toBe('cancelled')
+    })
+
+    it('preserves cancelled status when close fires after abort (cancel-then-close ordering)', async () => {
+      // Given a fake copilot binary that emits 1 line and then sleeps
+      const { spawnCopilot } = await loadModules()
+      const cwd = mkdtempSync(join(tmpdir(), 'copilot-cwd-'))
+      const binDir = makeFakeCopilotBin()
+      tempPaths.push(cwd, binDir)
+
+      const task = spawnCopilot(
+        [
+          '-c',
+          [
+            'printf \'%s\\n\' \'{"type":"assistant.message","data":{"messageId":"msg-1","content":"line1","toolRequests":[]}}\'',
+            'sleep 30',
+          ].join('; '),
+        ],
+        { cwd, env: makeSpawnEnv(binDir) },
+      )
+
+      // Wait for the line to be parsed
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if (task.events.length >= 1) break
+        await delay(20)
+      }
+      expect(task.events).toHaveLength(1)
+
+      // When cancellation is requested
+      task.abortController.abort()
+
+      // Wait for the subprocess to actually close after the kill
+      await task.completionPromise
+
+      // Then the status remains cancelled, not flipped to complete/failed by finalizeTask
       expect(task.status).toBe('cancelled')
     })
   })

--- a/tests/task-registry.test.ts
+++ b/tests/task-registry.test.ts
@@ -33,7 +33,7 @@ describe('task registry PID-file hooks', () => {
         cwd: process.cwd(),
         stdoutLineBuffer: '',
         events: [],
-        child: { pid: child.pid },
+        child,
         completionPromise: child.exited.then(() => undefined),
         abortController,
         pidFilePath,
@@ -68,7 +68,7 @@ describe('task registry PID-file hooks', () => {
         cwd: process.cwd(),
         stdoutLineBuffer: '',
         events: [],
-        child: { pid: child.pid },
+        child,
         completionPromise: child.exited.then(() => undefined),
         abortController,
         pidFilePath,
@@ -86,5 +86,59 @@ describe('task registry PID-file hooks', () => {
 
     child.kill()
     deleteTask(task.taskId)
+  })
+
+  it('warns and skips append when ps lookup returns null', async () => {
+    // Use a never-existed PID so getPidComm/getPidStartTime return null.
+    // PIDs above 2^22 are guaranteed unused on Linux/macOS (kernel pid_max).
+    const ghostPid = 4_194_305
+
+    const dir = mkdtempSync(join(tmpdir(), 'task-registry-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const abortController = new AbortController()
+    // Capture console.warn output so we can assert the warning fires.
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (msg: string) => warnings.push(msg)
+
+    try {
+      const task = createTask(
+        {
+          parentSessionID: 'session-1',
+          pid: ghostPid,
+          startedAt: Date.now(),
+          status: 'running',
+          args: ['-c', 'sleep 30'],
+          cwd: process.cwd(),
+          stdoutLineBuffer: '',
+          events: [],
+          // biome-ignore lint/suspicious/noExplicitAny: ghost-pid fixture has no real child
+          child: { pid: ghostPid } as any,
+          completionPromise: Promise.resolve(),
+          abortController,
+          pidFilePath,
+        },
+        undefined,
+      )
+
+      await delay(200)
+
+      // PID file should not have been created — neither comm nor lstart resolved.
+      expect(() => readFileSync(pidFilePath, 'utf-8')).toThrow()
+
+      // The silent-skip warning must be observable.
+      const matched = warnings.find((w) =>
+        w.includes(
+          `[task-registry] ps lookup returned null for pid ${ghostPid}`,
+        ),
+      )
+      expect(matched).toBeTruthy()
+
+      deleteTask(task.taskId)
+    } finally {
+      console.warn = originalWarn
+    }
   })
 })

--- a/tests/task-registry.test.ts
+++ b/tests/task-registry.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { createTask, deleteTask } from '../src/runtime/task-registry'
+import { setStatus } from '../src/runtime/task-status'
+
+const tempPaths: string[] = []
+
+afterEach(() => {
+  for (const p of tempPaths.splice(0)) {
+    rmSync(p, { force: true, recursive: true })
+  }
+})
+
+describe('task registry PID-file hooks', () => {
+  it('appends to PID file on spawn', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-registry-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const child = Bun.spawn({ cmd: ['sleep', '30'] })
+    const abortController = new AbortController()
+
+    const task = createTask(
+      {
+        parentSessionID: 'session-1',
+        pid: child.pid,
+        startedAt: Date.now(),
+        status: 'running',
+        args: ['-c', 'sleep 30'],
+        cwd: process.cwd(),
+        stdoutLineBuffer: '',
+        events: [],
+        child: { pid: child.pid },
+        completionPromise: child.exited.then(() => undefined),
+        abortController,
+        pidFilePath,
+      },
+      undefined,
+    )
+
+    await delay(200)
+
+    const content = readFileSync(pidFilePath, 'utf-8')
+    expect(content).toContain(`${child.pid}\t`)
+
+    child.kill()
+    deleteTask(task.taskId)
+  })
+
+  it('removes from PID file on terminal transition', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-registry-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const child = Bun.spawn({ cmd: ['sleep', '30'] })
+    const abortController = new AbortController()
+
+    const task = createTask(
+      {
+        parentSessionID: 'session-1',
+        pid: child.pid,
+        startedAt: Date.now(),
+        status: 'running',
+        args: ['-c', 'sleep 30'],
+        cwd: process.cwd(),
+        stdoutLineBuffer: '',
+        events: [],
+        child: { pid: child.pid },
+        completionPromise: child.exited.then(() => undefined),
+        abortController,
+        pidFilePath,
+      },
+      undefined,
+    )
+
+    await delay(200)
+    expect(readFileSync(pidFilePath, 'utf-8')).toContain(`${child.pid}\t`)
+
+    setStatus(task, 'cancelled', { pidFilePath })
+
+    await delay(200)
+    expect(() => readFileSync(pidFilePath, 'utf-8')).toThrow()
+
+    child.kill()
+    deleteTask(task.taskId)
+  })
+})

--- a/tests/task-status.test.ts
+++ b/tests/task-status.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import type { TaskStatus } from '../src/runtime/envelope'
+import { appendPidEntry } from '../src/runtime/pid-file'
+import { setStatus } from '../src/runtime/task-status'
+
+const tempPaths: string[] = []
+
+afterEach(() => {
+  for (const p of tempPaths.splice(0)) {
+    rmSync(p, { force: true, recursive: true })
+  }
+})
+
+function makeTask(status: TaskStatus, pid: number) {
+  return { status, pid }
+}
+
+describe('setStatus', () => {
+  it('sets complete and removes PID file entry from running state', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const task = makeTask('running', 12345)
+    await appendPidEntry(
+      pidFilePath,
+      task.pid,
+      'bash',
+      'Mon Apr 27 10:00:00 2026',
+    )
+
+    setStatus(task, 'complete', { pidFilePath })
+    expect(task.status).toBe('complete')
+
+    await delay(100)
+    expect(() => readFileSync(pidFilePath, 'utf-8')).toThrow()
+  })
+
+  it('preserves cancelled when setStatus is called with complete', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const task = makeTask('cancelled', 12345)
+    await appendPidEntry(
+      pidFilePath,
+      task.pid,
+      'bash',
+      'Mon Apr 27 10:00:00 2026',
+    )
+
+    setStatus(task, 'complete', { pidFilePath })
+    expect(task.status).toBe('cancelled')
+
+    await delay(100)
+    const content = readFileSync(pidFilePath, 'utf-8')
+    expect(content).toContain('12345')
+  })
+
+  it('preserves failed when setStatus is called with cancelled', () => {
+    const task = makeTask('failed', 12345)
+
+    setStatus(task, 'cancelled')
+    expect(task.status).toBe('failed')
+  })
+
+  it('allows non-terminal transitions without removing PID entry', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const task = makeTask('running', 12345)
+    await appendPidEntry(
+      pidFilePath,
+      task.pid,
+      'bash',
+      'Mon Apr 27 10:00:00 2026',
+    )
+
+    setStatus(task, 'running', { pidFilePath })
+    expect(task.status).toBe('running')
+
+    await delay(100)
+    const content = readFileSync(pidFilePath, 'utf-8')
+    expect(content).toContain('12345')
+  })
+
+  it('sets failed without options and does not throw', () => {
+    const task = makeTask('running', 12345)
+
+    setStatus(task, 'failed')
+    expect(task.status).toBe('failed')
+  })
+
+  it('swallows removePidEntry rejection', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
+    tempPaths.push(dir)
+
+    const task = makeTask('running', 12345)
+
+    expect(() => {
+      setStatus(task, 'complete', { pidFilePath: dir })
+    }).not.toThrow()
+
+    expect(task.status).toBe('complete')
+  })
+
+  it('is idempotent when task is already terminal', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const task = makeTask('cancelled', 12345)
+    await appendPidEntry(
+      pidFilePath,
+      task.pid,
+      'bash',
+      'Mon Apr 27 10:00:00 2026',
+    )
+
+    setStatus(task, 'cancelled', { pidFilePath })
+    expect(task.status).toBe('cancelled')
+
+    await delay(100)
+    const content = readFileSync(pidFilePath, 'utf-8')
+    expect(content).toContain('12345')
+  })
+})


### PR DESCRIPTION
## Summary

This is a v0.1.1 patch that ships runtime hardening for the `copilot` subprocess lifecycle. It closes a real correctness gap (orphaned subprocesses on plugin reload) and tightens two cancel-race windows in the JSONL data path.

The orphan reaper addresses what happens when OpenCode reloads the plugin (config change, plugin update, session restart) — in-flight `copilot` subprocesses receive no cleanup signal and would otherwise be left running. The reaper writes a per-instance PID file at `<XDG_STATE_HOME>/opencode-copilot-delegate/orphans/<plugin-pid>.pids` for every spawned subprocess, scans that directory at the next plugin init, probes the owning plugin's liveness via `process.kill(<plugin-pid>, 0)`, and reaps entries from files whose plugin has exited.

Identity gating is strict: each kill requires the live process's `comm` (kernel-tracked executable name from `ps -o comm=`) AND `lstart` (start-time string) to match values recorded at spawn time. Combined with the spawner-liveness probe, this prevents both PID reuse of an unrelated process and cross-instance kill of a live foreign instance's children.

The cancel-race fixes close two leak windows in the JSONL data path — events buffered before abort can no longer be appended after `task.status === 'cancelled'`. The new `setStatus` helper centralizes all three terminal status mutations through a single terminal-state-preserving entry point so future contributors can't accidentally bypass the PID file cleanup hook.

## Scope

**New modules**

- `src/runtime/pid-file.ts` — atomic append/remove with `O_EXCL` + rename + in-process Promise-chain serialization queue
- `src/runtime/orphan-reaper.ts` — directory scan, spawner-liveness gate, parallel `ps` probes (capped at 5), strict identity gate, foreign-file deletion on dead-spawner reap
- `src/runtime/task-status.ts` — terminal-state-preserving `setStatus` helper with PID file cleanup hook
- `src/lib/errno.ts` — typed `isErrnoException` predicate

**Modified**

- `src/runtime/subprocess.ts` — cancel-race guards in the data handler and `flushBufferedStdout`; `setStatus` call sites
- `src/runtime/task-registry.ts` — `appendPidEntry` on spawn (fire-and-forget so `createTask` does not block on `ps` shellouts)
- `src/lib/kill-tree.ts` — refuses `pid <= 1` (avoids `fkill(-1, ...)` blast radius in containers)
- `src/index.ts` — plugin-init reap with `mkdir` + reap inside a shared try/catch so read-only or permission-denied state dirs degrade gracefully

**Tests**

- 133 / 0 fail / 715 expects across 11 files
- New: `tests/pid-file.test.ts`, `tests/orphan-reaper.test.ts`, `tests/task-status.test.ts`, `tests/task-registry.test.ts`
- Modified: `tests/subprocess.test.ts` adds the cancel-race guard and cancel-then-close ordering scenarios

## Plan

`docs/plans/2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md`. All four implementation units ticked. The plan was deepened twice during planning to add the per-instance PID file design and the spawner-liveness gate.

## Out of scope

A handful of additional improvements surfaced during implementation and are tracked in #49 for follow-up PRs:

- Streaming worker pool to replace the chunked-of-5 sequential await
- Combined `ps -p <pid> -o comm=,lstart=` query
- Configurable `ps` timeout + degradation logging
- Overall `reapOrphans` timeout via `Promise.race`
- Symlink hardening (`O_NOFOLLOW` / `lstat`) on PID file paths
- Test coverage for `psField` branches, plugin init lifecycle, `createTask` edge cases, `defaultIsPluginAlive` EPERM
- Wall-clock sleeps in `task-registry.test.ts` replaced with poll loops
- Several maintainability cleanups (magic numbers, naming, parameter shapes)

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run build` — `dist/index.js` 0.33 MB
- `bun test` — 133 / 0 fail / 715 expects



Patch bump (`opencode-copilot-delegate@minor`) per the unstable 0.x series convention. Full description in `.changeset/runtime-hardening-orphan-reaper.md`.

## Changelog entry

Minor bump per the unstable 0.x convention — release will be 0.2.0. The plan document is named `v0.1.1` because it was scoped as a patch-class hardening fix; the npm version diverges per project convention. Full description in `.changeset/runtime-hardening-orphan-reaper.md`.
