### PR TITLE
docs: decouple plan filenames from npm version + capture five orphan-reaper patterns

### DIFF
--- a/docs/plans/2026-04-27-001-feat-copilot-status-tui-foundation-plan.md
+++ b/docs/plans/2026-04-27-001-feat-copilot-status-tui-foundation-plan.md
@@ -1,43 +1,42 @@
 ---
-title: "feat: /copilot-status TUI foundation (v0.2.0)"
+title: "feat: /copilot-status TUI foundation"
 type: feat
 status: active
 date: 2026-04-27
 origin: docs/brainstorms/2026-04-27-copilot-status-tui-requirements.md
-target_release: v0.2.0
-prerequisite_plan: docs/plans/2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md
+prerequisite_plan: docs/plans/2026-04-27-002-fix-runtime-hardening-plan.md
 ---
 
-# feat: /copilot-status TUI foundation (v0.2.0)
+# feat: /copilot-status TUI foundation
 
 ## Overview
 
-Lay the v0.2.x visibility-platform foundation by turning `opencode-copilot-delegate` into a two-entrypoint package. The existing server-side plugin keeps its current responsibilities. A new TUI half ships alongside it: an opt-in `@opencode-ai/plugin/tui` that registers a `/copilot-status` command, opens a modal listing running delegations, exposes a cancel keybind, and emits a spawn-toast lifecycle signal. The two halves communicate over an HTTP-over-localhost RPC channel published via a per-session port file with a per-process auth token; the port file lives at `0o600` permissions.
+Lay the visibility-platform foundation by turning `opencode-copilot-delegate` into a two-entrypoint package. The existing server-side plugin keeps its current responsibilities. A new TUI half ships alongside it: an opt-in `@opencode-ai/plugin/tui` that registers a `/copilot-status` command, opens a modal listing running delegations, exposes a cancel keybind, and emits a spawn-toast lifecycle signal. The two halves communicate over an HTTP-over-localhost RPC channel published via a per-session port file with a per-process auth token; the port file lives at `0o600` permissions.
 
-The PID-file orphan reaper that was originally bundled here ships first as a v0.1.1 patch — see `docs/plans/2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md`. v0.2.0 builds on top of that hardening.
+The PID-file orphan reaper that was originally bundled here shipped first as a runtime hardening release — see `docs/plans/2026-04-27-002-fix-runtime-hardening-plan.md`. This plan builds on top of that hardening.
 
-v0.2.1 (drilled fullscreen view) and v0.2.2 (recent-history + concurrent navigation) are out of scope and will get their own brainstorms once this lands.
+The drilled fullscreen view and the recent-history + concurrent-navigation surface are out of scope and will get their own brainstorms once this lands.
 
 ## Problem Frame
 
-`opencode-copilot-delegate` v0.1 makes long-running Copilot delegations possible but inconvenient to monitor — a 5-minute delegation looks identical to a hung subprocess until the completion toast fires. `copilot_output` exists but requires a tool call away from the chat. The brainstorm (`docs/brainstorms/2026-04-27-copilot-status-tui-requirements.md`) commits the plugin to a chat-native visibility surface mirroring OpenCode's native subagent rendering — modal listing in v0.2.0, drilled view + history later.
+`opencode-copilot-delegate` v0.1 makes long-running Copilot delegations possible but inconvenient to monitor — a 5-minute delegation looks identical to a hung subprocess until the completion toast fires. `copilot_output` exists but requires a tool call away from the chat. The brainstorm (`docs/brainstorms/2026-04-27-copilot-status-tui-requirements.md`) commits the plugin to a chat-native visibility surface mirroring OpenCode's native subagent rendering — modal listing in this foundation phase, drilled view + history later.
 
-The architectural commit is one-way: shipping a `tui` entrypoint means users add the plugin to their `tui.jsonc`. Removing it is a breaking change. v0.2.0's job is to ship that commit cleanly so v0.2.1 / v0.2.2 can build on top.
+The architectural commit is one-way: shipping a `tui` entrypoint means users add the plugin to their `tui.jsonc`. Removing it is a breaking change. This foundation plan's job is to ship that commit cleanly so the drilled-view and history phases can build on top.
 
 ## Requirements Trace
 
-From the origin brainstorm — v0.2.0 functional requirements (R8 moved to the pre-TUI hardening plan):
+From the origin brainstorm — foundation-phase functional requirements (R8 moved to the runtime hardening plan):
 
 - **R1** — `/copilot-status` slash command opens the modal at the list view. (origin: `docs/brainstorms/2026-04-27-copilot-status-tui-requirements.md` §"v0.2.0 — functional requirements" → "Slash command". The brainstorm's wording suggests server-side registration; the plan registers from the TUI half because the slash command is meaningless without the TUI to render the dialog — see Key Decisions.)
-- **R2** — Modal list view: header shows `<n> running · 0 recent`; rows show status badge / abbreviated task ID / agent / model / elapsed (live) / tool-call count; running-only in v0.2.0. (origin: same → "Modal — list view")
+- **R2** — Modal list view: header shows `<n> running · 0 recent`; rows show status badge / abbreviated task ID / agent / model / elapsed (live) / tool-call count; running-only in the foundation phase. (origin: same → "Modal — list view")
 - **R3** — Cancel via `c` keybind on focused row → confirm dialog → existing `copilot_cancel` machinery via authenticated RPC → row transitions to `cancelling` then `cancelled`, then is removed per running-only rule. (origin: same → "Cancel flow" + UX micro-spec)
 - **R4** — Spawn lifecycle toast: `client.tui.showToast({ body: { message: 'Copilot delegation cpl_xxxxxxxx started', variant: 'info' } })` from `copilot_delegate` immediately after task creation. Existing completion toast unchanged. (origin: same → "Lifecycle notifications". Note: the existing `notify.ts` API uses a `body:` wrapper around `{ message, variant }`; new spawn-toast helper follows the same shape.)
-- **R5** — v0.2.0 keybinds in the list view: `↑`/`k`, `↓`/`j`, `c`, `Esc`. No `Enter` / drill-in / scroll keys (those belong to v0.2.1). The confirm-card dialog adds `←`/`→`/`Enter`/`Space`/`Esc` within its own surface. (origin: same → "Interaction model")
+- **R5** — foundation-phase keybinds in the list view: `↑`/`k`, `↓`/`j`, `c`, `Esc`. No `Enter` / drill-in / scroll keys (those belong to the drilled-view phase). The confirm-card dialog adds `←`/`→`/`Enter`/`Space`/`Esc` within its own surface. (origin: same → "Interaction model")
 - **R6** — UX micro-specs: focus indicator (inverse video + `●` prefix on running badge), empty state, loading state, RPC error state, cancel-confirm dialog flow, list scroll behavior — including footer hints (`Esc close`) on empty/error states and explicit focus behavior after a cancelled row is removed. (origin: same → "v0.2.0 UX micro-specs")
 - **R7** — TUI plugin is opt-in via user's `tui.jsonc`; server-side keeps working without it; `/copilot-status` shows a graceful RPC-error state when the TUI half fails to load or the RPC server is unreachable. (origin: §"Architectural commit" + success criteria)
-- **R9** — Pull-from-registry event delivery: server-side exposes a list query method; v0.2.0 only needs the *list* endpoint (plus health and cancel) — per-task event endpoint lands with v0.2.1. (origin: §"Prerequisites for ce:plan" #4)
+- **R9** — Pull-from-registry event delivery: server-side exposes a list query method; this foundation phase only needs the *list* endpoint (plus health and cancel) — per-task event endpoint lands with the drilled-view phase. (origin: §"Prerequisites for ce:plan" #4)
 
-**R8 is in the pre-TUI hardening plan** (see `prerequisite_plan` frontmatter). v0.2.0 assumes the orphan reaper has already shipped and the runtime parser is guarded; both are independent runtime correctness fixes that don't depend on the TUI architecture.
+**R8 is in the runtime hardening plan** (see `prerequisite_plan` frontmatter). This plan assumes the orphan reaper has already shipped and the runtime parser is guarded; both are independent runtime correctness fixes that don't depend on the TUI architecture.
 
 Performance / compatibility success criteria from the origin doc:
 - List populates within one localhost-HTTP round-trip (≤250ms target).
@@ -46,11 +45,11 @@ Performance / compatibility success criteria from the origin doc:
 
 ## Scope Boundaries
 
-- **No drilled fullscreen view** — that's v0.2.1's brainstorm.
-- **No recent-history surface** — that's v0.2.2.
-- **No expandable output cards / concurrent ←/→ navigation in the list view** — v0.2.2.
+- **No drilled fullscreen view** — that's the next phase's brainstorm.
+- **No recent-history surface** — that's the third phase.
+- **No expandable output cards / concurrent ←/→ navigation in the list view** — third phase.
 - **No persistent task storage** — in-memory only.
-- **No sidebar / always-visible panel** — modal-only across v0.2.x.
+- **No sidebar / always-visible panel** — modal-only across the visibility-platform phases.
 - **No new slash commands beyond `/copilot-status`** — cancel is keybind-only.
 - **No production code in this PR for resume/connect (S2), watchdog (S5), transcript export (S6), or `copilot_doctor` (S7)** — separate ideation lines.
 - **No upstream behavior change to existing `copilot_delegate` / `copilot_output` / `copilot_cancel` tools beyond the additions enumerated in Unit 4.** (Specifically: `copilot_delegate` adds the spawn-toast call; the cancel-helper extraction touches `copilot_cancel`'s callsite to share machinery with the RPC handler. No changes to return shapes or error contracts.)
@@ -59,8 +58,8 @@ Performance / compatibility success criteria from the origin doc:
 
 ### Deferred to Separate Tasks
 
-- **PID-file orphan reaper + parser cancel-race guard** — `docs/plans/2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md`, ships as v0.1.1 before v0.2.0.
-- **Upstream lifecycle-hook feature request to `anomalyco/opencode`** — file from the v0.2.0 implementation PR with a code TODO pointing at the issue. Brainstorm open question #2.
+- **PID-file orphan reaper + parser cancel-race guard** — `docs/plans/2026-04-27-002-fix-runtime-hardening-plan.md`, shipped first as a runtime hardening release before this plan.
+- **Upstream lifecycle-hook feature request to `anomalyco/opencode`** — file from this plan's implementation PR with a code TODO pointing at the issue. Brainstorm open question #2.
 - **`bunx opencode-copilot-delegate doctor` setup helper** — defer to v0.3+ once the user-install pattern stabilizes.
 - **`@opencode-ai/plugin` peer-dep version verification against the host's bundled SDK** — verify at implementation time; bump may be required to `>= 0.1.99` to match Magic Context's working baseline.
 
@@ -74,22 +73,22 @@ Performance / compatibility success criteria from the origin doc:
 - `src/tools/cancel.ts` — `createCancelTool`. Currently 23 lines, only calls `task.abortController.abort()`. The actual kill chain lives in `subprocess.ts`'s abort listener. Unit 4 extracts the cancel call into a shared helper that both this tool and the RPC server's cancel handler can invoke.
 - `src/runtime/task-registry.ts` — `taskRegistry`. List-RPC handler reads from this. `taskRegistry.getAllTasks()` exists; add a `listRunning()` projection that returns the schema-shaped list (no event buffers).
 - `src/runtime/notify.ts` — existing `notifyCompletion`, manually-typed `NotifyClient`. The `client.tui.showToast` API takes `{ body: { message, variant } }`; spawn-toast helper follows that shape.
-- `src/runtime/subprocess.ts` — current home of the JSONL data handler (an anonymous callback inside `spawnCopilot`, not a named function). v0.2.0 does not modify this file; the cancel-race guard belongs to the pre-TUI hardening plan.
+- `src/runtime/subprocess.ts` — current home of the JSONL data handler (an anonymous callback inside `spawnCopilot`, not a named function). This plan does not modify this file; the cancel-race guard belongs to the runtime hardening plan.
 - `src/runtime/envelope.ts` — `tool_calls` array via `summary.tool_calls.length` for the list-view tool-call count column.
-- `src/lib/kill-tree.ts` — `killProcessTree`. Used indirectly via the existing abort-listener path; not directly referenced by v0.2.0 code.
+- `src/lib/kill-tree.ts` — `killProcessTree`. Used indirectly via the existing abort-listener path; not directly referenced by foundation code.
 - `package.json` — root manifest. New `exports["."]` (preserve current default), `exports["./tui"]`, `oc-plugin` field, opentui + solid-js + zod deps, peer-dep bump to `@opencode-ai/plugin >= 0.1.99`.
 - `tsconfig.json` — current `module: NodeNext`, no JSX. Unit 1 adds JSX support; see Key Decisions for the precise config given the `jsx: "preserve"` + `jsxImportSource` interaction.
 - `tests/` — bun-test files at top level (`*.test.ts`). New work follows the same shape; TUI-component tests live alongside source under `src/tui/__tests__/`.
 
 **Magic Context precedent (read-only reference, not a dependency):**
 - `node_modules/@cortexkit/opencode-magic-context-tui/src/index.tsx` — TUI plugin shell; `api.command.register`, `api.ui.dialog.replace`, `api.ui.toast`, `api.lifecycle.onDispose` patterns; SolidJS render via `<Render onDismiss={...} />`.
-- `node_modules/@cortexkit/opencode-magic-context-tui/src/api.ts` — TUI-side HTTP RPC client over `fetch`. (Their notification poller is not needed in v0.2.0.)
+- `node_modules/@cortexkit/opencode-magic-context-tui/src/api.ts` — TUI-side HTTP RPC client over `fetch`. (Their notification poller is not needed in the foundation phase.)
 - `node_modules/@cortexkit/opencode-magic-context-tui/package.json` — `oc-plugin: ["tui"]`, `exports["./tui"]: ./src/index.tsx`, opentui + solid-js as direct deps, `@opencode-ai/plugin` as peer.
 - `node_modules/@cortexkit/opencode-magic-context/src/server.js` — `node:http` server on `127.0.0.1`, port written to `~/.cache/opencode/<scope>/server-port.json`, JSON request/response routing.
 
 ### Institutional Learnings
 
-- `docs/solutions/best-practices/reliable-cli-integration-testing-2026-04-26.md` — `OPENCODE_CONFIG_DIR` + `OPENCODE_CONFIG_CONTENT` isolation pattern. Relevant if v0.2.0 adds an integration test that drives `opencode run` against the new plugin.
+- `docs/solutions/best-practices/reliable-cli-integration-testing-2026-04-26.md` — `OPENCODE_CONFIG_DIR` + `OPENCODE_CONFIG_CONTENT` isolation pattern. Relevant if this plan adds an integration test that drives `opencode run` against the new plugin.
 - `docs/solutions/developer-experience/opencode-debug-diagnostics-2026-04-26.md` — `--print-logs --log-level DEBUG` workflow.
 
 ### External References
@@ -108,7 +107,7 @@ Performance / compatibility success criteria from the origin doc:
 - **Constant-time auth comparison with length normalization.** `crypto.timingSafeEqual` throws when the two `Buffer`s have different lengths, so it cannot be invoked directly on the raw header value. Auth middleware: (1) parse the `Authorization` header; if absent OR not `Bearer`-scheme OR token-half is empty, return 401 immediately without any comparison call; (2) Buffer-encode both the presented token and the server-side token; if lengths differ, return 401 immediately (the length check itself is not constant-time, but neither length nor the absence/presence path leaks anything that wasn't already implicit in 401-vs-200); (3) only when lengths match, call `crypto.timingSafeEqual` for the constant-time compare. This avoids the unhandled exception path entirely while still defending the equal-length case against timing attacks.
 - **`0o600` permissions on the port file.** Written via `fs.writeFile(path, data, { mode: 0o600 })` and `fs.chmod(path, 0o600)` after atomic rename. Parent directory created with `0o700`. Other users on shared machines cannot read the token.
 - **JSON body parsing.** `node:http` does not parse request bodies. The Unit 3 server collects `data`/`end` chunks per request with a **streaming size guard**: each `data` event increments a running byte total; if the total exceeds 64KB, the server immediately responds 413 and aborts the request (`req.destroy()`) without buffering the rest. Only when `end` fires under the cap does the handler `JSON.parse` the joined buffer inside try/catch and validate against the Zod schema. Bad bodies → 400. Streaming the cap (vs checking after collection) prevents holding a 64KB+ buffer for any request that would be rejected anyway.
-- **Pull-only RPC for v0.2.0.** Brainstorm prerequisite #4. Server exposes `GET /health`, `POST /tasks/list`, `POST /tasks/cancel`. No notification poller in v0.2.0. Per-task event endpoint + push poller land in v0.2.1.
+- **Pull-only RPC in the foundation.** Brainstorm prerequisite #4. Server exposes `GET /health`, `POST /tasks/list`, `POST /tasks/cancel`. No notification poller in the foundation phase. Per-task event endpoint + push poller land with the drilled-view phase.
 - **Slash command registered from the TUI half.** Per Magic Context's working code; the brainstorm's note about server-side registration was based on a stale comment. TUI-side registration via `api.command.register` is correct because invoking `/copilot-status` without a TUI to render the dialog is meaningless. **Verify at implementation time** that the actual field name is `trigger` (per Magic Context's TS) vs `value` (per other docs) — the slash-command shape is the one TUI-API detail not directly verifiable from this repo's `node_modules`.
 - **Cancel-confirm via `api.ui.dialog.replace(<ConfirmCard />)`.** opentui has no `DialogConfirm` symbol. Implemented as a SolidJS card with two action buttons (`Cancel Task` destructive, `Keep Running` secondary). On `rpc.tasksCancel` failure, the card stays open and replaces its button row with an inline error message + a single `Dismiss` button. **Locked**: no toast fallback, no card-close-then-toast — inline-only.
 - **Cancel-helper extraction.** Unit 4 (not Unit 3) creates `src/runtime/cancel-helper.ts` exposing `cancelTaskById(taskId): { cancelled, error? }`. Both `createCancelTool` (existing) and the RPC `/tasks/cancel` handler (new) call into this single helper. The helper invokes `task.abortController.abort()`; the existing abort listener in `subprocess.ts` handles the actual kill via `killProcessTree`.
@@ -126,8 +125,8 @@ Performance / compatibility success criteria from the origin doc:
 - **`@opentui/*` dep posture** — direct deps (Magic Context precedent).
 - **Slash command registration side** — TUI-side, see Key Decisions.
 - **`DialogConfirm` symbol** — doesn't exist; use `dialog.replace(<ConfirmCard />)`.
-- **RPC routes for v0.2.0** — `GET /health`, `POST /tasks/list`, `POST /tasks/cancel`. No event endpoint until v0.2.1.
-- **PID-file lock strategy** — moot for v0.2.0 (PID file lives in the pre-TUI hardening plan).
+- **RPC routes in the foundation phase** — `GET /health`, `POST /tasks/list`, `POST /tasks/cancel`. No event endpoint until the drilled-view phase.
+- **PID-file lock strategy** — moot here (PID file lives in the runtime hardening plan).
 - **Server-side `Hooks` dispose presence** — confirmed absent in the installed SDK; cleanup wires to process exit signals.
 - **Confirm-card error UX branch** — locked to inline-error; see Key Decisions.
 - **Port file path discrimination** — per-session, see Key Decisions.
@@ -253,11 +252,11 @@ tests/
 - Add `exports["."]: { types: "./dist/index.d.ts", import: "./dist/index.js" }` (preserve current default-import semantics — required because once `exports` is present, Node ESM ignores `"main"`).
 - Add `exports["./plugin"]: { types: "./dist/index.d.ts", import: "./dist/index.js" }` (explicit alias for callers that want it).
 - Add `exports["./tui"]: { types: "./src/tui/index.tsx", import: "./src/tui/index.tsx" }`.
-- Add direct deps: `@opentui/core`, `@opentui/solid`, `solid-js`, `zod` (Zod is currently only a transitive dep via `@opencode-ai/plugin`; v0.2.0 uses it directly in `rpc-contract.ts` and must declare it).
+- Add direct deps: `@opentui/core`, `@opentui/solid`, `solid-js`, `zod` (Zod is currently only a transitive dep via `@opencode-ai/plugin`; this plan uses it directly in `rpc-contract.ts` and must declare it).
 - Pin to versions matching Magic Context's working baseline (`^0.1.40` for opentui, `^1.9.9` for solid-js); resolve actual versions at install time via `bun add`.
 - Bump `@opencode-ai/plugin` peer dep to match the host's bundled version.
 - Add per-file pragma support to `tsconfig.json` (`jsx: "preserve"` + `jsxImportSource: "@opentui/solid"`). **Implementation gate**: run `bun run typecheck` after Unit 5 adds the first `.tsx` file. If `tsc` fails to resolve JSX element types under `jsx: "preserve"` + per-file pragma, fall back to `jsx: "react-jsx"` and verify the runtime still loads. Document the chosen mode in `AGENTS.md`.
-- Single minor changeset for the whole v0.2.0 PR ("v0.2.0 foundation: TUI plugin half + RPC + spawn toast"), not per-unit.
+- Single minor changeset for the whole foundation PR ("TUI foundation: plugin half + RPC + spawn toast"), not per-unit.
 
 **Patterns to follow:**
 - Magic Context's TUI package.json `oc-plugin` + `exports` shape.
@@ -287,7 +286,7 @@ tests/
 
 **Approach:**
 - Export Zod schemas: `HealthResponseSchema`, `TasksListResponseSchema`, `TasksCancelRequestSchema`, `TasksCancelResponseSchema`, plus a `PortFileSchema` describing the on-disk shape (`{ port, pid, token }`).
-- `TasksListResponseSchema` carries: `{ tasks: Array<{ taskId, status, agent, model, elapsedMs, toolCallCount, startedAt }> }`. Status enum is `"running"` only in v0.2.0 (the running-only rule); add other variants now to make v0.2.1 a no-schema-change addition.
+- `TasksListResponseSchema` carries: `{ tasks: Array<{ taskId, status, agent, model, elapsedMs, toolCallCount, startedAt }> }`. Status enum is `"running"` only in the foundation phase (the running-only rule); add other variants now to make the drilled-view phase a no-schema-change addition.
 - `TasksCancelRequestSchema`: `{ taskId: string }` with `cpl_*` prefix regex.
 - `TasksCancelResponseSchema`: `{ cancelled: boolean, error?: string }`.
 - Export inferred TS types via `z.infer`.
@@ -472,7 +471,7 @@ tests/
 
 **Approach:**
 - Stateful SolidJS component. On mount, calls `rpc.tasksList()` (Unit 5). State machine: `loading` → (`populated` | `empty` | `error`).
-- **Header**: `<n> running · 0 recent` (recent count is always 0 in v0.2.0; field reserved for v0.2.2). During loading, header reads `Loading delegations…` instead. During error, header reads `Status unavailable.`. The header component is owned by the modal-list root, not by the per-state child components — this keeps header behavior consistent across states.
+- **Header**: `<n> running · 0 recent` (recent count is always 0 in the foundation phase; field reserved for the third phase). During loading, header reads `Loading delegations…` instead. During error, header reads `Status unavailable.`. The header component is owned by the modal-list root, not by the per-state child components — this keeps header behavior consistent across states.
 - Row: 6 columns from the brainstorm spec; status badge `●` prefix when `running`; focused row uses inverse video.
 - **Footer**: persistent across all states. Empty/error states show `Esc close`. Populated state shows `↑↓ navigate · c cancel · Esc close`. (Brainstorm specifies `Esc close` for empty/error; populated state's footer is a small affordance addition.)
 - Keybind handler via opentui's input subscription:
@@ -561,9 +560,10 @@ tests/
 
 ## Definition of Done (PR housekeeping; not a planning unit)
 
-These updates ride with the v0.2.0 implementation PR but are not numbered units (per scope-guardian's recommendation that pure docs not be elevated to planning-unit status):
+These updates ride with the foundation implementation PR but are not numbered units (per scope-guardian's recommendation that pure docs not be elevated to planning-unit status):
 
-- **README.md**: under Known Limitations, add the v0.2.0 entries for the architectural commit (TUI half opt-in via `tui.jsonc`, RPC server posture). Note the upstream-issue link for the dispose-hook workaround once filed.
+- **README.md**: under Known Limitations, add the foundation-release entries for the architectural commit (TUI half opt-in via `tui.jsonc`, RPC server posture). Note the upstream-issue link for the dispose-hook workaround once filed.
+
 - **README.md**: new section "Optional: install the TUI half" with one-paragraph instructions for adding `opencode-copilot-delegate` to the user's `tui.jsonc`.
 - **AGENTS.md**: extend the architecture tree to include `src/tui/`, `src/runtime/rpc-server.ts`, `src/runtime/cancel-helper.ts`. Add a one-paragraph "Two-entrypoint architecture" subsection explaining the server/TUI split.
 - **AGENTS.md**: document the resolved `tsconfig.json` JSX mode (`jsx: "preserve"` + per-file pragma if it works, else `jsx: "react-jsx"`) and the resolved `api.command.register` field (`trigger` vs `value`).
@@ -574,7 +574,7 @@ These updates ride with the v0.2.0 implementation PR but are not numbered units 
 - **Error propagation:** RPC errors are typed (`RpcUnreachableError`, `RpcServerError`, `RpcAuthError`, `RpcValidationError`) and surfaced as the modal's error state or the confirm-card's inline-error branch.
 - **State lifecycle risks:** Per-session port file is the new shared state. Per-session path eliminates the cross-session collision class. Cleanup runs best-effort on `beforeExit`/`SIGTERM`; the pre-TUI hardening plan's reaper covers misses.
 - **API surface parity:** No change to existing tools' return shapes or error contracts. `copilot_delegate` adds one fire-and-forget toast call. `copilot_cancel` is functionally unchanged but factored through `cancel-helper` so the RPC handler can share the path.
-- **Integration coverage:** Unit 3's "Integration" scenario exercises the cross-layer flow `RPC → cancel-helper → abortController → killProcessTree`. Unit 4's "Integration (cancel parity)" verifies tool and RPC paths produce identical observable behavior. End-to-end TUI testing (modal → keybind → RPC → kill) requires a running OpenCode TUI runtime; manual verification at implementation time, no automated end-to-end test in v0.2.0.
+- **Integration coverage:** Unit 3's "Integration" scenario exercises the cross-layer flow `RPC → cancel-helper → abortController → killProcessTree`. Unit 4's "Integration (cancel parity)" verifies tool and RPC paths produce identical observable behavior. End-to-end TUI testing (modal → keybind → RPC → kill) requires a running OpenCode TUI runtime; manual verification at implementation time, no automated end-to-end test in the foundation phase.
 - **Unchanged invariants:** `task-registry.ts`'s `MAX_CONCURRENT` cap, the `cpl_` task ID prefix, the `notifyCompletion` shape, the `client.session.prompt({ noReply, ... })` system-reminder API, the existing `bun build` artifact shape (`dist/index.js` only), the `dist/` build does not include TUI source.
 
 ## Risks & Dependencies
@@ -591,7 +591,7 @@ These updates ride with the v0.2.0 implementation PR but are not numbered units 
 | Cross-session token theft if port-file 0o600 perms regress | Test asserts `mode === 0o600` after write (Unit 3). Auth token defense-in-depth: even if perms regress, an attacker still needs the token to make calls. |
 | Spawn-toast queue saturation at 10 concurrent delegations | Unverified; OpenCode's toast implementation may rate-limit. Implementation-time observation: if toasts drop, batch via a debounce. |
 | Transitive dep conflicts from `@opentui/*` + `solid-js` | Verify at `bun add` time (Unit 1). If conflicts, escalate before downstream units begin. |
-| Cancel-from-UI race with stdout buffer (post-kill JSONL events appended to registry) | Closed by the parser-status guard in the pre-TUI hardening plan; v0.2.0 assumes that's already shipped. |
+| Cancel-from-UI race with stdout buffer (post-kill JSONL events appended to registry) | Closed by the parser-status guard in the runtime hardening plan; this plan assumes that's already shipped. |
 | Modal interferes with active OpenCode work | Modal does not block input to the underlying session; Esc returns instantly. |
 | OpenCode `Hooks` interface lacks dispose; cleanup is best-effort | `process.on('beforeExit'/'SIGTERM')` covers normal exits. Reaper covers SIGKILL leftovers. Upstream-issue follow-up to retire the workaround when a dispose hook lands. |
 
@@ -602,7 +602,7 @@ See "Definition of Done" above. CHANGELOG is generated automatically by changese
 ## Sources & References
 
 - **Origin document:** [docs/brainstorms/2026-04-27-copilot-status-tui-requirements.md](../brainstorms/2026-04-27-copilot-status-tui-requirements.md)
-- **Prerequisite plan:** [docs/plans/2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md](2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md)
+- **Prerequisite plan:** [docs/plans/2026-04-27-002-fix-runtime-hardening-plan.md](2026-04-27-002-fix-runtime-hardening-plan.md)
 - Related brainstorm research: [docs/research/copilot-cli-capabilities-2026-04-27.md](../research/copilot-cli-capabilities-2026-04-27.md)
 - Related ideation: [docs/ideation/2026-04-27-copilot-delegate-v0.2.md](../ideation/2026-04-27-copilot-delegate-v0.2.md) (S1)
 - Closed plan it builds on: [docs/plans/2026-04-21-copilot-delegate-plugin.md](2026-04-21-copilot-delegate-plugin.md)

--- a/docs/plans/2026-04-27-002-fix-runtime-hardening-plan.md
+++ b/docs/plans/2026-04-27-002-fix-runtime-hardening-plan.md
@@ -1,24 +1,24 @@
 ---
-title: "fix: pre-TUI runtime hardening (orphan reaper + cancel-race parser guard)"
+title: "fix: runtime hardening (orphan reaper + cancel-race parser guard)"
 type: fix
-status: active
+status: completed
 date: 2026-04-27
 deepened: 2026-04-27
+completed: 2026-04-28
 origin: docs/brainstorms/2026-04-27-copilot-status-tui-requirements.md
-target_release: v0.1.1
 follow_up_plan: docs/plans/2026-04-27-001-feat-copilot-status-tui-foundation-plan.md
 ---
 
-# fix: pre-TUI runtime hardening (orphan reaper + cancel-race parser guard)
+# fix: runtime hardening (orphan reaper + cancel-race parser guard)
 
 ## Overview
 
-Two existing-runtime correctness fixes that ship as a v0.1.1 patch ahead of the v0.2.0 TUI foundation:
+Two existing-runtime correctness fixes that ship as a runtime hardening patch ahead of the TUI foundation:
 
 1. **PID-file orphan reaper** — closes the case where Copilot subprocesses survive plugin reload because the OpenCode `Hooks` interface has no dispose hook. Server reads a PID file at init time and reaps any survivors before resuming normal operation.
 2. **Parser cancel-race guard** — closes a real bug in the existing JSONL stdout handler that allows post-cancel events to mutate the task registry. The fix is a single-line guard at the top of the inline data handler.
 
-Both are correctness fixes, not features. They surfaced during planning for the v0.2.0 TUI work but are independent of the TUI architecture and worth shipping on their own. Splitting them out keeps the v0.2.0 PR focused on TUI scope and gives each fix a clean review/merge cycle.
+Both are correctness fixes, not features. They surfaced during planning for the TUI foundation work but are independent of the TUI architecture and worth shipping on their own. Splitting them out keeps the TUI PR focused on its scope and gives each fix a clean review/merge cycle.
 
 ## Problem Frame
 
@@ -26,24 +26,24 @@ Both are correctness fixes, not features. They surfaced during planning for the 
 
 **Cancel-race parser guard**: When `copilot_cancel` is invoked, `task.abortController.abort()` synchronously sets `task.status = 'cancelled'` and asynchronously kills the subprocess. Between the kill signal and the actual stream close, the child process's stdout buffer may still contain unread JSONL lines. The current inline data handler in `src/runtime/subprocess.ts` (an anonymous `child.stdout?.on('data', ...)` callback inside `spawnCopilot`) does not check `task.status` before pushing parsed events onto `task.events`. Result: events from a cancelled task continue to accumulate in the registry until the stream actually closes — observable as `copilot_output cpl_xxx` returning events recorded after the cancel timestamp.
 
-Both bugs predate the v0.2.0 TUI work. They were identified during planning for that plan but neither requires the TUI architecture to fix.
+Both bugs predate the TUI work. They were identified during planning for that plan but neither requires the TUI architecture to fix.
 
 ## Requirements Trace
 
 - **R1** (orphan reaper) — On plugin init, read the PID file at `<XDG_STATE_HOME or ~/.local/state>/opencode-copilot-delegate/orphans.pids`. For each entry: probe liveness (`process.kill(pid, 0)`), compare recorded start time against live `ps -p <pid> -o lstart=` output, and `killProcessTree(pid)` only when the live process is the same one originally tracked. Persist append on task spawn; persist remove on terminal transition. (origin: `docs/brainstorms/2026-04-27-copilot-status-tui-requirements.md` §"Prerequisites for ce:plan" #3)
-- **R2** (parser guard) — In the `child.stdout?.on('data', ...)` callback inside `spawnCopilot`, skip event-push and registry mutation when `task.status !== 'running'`. The single-threaded JS execution model means the guard at the top of the line-loop closes the race for all subsequent events in this and future `data` ticks. (origin: planning pass on the v0.2.0 plan; see commentary in the v0.2.0 follow-up plan's deferred-tasks section)
+- **R2** (parser guard) — In the `child.stdout?.on('data', ...)` callback inside `spawnCopilot`, skip event-push and registry mutation when `task.status !== 'running'`. The single-threaded JS execution model means the guard at the top of the line-loop closes the race for all subsequent events in this and future `data` ticks. (origin: planning pass on the TUI foundation plan; see commentary in the follow-up plan's deferred-tasks section)
 
 ## Scope Boundaries
 
 - **No new public API surface.** PID file path is internal. Parser guard is invisible to consumers.
 - **No changes to existing tool inputs or outputs.** `copilot_delegate`, `copilot_output`, `copilot_cancel` keep their current shapes.
-- **No RPC server, no TUI, no slash commands.** Those are v0.2.0.
+- **No RPC server, no TUI, no slash commands.** Those are scope of the follow-up TUI plan.
 - **No new dependencies.** `node:fs`, `node:child_process`, `node:os` only.
 - **No Windows support beyond what's already there.** The reaper uses POSIX `process.kill(pid, 0)` and the `ps` shell-out, both Unix-only — same constraint as the existing `kill-tree.ts`.
 
 ### Deferred to Separate Tasks
 
-- **Upstream lifecycle-hook feature request to `anomalyco/opencode`** — file alongside this v0.1.1 PR with a code TODO pointing at the issue. The reaper retires when upstream lands a dispose hook.
+- **Upstream lifecycle-hook feature request to `anomalyco/opencode`** — file alongside this hardening PR with a code TODO pointing at the issue. The reaper retires when upstream lands a dispose hook.
 
 ## Context & Research
 
@@ -60,19 +60,19 @@ Both bugs predate the v0.2.0 TUI work. They were identified during planning for 
 
 ## Key Technical Decisions
 
-- **PID file location (per-instance, keyed on plugin process PID)**: `<XDG_STATE_HOME or ~/.local/state>/opencode-copilot-delegate/orphans/<plugin-pid>.pids`, where `<plugin-pid>` is `String(process.pid)` (the plugin host process PID at startup). v0.1.1 deliberately keys on PID rather than `OPENCODE_SESSION_ID` because the reaper needs a directly **probeable spawner-liveness signal** at scan time — see the spawner-liveness gate below. Two concurrent OpenCode sessions each load the plugin in their own host process and naturally get different PIDs, so per-instance isolation is preserved without requiring session env vars. (v0.2.0's port file uses `OPENCODE_SESSION_ID` because its consumer needs session-aware lookup, not liveness probing — different requirement, different key.) Plain text, line-delimited, format `<pid>\t<comm>\t<lstart>` (tab-separated; the `comm` value is the kernel-tracked executable name from `ps -o comm=` and is the kill-gate identity check). Parent directory `<state-dir>/orphans/` created with `0o700`; per-instance files created with `0o600`. **Per-instance keying eliminates the cross-instance file-clobbering risk** that a single shared `orphans.pids` file would create — concurrent OpenCode sessions each read/write/truncate only their own file.
+- **PID file location (per-instance, keyed on plugin process PID)**: `<XDG_STATE_HOME or ~/.local/state>/opencode-copilot-delegate/orphans/<plugin-pid>.pids`, where `<plugin-pid>` is `String(process.pid)` (the plugin host process PID at startup). this plan deliberately keys on PID rather than `OPENCODE_SESSION_ID` because the reaper needs a directly **probeable spawner-liveness signal** at scan time — see the spawner-liveness gate below. Two concurrent OpenCode sessions each load the plugin in their own host process and naturally get different PIDs, so per-instance isolation is preserved without requiring session env vars. (the TUI foundation plan's port file uses `OPENCODE_SESSION_ID` because its consumer needs session-aware lookup, not liveness probing — different requirement, different key.) Plain text, line-delimited, format `<pid>\t<comm>\t<lstart>` (tab-separated; the `comm` value is the kernel-tracked executable name from `ps -o comm=` and is the kill-gate identity check). Parent directory `<state-dir>/orphans/` created with `0o700`; per-instance files created with `0o600`. **Per-instance keying eliminates the cross-instance file-clobbering risk** that a single shared `orphans.pids` file would create — concurrent OpenCode sessions each read/write/truncate only their own file.
 - **Start-time source for the recorded value**: at task spawn, immediately invoke `ps -p <pid> -o lstart=` (array-spawn, no shell) and store the returned string verbatim alongside `comm`. This guarantees the recorded value matches the format `ps` will return at reap time. (Do **not** use `task.startedAt` epoch ms — `ps` and `Date.now()` produce incomparable strings.)
 - **`ps` invocation**: `child_process.spawn('ps', ['-p', String(pid), '-o', '<field>='])` with no shell, where `<field>` is `lstart`, `comm`, or (for diagnostic logging) `args`. Eliminates command-injection risk if the PID file is malformed.
 - **PID file write strategy**: `node:fs` `O_EXCL` temp-file + atomic `rename` for both append and remove. No new dep. **Per-instance keying means single-writer per file** — there is no cross-instance contention, and within an instance a process-local serialization queue (a `Promise` chain in `pid-file.ts`) orders concurrent appends/removes from the existing `MAX_CONCURRENT = 10` task lifecycle without needing a `proper-lockfile`-style cross-process lock. The combination guarantees no lost appends, no torn writes, and idempotent removal. The flag constant lives in `fs.constants.O_EXCL` (not `os.constants`).
 - **PID-validate-before-kill (executable identity, exact `comm` match)**: Before invoking `killProcessTree(pid)`, validate that the process's kernel-tracked executable name from `ps -p <pid> -o comm=` (array-spawn, exact-string compare) matches the `<comm>` value recorded at spawn time. `comm` returns the binary name only — no arguments, no full path — which closes the false-positive class where a process's `args` happens to contain the substring `copilot` (e.g., `cat /tmp/copilot-output.log`, a manually-invoked GitHub Copilot CLI command running on the same host, or a shell script with `copilot` in its path or argv). Combined with the start-time match, the kill gate requires (live PID = recorded PID) AND (live comm = recorded comm) AND (live lstart = recorded lstart) — collisions are statistically impossible without deliberate forging, and forging requires write access to a 0o600 PID file inside a 0o700 directory.
-- **Reap sequencing (awaited)**: Reap runs **awaited** inside the plugin factory, before the factory returns its `Hooks` object. The SDK's `Plugin = (input) => MaybePromise<Hooks>` contract guarantees the host won't dispatch tools until the factory resolves, so a same-instance "tool-call-before-reap-finishes" race cannot occur. v0.2.0's RPC server starts after this completes; v0.1.1 has no RPC server. **Implementation note**: wrap the reap call in try/catch — reap failure must never block plugin init.
+- **Reap sequencing (awaited)**: Reap runs **awaited** inside the plugin factory, before the factory returns its `Hooks` object. The SDK's `Plugin = (input) => MaybePromise<Hooks>` contract guarantees the host won't dispatch tools until the factory resolves, so a same-instance "tool-call-before-reap-finishes" race cannot occur. The TUI foundation plan's RPC server starts after this completes; this plan has no RPC server. **Implementation note**: wrap the reap call in try/catch — reap failure must never block plugin init.
 - **Reap latency budget (parallel probes)**: At `MAX_CONCURRENT = 10` historical entries across all `<state-dir>/orphans/*.pids` files, naive sequential per-PID `ps` shellouts could take 0.5-3s — unacceptable for plugin init. Reap probes run **in parallel with a small concurrency cap** (`Promise.all` over up to 5 simultaneous workers; each worker handles its assigned PIDs sequentially: liveness probe → `comm` check → `lstart` check → optional `killProcessTree`). Soft target: total reap time under 200ms at full cap on a typical macOS dev host. Verified by Unit 2's smoke test.
 - **Reap directory scan + spawner-liveness gate**: Reaper scans **all `*.pids` files** in `<state-dir>/orphans/` so survivors from previous plugin instances are recovered. For each foreign file (filename PID ≠ our `process.pid`), the reaper extracts the owning plugin's PID from the filename and probes `process.kill(<plugin-pid>, 0)`:
   - **Alive** (call succeeds) or **`EPERM`** (process exists but we lack signal permission — still counts as alive): skip the entire file. The owning plugin is still tracking those subprocesses; killing them would break a running session. The identity gate alone is insufficient for foreign files: a live foreign instance's subprocesses would pass the `comm`+`lstart` gate (they ARE legitimate copilot subprocesses) and be wrongly killed.
   - **Dead** (`ESRCH`): proceed with per-entry reap. After processing, **delete the file** — the owning plugin is gone, and bounded directory growth is the desirable hygiene property here.
   - **Current instance's own file** (filename matches `String(process.pid)`): processed unconditionally; truncated/recreated post-reap. We know our own plugin is alive; we want to clean entries from subprocesses that died while the plugin was loaded but before reap fired.
 - **Parser guard placement**: In `spawnCopilot`, at the top of the existing inline `child.stdout?.on('data', (chunk: string) => { ... })` handler. Inside the `for (const line of lines)` loop, the guard goes **before** `parseJsonlLine(line)` (not before `events.push(event)`) so a cancelled task does not pay the parse cost on already-buffered lines: `if (task.status !== 'running') break;`. The partial-line buffer update (`lines.pop()`) runs *before* the loop, so `break` and `return` would behave identically here — `break` is preferred for clarity. Single-threaded JS guarantees the guard is checked synchronously with every iteration, with no interleaving possible.
-- **Status-mutation refactor (terminal-state-preserving)**: The current `src/runtime/subprocess.ts` mutates `task.status` inline at three sites — line 59 (`finalizeTask`, on subprocess `close` event), line 143 (abort listener), and line 153 (spawn `error` event). v0.1.1 introduces a `setStatus(task, newStatus, options?)` helper that wraps the assignment and the `removePidEntry` cleanup as a single atomic-from-the-caller's-perspective operation. **The helper is idempotent on terminal state**: if `task.status` is already terminal (`complete | failed | cancelled`) and `newStatus` is also terminal, `setStatus` no-ops and returns. This preserves the existing `finalizeTask` invariant `if (task.status !== 'cancelled') task.status = ...` automatically: when the subprocess `close` event fires after the abort listener has already set `cancelled`, `setStatus(task, 'complete' | 'failed', ...)` is a no-op. Future contributors don't need to remember the guard. The three sites become `setStatus(task, 'complete' | 'failed' | 'cancelled', { pidFilePath })` calls. Centralizes lifecycle plumbing, prevents the cleanup hook from being forgotten, and gives Unit 4's parser guard a stable invariant to read.
+- **Status-mutation refactor (terminal-state-preserving)**: The current `src/runtime/subprocess.ts` mutates `task.status` inline at three sites — line 59 (`finalizeTask`, on subprocess `close` event), line 143 (abort listener), and line 153 (spawn `error` event). This plan introduces a `setStatus(task, newStatus, options?)` helper that wraps the assignment and the `removePidEntry` cleanup as a single atomic-from-the-caller's-perspective operation. **The helper is idempotent on terminal state**: if `task.status` is already terminal (`complete | failed | cancelled`) and `newStatus` is also terminal, `setStatus` no-ops and returns. This preserves the existing `finalizeTask` invariant `if (task.status !== 'cancelled') task.status = ...` automatically: when the subprocess `close` event fires after the abort listener has already set `cancelled`, `setStatus(task, 'complete' | 'failed', ...)` is a no-op. Future contributors don't need to remember the guard. The three sites become `setStatus(task, 'complete' | 'failed' | 'cancelled', { pidFilePath })` calls. Centralizes lifecycle plumbing, prevents the cleanup hook from being forgotten, and gives Unit 4's parser guard a stable invariant to read.
 
 ## Open Questions
 
@@ -86,7 +86,7 @@ Both bugs predate the v0.2.0 TUI work. They were identified during planning for 
 ### Resolved During Deepening Pass (2026-04-27)
 
 - **Per-instance PID files vs single shared file**: shared `orphans.pids` was a real cross-instance integrity hole (one OpenCode session's end-of-reap truncate could wipe a live PID written by another session). Resolved to per-instance files at `<state-dir>/orphans/<plugin-pid>.pids`. The reaper scans the whole directory.
-- **Discriminator choice (PID, not session ID)**: keying the v0.1.1 PID file on `process.pid` rather than `OPENCODE_SESSION_ID` is intentional — the reaper needs spawner-liveness probing, and PID is directly probeable via `process.kill(pid, 0)` whereas session IDs are not. v0.2.0's port file keys on session ID for a different reason (consumer-side session lookup).
+- **Discriminator choice (PID, not session ID)**: keying this plan's PID file on `process.pid` rather than `OPENCODE_SESSION_ID` is intentional — the reaper needs spawner-liveness probing, and PID is directly probeable via `process.kill(pid, 0)` whereas session IDs are not. the TUI foundation plan's port file keys on session ID for a different reason (consumer-side session lookup).
 - **Spawner-liveness gate (foreign files)**: the identity gate alone (exact `comm` + `lstart` match) cannot distinguish "OUR live child" from "a live foreign instance's child whose recorded identity happens to match" — a foreign live instance's subprocesses would pass the gate and be wrongly killed. Resolved by adding a per-file spawner-liveness probe: alive foreign spawner → skip file entirely; dead foreign spawner → reap entries and delete the file. Side benefit: bounds directory growth without a separate cleanup policy.
 - **Reap blocking init**: keeping reap awaited inside the factory is correct (the SDK contract guarantees no tool dispatch until the factory resolves). The acceptability concern is latency, not sequencing. Resolved by parallelizing per-PID probes with a concurrency cap of 5; soft 200ms target at full cap.
 - **Status-mutation refactor (terminal-preserving)**: three inline sites in `subprocess.ts` (lines 59, 143, 153) become a single `setStatus` helper that no-ops when transitioning between terminal states. Preserves the existing `finalizeTask` `if (task.status !== 'cancelled')` invariant automatically; future contributors can't drop it accidentally.
@@ -310,9 +310,9 @@ tests/
 
 ## Definition of Done (PR housekeeping; not a planning unit)
 
-- **README.md**: under Known Limitations, update the "PID-file reaper: planned for v1.x" entry to reflect v0.1.1 shipping. Add a one-line note about POSIX `ps` dependency.
+- **README.md**: under Known Limitations, update the "PID-file reaper: planned for v1.x" entry to reflect that the reaper has shipped. Add a one-line note about POSIX `ps` dependency.
 - **AGENTS.md**: extend the architecture tree to include `src/runtime/orphan-reaper.ts` and `src/runtime/pid-file.ts`. One sentence on the reaper's init-time sequencing.
-- **Single patch changeset for the v0.1.1 PR.** (Patch bump in the unstable `0.x` series for a behavior-preserving correctness fix; `minor` is reserved for new features under the repo policy.)
+- **Single minor changeset for this PR.** (Per repo policy: `minor` bump for the unstable `0.x` series.)
 
 ## System-Wide Impact
 

--- a/docs/solutions/best-practices/atomic-file-append-remove-o-excl-temp-file-2026-04-28.md
+++ b/docs/solutions/best-practices/atomic-file-append-remove-o-excl-temp-file-2026-04-28.md
@@ -1,0 +1,259 @@
+---
+title: Atomic File Append/Remove with O_EXCL Temp-File and In-Process Serialization Queue
+date: 2026-04-28
+category: best-practices
+module: file_operations
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Implementing atomic file mutations
+  - Handling concurrent appends to shared files
+  - Ensuring crash-safe PID file writes
+  - Avoiding race conditions without locks
+tags:
+  - atomic-writes
+  - file-serialization
+  - temp-files
+  - o-excl
+  - crash-safety
+  - in-process-queue
+---
+
+# Atomic File Append/Remove with O_EXCL Temp-File and In-Process Serialization Queue
+
+## Context
+
+The orphan reaper needs a tiny durable ledger of child processes so cleanup can survive crashes and restarts. A naive "just append a line" implementation is fine until several spawn paths try to mutate the same PID file at nearly the same time, at which point you can get torn writes, lost updates, or truncated rewrites. `proper-lockfile` would solve a broader class of problems, but for a per-instance PID file owned by one process, that's heavier than the problem warrants.
+
+This fix uses two cheaper guarantees together: atomic replace at the filesystem level, and per-file serialization at the application level. The result is a small dependency-free pattern that is easy to audit and hard to corrupt.
+
+## Guidance
+
+Use a per-target in-process queue to serialize all read-modify-write mutations, then make each mutation itself atomic by writing the full next file image to a unique temp file and `rename()`-ing it into place. In this repo, the queue is keyed by absolute file path in `writeChains`, and both append and remove operations run through the same helper (`src/runtime/pid-file.ts:15-30`).
+
+```ts
+// src/runtime/pid-file.ts:15-30
+const writeChains = new Map<string, Promise<void>>()
+
+async function serializeWrite(
+  filePath: string,
+  work: () => Promise<void>,
+): Promise<void> {
+  const prev = writeChains.get(filePath) ?? Promise.resolve()
+  const next = prev.catch(() => {}).then(work)
+  writeChains.set(filePath, next)
+  try {
+    await next
+  } finally {
+    if (writeChains.get(filePath) === next) {
+      writeChains.delete(filePath)
+    }
+  }
+}
+```
+
+That cleanup check is the important invariant: only delete the map entry if the promise you just awaited is still the current tail for that path. Without that guard, one caller could finish and erase a newer chain entry created by another caller, reopening the race you were trying to close.
+
+The append path is a straight read-modify-write. It reads the current file if present, appends one tab-delimited line, writes the entire new content to a random temp path opened with exclusive-create semantics, then atomically renames the temp file over the target (`src/runtime/pid-file.ts:44-77`).
+
+```ts
+// src/runtime/pid-file.ts:50-76
+await serializeWrite(filePath, async () => {
+  await mkdir(dirname(filePath), { recursive: true, mode: 0o700 })
+
+  let existing = ''
+  try {
+    existing = await readFile(filePath, 'utf-8')
+  } catch (e) {
+    if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
+  }
+
+  const line = `${pid}\t${comm}\t${lstart}\n`
+  const content = existing + line
+  const tempPath = `${filePath}.tmp.${randomBytes(8).toString('hex')}`
+  const fd = await open(
+    tempPath,
+    fsConstants.O_EXCL | fsConstants.O_CREAT | fsConstants.O_WRONLY,
+    0o600,
+  )
+  // ...
+  await rename(tempPath, filePath)
+  await chmod(filePath, 0o600)
+})
+```
+
+The remove path uses the exact same structure: read the whole file, filter out the matching PID line, write the replacement image to a unique temp file, rename over the original, and delete the file entirely if it becomes empty (`src/runtime/pid-file.ts:80-120`).
+
+```ts
+// src/runtime/pid-file.ts:84-119
+await serializeWrite(filePath, async () => {
+  let existing = ''
+  try {
+    existing = await readFile(filePath, 'utf-8')
+  } catch (e) {
+    if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
+    return
+  }
+
+  const prefix = `${pid}\t`
+  const lines = existing.split('\n')
+  const filtered = lines.filter((line) => !line.startsWith(prefix))
+  if (filtered.length === lines.length) return
+
+  const content = filtered.join('\n')
+  const tempPath = `${filePath}.tmp.${randomBytes(8).toString('hex')}`
+  // ...
+  await rename(tempPath, filePath)
+  await chmod(filePath, 0o600)
+
+  if (content.trim().length === 0) {
+    await unlink(filePath)
+  }
+})
+```
+
+Per-instance keying is what makes the in-process queue sufficient here. The PID file path includes the current process ID, so each running plugin instance owns its own file instead of many processes contending on one shared ledger (`src/runtime/pid-file.ts:33-41`).
+
+```ts
+// src/runtime/pid-file.ts:33-41
+export function resolveInstancePidFilePath(): string {
+  const stateDir =
+    process.env.XDG_STATE_HOME ?? join(homedir(), '.local', 'state')
+  return join(
+    stateDir,
+    'opencode-copilot-delegate',
+    'orphans',
+    `${process.pid}.pids`,
+  )
+}
+```
+
+The visible test coverage in this checkout validates the queue behavior directly by firing ten concurrent appends and asserting that the final file contains exactly ten well-formed entries with unique PIDs (`tests/pid-file.test.ts:179-211`). That is the application-level guarantee you care about: concurrent callers do not stomp each other's read step.
+
+```ts
+// tests/pid-file.test.ts:179-211
+describe('concurrency', () => {
+  it('should serialize 10 concurrent appends into exactly 10 entries', async () => {
+    const triples = Array.from({ length: 10 }, (_, i) => ({
+      pid: 1000 + i,
+      comm: `proc-${i}`,
+      lstart: `time-${i}`,
+    }))
+
+    await Promise.all(
+      triples.map((t) => appendPidEntry(filePath, t.pid, t.comm, t.lstart)),
+    )
+
+    expect(lines).toHaveLength(10)
+    expect(pids.size).toBe(10)
+  })
+})
+```
+
+> Note: `O_EXCL` lives in the `fs` constants namespace, not `os.constants`. In this implementation it is accessed as `fsConstants.O_EXCL` via the `node:fs/promises` constants export (`src/runtime/pid-file.ts:64-67`, `103-106`). `os.constants.O_EXCL` is the sharp edge here: it is not the right source, and code that composes flags from `os.constants` will quietly do the wrong thing.
+
+> Source note: the current `tests/pid-file.test.ts` in this repo snapshot clearly covers concurrent-write determinism, but separate crash-mid-write or `EEXIST` tests are not present in that file. The crash and exclusive-create semantics below are therefore derived from the implementation itself, not quoted from missing test cases.
+
+## Why This Matters
+
+Naive direct append code fails in two ways once concurrency shows up: writes can interleave at byte boundaries, and any later remove operation forces a read-modify-write cycle that can drop updates if two callers read the same old content. Writing the full next state to a temp file and renaming it means readers either get the old complete file or the new complete file, never a half-written target. The in-process queue handles the other half of the problem by ordering the read step, so caller B cannot compute its new content from stale state while caller A is already mid-update.
+
+`proper-lockfile` is overkill here because the scope is tiny: one small text file, one process owns it, and the cost of serializing in memory is near zero. The per-instance filename (`${process.pid}.pids`) removes cross-process contention by design, so there is no need to reach for fcntl-style coordination or a heavier dependency just to protect one process from itself.
+
+## When to Apply
+
+- Small line-delimited state files where the whole file is comfortably rewritten on each mutation.
+- All writers are in the same process, or you otherwise know a single process owns a given target path.
+- Correctness and crash safety matter more than raw append throughput.
+- You want a boring solution with no native locking dependency and no extra package surface.
+
+## When NOT to Apply
+
+- Multiple processes can mutate the same file path. Use a real cross-process lock or move the state into sqlite/WAL.
+- The file is append-heavy or large enough that full rewrite-on-each-mutation becomes a bottleneck.
+- The target may live on filesystems where `rename()` atomicity or `O_EXCL` behavior is weak or inconsistent, such as some NFS/FUSE setups.
+
+## Examples
+
+### Before: naive direct append
+
+A naive implementation treats each spawn event as "just append one line." That looks harmless until two writers overlap and the underlying writes are not observed as one indivisible record append.
+
+```ts
+// before: illustrative naive pattern
+import { appendFile } from 'node:fs/promises'
+
+async function recordSpawn(filePath: string, pid: number, comm: string, lstart: string) {
+  const line = `${pid}\t${comm}\t${lstart}\n`
+  await appendFile(filePath, line, 'utf8')
+}
+
+await Promise.all([
+  recordSpawn(pidFile, 101, 'copilot', 'T1'),
+  recordSpawn(pidFile, 102, 'copilot', 'T2'),
+])
+```
+
+Possible corruption mode from overlapping appends:
+
+```text
+101\tcopi102\tcopilot\tT2
+lot\tT1
+```
+
+Even if you dodge byte-level tearing, the minute you also need removal, you tend to graduate into naive concurrent read-modify-write:
+
+```ts
+// before: illustrative lost-update pattern
+async function removePidNaive(filePath: string, pid: number) {
+  const existing = await readFile(filePath, 'utf8')
+  const next = existing
+    .split('\n')
+    .filter((line) => !line.startsWith(`${pid}\t`))
+    .join('\n')
+  await writeFile(filePath, next, 'utf8')
+}
+```
+
+Now the failure mode is stale reads:
+
+1. append A reads old file
+2. append B reads same old file
+3. append A writes `old + A`
+4. append B writes `old + B`
+
+Final state: A disappears.
+
+### After: queued read-modify-write + atomic replace
+
+The shipped pattern makes each mutation compute the next full file image in order, then publish that image atomically.
+
+```ts
+await Promise.all([
+  appendPidEntry(pidFile, 101, 'copilot', 'T1'),
+  appendPidEntry(pidFile, 102, 'copilot', 'T2'),
+])
+```
+
+What happens instead:
+
+1. caller A enters `serializeWrite(pidFile, ...)`
+2. caller B chains behind A in `writeChains`
+3. A reads current content, writes temp file, renames into place
+4. B reads A's finished result, writes its own temp file, renames into place
+
+Final file:
+
+```text
+101\tcopilot\tT1
+102\tcopilot\tT2
+```
+
+No partial target file is ever published because `rename()` swaps in a completed temp file, and a crash before `rename()` leaves at worst an orphaned `*.tmp.<hex>` file. The repo's concurrency test captures the ordering guarantee in bulk by launching ten concurrent appends and asserting ten intact records, not a corrupted subset (`tests/pid-file.test.ts:179-211`).
+
+## Related
+
+- See [Per-instance PID files with spawner-liveness gating](per-instance-pid-files-spawner-liveness-gating-2026-04-28.md) for the file naming scheme that makes the in-process queue sufficient.
+- See [Centralized terminal-state idempotency for task lifecycle](centralized-terminal-state-idempotency-task-lifecycle-2026-04-28.md) for the cleanup hook that triggers `removePidEntry` calls.
+- Tracking issue: [#49 — v0.1.x / v0.2.x runtime hardening follow-ups](https://github.com/marcusrbrown/opencode-copilot-delegate/issues/49) (symlink hardening / `O_NOFOLLOW`, `chmod`-after-rename redundancy)

--- a/docs/solutions/best-practices/bounded-concurrency-worker-pool-chunked-promise-all-2026-04-28.md
+++ b/docs/solutions/best-practices/bounded-concurrency-worker-pool-chunked-promise-all-2026-04-28.md
@@ -1,0 +1,278 @@
+---
+title: Bounded-Concurrency Worker Pool via Chunked Promise.all
+date: 2026-04-28
+category: best-practices
+module: concurrency_control
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Implementing bounded parallel processing
+  - Processing lists with concurrent tasks
+  - Trading simplicity for head-of-line blocking
+  - When individual tasks have bounded latency
+tags:
+  - bounded-concurrency
+  - promise-all
+  - chunking
+  - worker-pool
+  - parallel-processing
+  - head-of-line-blocking
+---
+
+# Bounded-Concurrency Worker Pool via Chunked Promise.all
+
+## Context
+
+Bounded concurrency is useful when you have a batch of independent async tasks, you want more throughput than a plain `for` loop, but a full worker-pool abstraction would be gratuitous. In this repo, `processEntries` in `src/runtime/orphan-reaper.ts` runs a small one-shot batch during plugin init, and each probe has an explicit 1-second ceiling via `psField` (`src/runtime/orphan-reaper.ts:29-38`). That bounded per-task latency is what makes a chunked `Promise.all` pattern viable here: the worst-case stall per chunk is known up front.
+
+## Guidance
+
+Use a fixed chunk size, slice the input into waves, and `await Promise.all(chunk.map(...))` for each wave. That gives you "at most K entries in flight" with no dependency, semaphore, queue, or token bucket.
+
+In the shipped code, the cap is currently an inline literal `5` in `src/runtime/orphan-reaper.ts:99-100`, not a named `MAX_CONCURRENT_PROBES` constant. The learning still holds: make the cap explicit, keep it small, and treat it as a deliberate latency-vs-simplicity tradeoff, not a magic number.
+
+`5` is a reasonable choice here because it cuts a 10-entry file from roughly 10 sequential waves to 2 waves, while keeping the implementation tiny. The cost is explicit head-of-line blocking: chunk `N+1` cannot start until the slowest task in chunk `N` finishes.
+
+One nuance from the real code: the cap is on **entries**, not individual `ps` children. Each entry then fans out into `getPidComm` and `getPidStartTime` concurrently (`src/runtime/orphan-reaper.ts:109-112`), so a 5-entry chunk can mean up to **10 concurrent `ps` subprocesses**. The current concurrency test only tracks `getPidComm`, so it proves the entry-wave shape, not total subprocess concurrency (`tests/orphan-reaper.test.ts:311-343`).
+
+Actual timeout bound:
+
+```ts
+// src/runtime/orphan-reaper.ts:29-38
+function psField(pid: number, field: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+    let stdout = ''
+    let timedOut = false
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+    }, 1000)
+```
+
+Actual chunked loop:
+
+```ts
+// src/runtime/orphan-reaper.ts:99-125
+for (let i = 0; i < entries.length; i += 5) {
+  const chunk = entries.slice(i, i + 5)
+  const results = await Promise.all(
+    chunk.map(async (entry) => {
+      try {
+        process.kill(entry.pid, 0)
+      } catch {
+        return { reaped: false, skipped: true }
+      }
+
+      const [liveComm, liveLstart] = await Promise.all([
+        getPidComm(entry.pid),
+        getPidStartTime(entry.pid),
+      ])
+
+      if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+        return { reaped: false, skipped: true }
+      }
+```
+
+Actual concurrency-cap test:
+
+```ts
+// tests/orphan-reaper.test.ts:311-343
+it('should cap concurrent getPidComm invocations at 5 for 10 entries', async () => {
+  let maxConcurrent = 0
+  let currentConcurrent = 0
+
+  const res = await reapOrphans({
+    // ...
+    getPidComm: async () => {
+      currentConcurrent++
+      maxConcurrent = Math.max(maxConcurrent, currentConcurrent)
+      await new Promise((r) => setTimeout(r, 30))
+      currentConcurrent--
+      return 'copilot'
+    },
+```
+
+If you present this pattern as guidance, be explicit about the head-of-line property:
+
+- wave 1 starts up to 5 entries
+- fast entries in wave 1 still wait for the slowest sibling
+- wave 2 does not start until `Promise.all(wave1)` resolves
+
+That is not a bug. It is the cost you are accepting in exchange for radical simplicity.
+
+## Why This Matters
+
+This pattern sits in the useful middle ground between "totally sequential" and "build a real worker pool." Here, that middle ground is justified because the work runs once at plugin init, each probe has a hard 1-second timeout (`src/runtime/orphan-reaper.ts:35-38`), and each file contains at most 10 entries, so even the chunked worst case is still within a soft startup budget. On a hot path, or anywhere tail latency matters, the same head-of-line blocking would be the wrong trade.
+
+Documenting that tradeoff matters because the current implementation is intentionally the pragmatic minimum, not the universally best concurrency pattern. Future contributors should feel free to upgrade it to a streaming pool if the batch size grows, the timeout bound disappears, or init latency starts mattering more; that is exactly the kind of follow-up tracked by issue #49.
+
+## When to Apply
+
+- One-shot batches with bounded per-task latency, especially when each task has an explicit timeout.
+- Small to moderate batches, roughly `<= 20` tasks.
+- Cold paths such as init, setup, startup cleanup, or periodic maintenance.
+- Situations where adding `p-limit`/`p-map` or writing a reusable pool would be more code than value.
+
+## When NOT to Apply
+
+- Hot paths where tail latency matters and one slow sibling should not delay the next ready task.
+- Tasks with unbounded or poorly bounded latency.
+- Large batches (`> 20-50` tasks) where per-wave blocking compounds into visible delay.
+
+## Examples
+
+### 1) Sequential baseline — simplest, but worst tail time
+
+This is the obvious baseline: do each entry one at a time. It is easy to reason about, but with a 1-second timeout per entry and 10 entries, the batch can stretch to roughly 10 seconds.
+
+```ts
+// illustrative sequential version, not the shipped code
+for (const entry of entries) {
+  try {
+    process.kill(entry.pid, 0)
+  } catch {
+    skipped++
+    continue
+  }
+
+  const [liveComm, liveLstart] = await Promise.all([
+    getPidComm(entry.pid),
+    getPidStartTime(entry.pid),
+  ])
+
+  if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+    skipped++
+    continue
+  }
+
+  try {
+    await killProcessTree(entry.pid)
+    reaped++
+  } catch {
+    skipped++
+  }
+}
+```
+
+Use this when the batch is tiny or clarity matters more than total wall time.
+
+### 2) Current repo pattern — chunked waves of 5
+
+This is the actual shipped approach in `src/runtime/orphan-reaper.ts:99-125`. It processes 10 entries in two waves of 5, so with bounded 1-second probes the batch is roughly `2 * timeout` in the "one slow entry per wave" shape.
+
+```ts
+// src/runtime/orphan-reaper.ts:99-125
+for (let i = 0; i < entries.length; i += 5) {
+  const chunk = entries.slice(i, i + 5)
+  const results = await Promise.all(
+    chunk.map(async (entry) => {
+      try {
+        process.kill(entry.pid, 0)
+      } catch {
+        return { reaped: false, skipped: true }
+      }
+
+      const [liveComm, liveLstart] = await Promise.all([
+        getPidComm(entry.pid),
+        getPidStartTime(entry.pid),
+      ])
+
+      if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+        return { reaped: false, skipped: true }
+      }
+
+      try {
+        await killProcessTree(entry.pid)
+        return { reaped: true, skipped: false }
+      } catch {
+        return { reaped: false, skipped: true }
+      }
+    }),
+  )
+
+  for (const r of results) {
+    if (r.reaped) reaped++
+    else if (r.skipped) skipped++
+  }
+}
+```
+
+Why this is fine here:
+
+- bounded per-task timeout: `psField(..., 1000ms)` in `src/runtime/orphan-reaper.ts:35-38`
+- cold path: orphan cleanup during plugin init
+- small batch: up to 10 entries per file
+- tiny implementation surface
+
+Why it is not ideal:
+
+- chunk `2` waits for the slowest task in chunk `1`
+- the literal `5` is currently inline, so the cap is implicit rather than named
+- real subprocess fan-out is higher than the test suggests because each entry does two probe calls in parallel
+
+### 3) Streaming worker pool sketch — better tail behavior, more machinery
+
+A streaming pool keeps `K` tasks in flight and starts the next task as soon as any slot frees up. For the same "two slow entries total, everything else fast" distribution that makes chunked-of-5 take about 2 seconds, a streaming pool of 5 can overlap both slow entries and finish in about 1 second.
+
+```ts
+// illustrative streaming pool sketch, not the shipped code
+const queue = [...entries]
+const workers = Array.from({ length: 5 }, async () => {
+  while (queue.length > 0) {
+    const entry = queue.shift()
+    if (!entry) return
+
+    try {
+      process.kill(entry.pid, 0)
+    } catch {
+      skipped++
+      continue
+    }
+
+    const [liveComm, liveLstart] = await Promise.all([
+      getPidComm(entry.pid),
+      getPidStartTime(entry.pid),
+    ])
+
+    if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+      skipped++
+      continue
+    }
+
+    try {
+      await killProcessTree(entry.pid)
+      reaped++
+    } catch {
+      skipped++
+    }
+  }
+})
+
+await Promise.all(workers)
+```
+
+This is the better pattern when:
+
+- tail latency matters
+- task runtimes vary a lot
+- the batch is larger
+- you want the queue to keep draining as soon as a fast task finishes
+
+But it is also more moving parts, more shared-state care, and more code than the repo currently needs.
+
+### Timing summary
+
+- **Sequential**: roughly `10 * 1s = 10s` worst case for 10 1-second entries.
+- **Chunked-of-5**: roughly `2 * 1s = 2s` when one slow entry lands in each wave.
+- **Streaming pool of 5**: roughly `1s` for that same two-slow-entry distribution, because both slow tasks can overlap across worker slots.
+
+That last number is **not** a universal worst-case bound. If all 10 entries hit the 1-second ceiling, a 5-worker streaming pool is still roughly 2 seconds. The win is eliminating artificial wave boundaries, not breaking the math of bounded concurrency.
+
+## Related
+
+- See [Per-instance PID files with spawner-liveness gating](per-instance-pid-files-spawner-liveness-gating-2026-04-28.md) for the consumer of this concurrency pattern (reap-time per-PID identity probes).
+- See [Secure process introspection with array-spawn ps and comm-field identity gate](secure-process-introspection-array-spawn-ps-comm-field-2026-04-28.md) for the per-task work that runs inside each chunk.
+- Tracking issue: [#49 — v0.1.x / v0.2.x runtime hardening follow-ups](https://github.com/marcusrbrown/opencode-copilot-delegate/issues/49) (streaming worker pool replacement, configurable concurrency cap)

--- a/docs/solutions/best-practices/centralized-terminal-state-idempotency-task-lifecycle-2026-04-28.md
+++ b/docs/solutions/best-practices/centralized-terminal-state-idempotency-task-lifecycle-2026-04-28.md
@@ -1,0 +1,259 @@
+---
+title: Centralized Terminal-State Idempotency for Task Lifecycle
+date: 2026-04-28
+category: best-practices
+module: task_management
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Managing task status transitions
+  - Ensuring idempotent terminal state changes
+  - Coupling task state with cleanup hooks
+  - Avoiding duplicate status mutations
+tags:
+  - task-lifecycle
+  - idempotency
+  - status-management
+  - terminal-states
+  - cleanup-hooks
+  - state-guards
+---
+
+# Centralized Terminal-State Idempotency for Task Lifecycle
+
+## Context
+
+PR #50 fixed a task-lifecycle race in `src/runtime/subprocess.ts`: the abort listener can synchronously mark a task as `cancelled`, then the subprocess `close` event lands a moment later and tries to rewrite the same task as `complete` or `failed`. Before the refactor, the protection lived in a fragile inline guard on the close path, while other terminal writes were still direct mutations, so the invariant depended on every future callsite remembering the same rule. This came out of code review as a classic "future contributors must remember X" smell.
+
+## Guidance
+
+Use one helper for terminal-state writes and make all terminal callsites go through it.
+
+**Shipped helper signature and actual contract**
+
+```ts
+setStatus(
+  task: { status: TaskStatus; pid: number },
+  newStatus: TaskStatus,
+  options?: { pidFilePath?: string },
+): void
+```
+
+In the shipped code, the helper is **terminal-idempotent**: if the current status and next status are both terminal (`complete | failed | cancelled`), it returns early; otherwise it writes the new status. If `options.pidFilePath` is present and the new status is terminal, it also fires the PID-file cleanup hook so terminal cleanup cannot be forgotten.
+
+**Helper implementation — `src/runtime/task-status.ts:18-30`**
+
+```ts
+export function setStatus(
+  task: { status: TaskStatus; pid: number },
+  newStatus: TaskStatus,
+  options?: SetStatusOptions,
+): void {
+  if (isTerminal(task.status) && isTerminal(newStatus)) {
+    return
+  }
+
+  task.status = newStatus
+
+  if (options?.pidFilePath && isTerminal(newStatus)) {
+    removePidEntry(options.pidFilePath, task.pid).catch(() => {})
+  }
+}
+```
+
+That gives you one place to enforce "first terminal write wins" across competing async handlers. It also couples terminal-state transition to PID-file cleanup, which is the right kind of coupling here: cleanup is part of finishing the task.
+
+**Close path after the refactor — `src/runtime/subprocess.ts:59-70`**
+
+```ts
+function finalizeTask(
+  task: SpawnCopilotResult,
+  exitCode: number | null,
+  stderrText: string,
+  pidFilePath?: string,
+): void {
+  flushBufferedStdout(task)
+  task.endedAt = Date.now()
+  task.exitCode = exitCode ?? undefined
+
+  setStatus(task, exitCode === 0 ? 'complete' : 'failed', { pidFilePath })
+```
+
+A useful nuance from the shipped code: the **`endedAt` invariant still lives on the close path**, not inside `setStatus`. So the centralization here is about terminal-status idempotency and cleanup; timestamping is still partially caller-owned. If you add more terminal paths later and they also need `endedAt`, either move that into the helper or make the caller stamp it explicitly.
+
+**Abort path after the refactor — `src/runtime/subprocess.ts:146-154`**
+
+```ts
+task.abortController.signal.addEventListener(
+  'abort',
+  () => {
+    if (task.status !== 'running') {
+      return
+    }
+
+    setStatus(task, 'cancelled', { pidFilePath: opts.pidFilePath })
+    killProcessTree(task.pid).catch(() => {
+```
+
+**Spawn-error path after the refactor — `src/runtime/subprocess.ts:161-166`**
+
+```ts
+task.completionPromise = new Promise<void>((resolve) => {
+  child.once('error', (error) => {
+    setStatus(task, 'failed', { pidFilePath: opts.pidFilePath })
+    task.errorText = stripAnsi(error.message)
+    resolve()
+  })
+```
+
+The tests pin the behavior that matters: once a task is already terminal, later terminal writes do nothing.
+
+**No-op on cancelled → complete — `tests/task-status.test.ts:43-57`**
+
+```ts
+it('preserves cancelled when setStatus is called with complete', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
+  tempPaths.push(dir)
+  const pidFilePath = join(dir, 'orphans.pids')
+
+  const task = makeTask('cancelled', 12345)
+  await appendPidEntry(
+    pidFilePath,
+    task.pid,
+    'bash',
+    'Mon Apr 27 10:00:00 2026',
+  )
+
+  setStatus(task, 'complete', { pidFilePath })
+  expect(task.status).toBe('cancelled')
+```
+
+**No-op on failed → cancelled — `tests/task-status.test.ts:64-68`**
+
+```ts
+it('preserves failed when setStatus is called with cancelled', () => {
+  const task = makeTask('failed', 12345)
+
+  setStatus(task, 'cancelled')
+  expect(task.status).toBe('failed')
+})
+```
+
+## Why This Matters
+
+Inline lifecycle guards rot because they are a memory exercise, not a structural guarantee. The fourth async path — timeout, watchdog, retry abort, orphan reaper, whatever — gets added months later by someone who did not internalize why the original guard existed, and the race quietly comes back. A helper like `setStatus` turns the rule into an API boundary: callsites become boring, and the invariant stops relying on discipline. Coupling PID cleanup to that same helper is cheaper than teaching every future caller to remember two things at once: "don't clobber terminal state" and "also remove the orphan PID entry."
+
+## When to Apply
+
+- Any scattered event-driven lifecycle where multiple handlers can race to finish the same task: `close`, `abort`, `error`, `timeout`, watchdog, retry cancellation.
+- Any place where terminal transition has cleanup that must happen exactly once or at least must not be forgotten.
+- Any workflow where the desired rule is effectively **first terminal writer wins**, not **last writer wins**.
+
+## When NOT to Apply
+
+- When the state model has many legal transitions with different rules per edge; use an explicit FSM or transition table instead of a single coarse helper.
+- When cleanup is intentionally repeatable and harmless, and duplicate execution is acceptable.
+- When you need stronger semantics than the shipped helper currently provides; this helper prevents terminal-over-terminal clobbering, but it is not a full "no transitions away from terminal" state machine.
+
+## Examples
+
+**Before: the invariant was split across callsites.**
+Only the close path carried a guard, and the other terminal paths still mutated `task.status` directly.
+
+**Pre-PR close path — `src/runtime/subprocess.ts:53-60` (parent of `e2ea508`)**
+
+```ts
+): void {
+  flushBufferedStdout(task)
+  task.endedAt = Date.now()
+  task.exitCode = exitCode ?? undefined
+
+  if (task.status !== 'cancelled') {
+    task.status = exitCode === 0 ? 'complete' : 'failed'
+  }
+```
+
+**Pre-PR abort path — `src/runtime/subprocess.ts:136-145` (parent of `e2ea508`)**
+
+```ts
+task.abortController.signal.addEventListener(
+  'abort',
+  () => {
+    if (task.status !== 'running') {
+      return
+    }
+
+    task.status = 'cancelled'
+    killProcessTree(task.pid).catch(() => {
+```
+
+**Pre-PR spawn-error path — `src/runtime/subprocess.ts:151-154` (parent of `e2ea508`)**
+
+```ts
+task.completionPromise = new Promise<void>((resolve) => {
+  child.once('error', (error) => {
+    task.status = 'failed'
+    task.errorText = stripAnsi(error.message)
+```
+
+That layout is brittle: one callsite remembered the guard, two did not, and a fourth one could easily have repeated the mistake.
+
+**After: every terminal path delegates to the same helper.**
+
+**Close path — `src/runtime/subprocess.ts:65-70`**
+
+```ts
+  flushBufferedStdout(task)
+  task.endedAt = Date.now()
+  task.exitCode = exitCode ?? undefined
+
+  setStatus(task, exitCode === 0 ? 'complete' : 'failed', { pidFilePath })
+```
+
+**Abort path — `src/runtime/subprocess.ts:149-154`**
+
+```ts
+    if (task.status !== 'running') {
+      return
+    }
+
+    setStatus(task, 'cancelled', { pidFilePath: opts.pidFilePath })
+    killProcessTree(task.pid).catch(() => {
+```
+
+**Spawn-error path — `src/runtime/subprocess.ts:162-164`**
+
+```ts
+  child.once('error', (error) => {
+    setStatus(task, 'failed', { pidFilePath: opts.pidFilePath })
+    task.errorText = stripAnsi(error.message)
+```
+
+**Hypothetical fourth callsite**
+
+Old pattern, easy to get wrong:
+
+```ts
+child.once('timeout', () => {
+  task.status = 'failed'
+})
+```
+
+That silently skips both the terminal-idempotency rule and PID cleanup.
+
+New pattern, hard to get wrong:
+
+```ts
+child.once('timeout', () => {
+  setStatus(task, 'failed', { pidFilePath: opts.pidFilePath })
+})
+```
+
+The timeout path now inherits the same terminal-write behavior as `close`, `abort`, and `error` without the contributor having to remember any repo-specific folklore.
+
+## Related
+
+- See [Per-instance PID files with spawner-liveness gating](per-instance-pid-files-spawner-liveness-gating-2026-04-28.md) for the cleanup hook that this helper invokes on terminal transitions.
+- See [Atomic file append/remove with O_EXCL temp-file and in-process serialization queue](atomic-file-append-remove-o-excl-temp-file-2026-04-28.md) for the underlying `removePidEntry` mechanism.
+- Tracking issue: [#49 — v0.1.x / v0.2.x runtime hardening follow-ups](https://github.com/marcusrbrown/opencode-copilot-delegate/issues/49) (maintainability cleanups in `task-status.ts`)

--- a/docs/solutions/best-practices/per-instance-pid-files-spawner-liveness-gating-2026-04-28.md
+++ b/docs/solutions/best-practices/per-instance-pid-files-spawner-liveness-gating-2026-04-28.md
@@ -1,0 +1,407 @@
+---
+title: Per-Instance PID Files with Spawner-Liveness Gating
+date: 2026-04-28
+category: best-practices
+module: subprocess_lifecycle
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - Managing subprocess lifecycles in plugins
+  - Preventing PID reuse of unrelated processes
+  - Handling cross-instance orphan cleanup
+  - Ensuring spawner liveness before reaping
+tags:
+  - pid-files
+  - subprocess-management
+  - liveness-probing
+  - orphan-reaping
+  - process-identity
+  - comm-lstart-gate
+---
+
+# Per-Instance PID Files with Spawner-Liveness Gating
+
+## Context
+
+This plugin needed a way to clean up child Copilot CLI processes after OpenCode reloads the plugin or the host process crashes.
+The original constraint was that OpenCode's `Hooks` interface had no dispose hook, so there was no reliable shutdown callback to do cleanup at unload time.
+That forced cleanup to happen opportunistically at the next startup instead.
+Once startup-time reap exists, the hard part is making it safe across concurrent OpenCode sessions and safe against PID reuse.
+
+## Guidance
+
+Use one orphan-tracking file per plugin host PID, not one shared file for the whole machine or repo.
+The filename must be the host process PID because the reaper needs to ask a concrete OS question: "is the spawner that owns this file still alive?"
+A logical session ID cannot answer that without an extra registry, while `process.pid` is directly probeable with `process.kill(pid, 0)`.
+
+Excerpt (`src/runtime/pid-file.ts:33-42`):
+
+```ts
+export function resolveInstancePidFilePath(): string {
+  const stateDir =
+    process.env.XDG_STATE_HOME ?? join(homedir(), '.local', 'state')
+  return join(
+    stateDir,
+    'opencode-copilot-delegate',
+    'orphans',
+    `${process.pid}.pids`,
+  )
+}
+```
+
+That gives each running plugin instance its own file:
+
+- `<XDG_STATE_HOME>/opencode-copilot-delegate/orphans/<plugin-pid>.pids`
+- one host process, one file
+- no cross-instance append/remove clobbering
+
+Store child identity in each line as:
+
+- `<pid>\t<comm>\t<lstart>`
+
+`pid` alone is not enough.
+A dead child PID can be reused by the kernel before the next startup.
+`comm` helps ensure the process still has the same executable identity, and `lstart` defeats PID reuse by pinning the process start time.
+
+Excerpt (`src/runtime/orphan-reaper.ts:73-77,109-115`):
+
+```ts
+interface PidEntry {
+  pid: number
+  comm: string
+  lstart: string
+}
+
+// ...
+
+const [liveComm, liveLstart] = await Promise.all([
+  getPidComm(entry.pid),
+  getPidStartTime(entry.pid),
+])
+
+if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+  return { reaped: false, skipped: true }
+}
+```
+
+To obtain those identity fields at reap time, query `ps` directly.
+The implementation asks for exactly the two fields it needs and treats timeout, spawn failure, or non-zero exit as "cannot verify," which safely downgrades to skip.
+
+Excerpt (`src/runtime/orphan-reaper.ts:29-63`):
+
+```ts
+function psField(pid: number, field: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+    let stdout = ''
+    let timedOut = false
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+    }, 1000)
+
+    // ...
+
+    child.on('close', (code) => {
+      clearTimeout(timeout)
+      if (timedOut || code !== 0) {
+        resolve(null)
+      } else {
+        const trimmed = stdout.trim()
+        resolve(trimmed || null)
+      }
+    })
+  })
+}
+```
+
+Before opening a peer file, first ask whether the spawner named by the filename is still alive.
+That is the spawner-liveness gate.
+If the owning plugin process is still alive, skip the file entirely because that live instance still owns its children and its cleanup state.
+
+Excerpt (`src/runtime/orphan-reaper.ts:20-27`):
+
+```ts
+export function defaultIsPluginAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (e) {
+    return isErrnoException(e) && e.code === 'EPERM'
+  }
+}
+```
+
+On POSIX, `process.kill(pid, 0)` means:
+
+- success: process exists and is signalable
+- `EPERM`: process exists but you lack permission to signal it
+- `ESRCH`: process does not exist
+
+This implementation treats success and `EPERM` as "alive," and everything else as "not alive enough to trust ownership."
+That is the right bias for reaping: never kill another still-running parent's children.
+
+The per-file reap flow is:
+
+1. list `orphans/`
+2. ignore non-`.pids` files
+3. parse the filename stem as the owning plugin PID
+4. if the file belongs to another plugin instance and that plugin is alive, skip it
+5. otherwise read entries from the file
+6. for each entry, re-check `pid`, `comm`, and `lstart`
+7. kill only when both identity fields still match
+8. truncate the current instance's own file, or delete a dead peer's file
+
+Excerpt (`src/runtime/orphan-reaper.ts:196-216`):
+
+```ts
+if (!isCurrent && isPluginAlive(filePid)) {
+  return empty
+}
+
+const entries = await readPidFileEntries(filePath)
+if (entries === null) {
+  return empty
+}
+
+const { reaped, skipped } = await processEntries(
+  entries,
+  killProcessTree,
+  getPidComm,
+  getPidStartTime,
+)
+const deleted = await cleanupAfterReap(
+  filePath,
+  isCurrent,
+  currentInstancePath,
+)
+```
+
+Excerpt (`src/runtime/orphan-reaper.ts:248-279`):
+
+```ts
+for (const file of files) {
+  if (!file.endsWith('.pids')) continue
+
+  const filePath = join(pidFileDir, file)
+  const stem = basename(file, extname(file))
+  if (!/^[1-9]\d*$/.test(stem)) {
+    console.warn(`[orphan-reaper] Skipping non-numeric PID file: ${file}`)
+    continue
+  }
+  const filePid = Number(stem)
+
+  const outcome = await reapOneFile(
+    filePath,
+    filePid,
+    filePid === process.pid,
+    currentInstancePath,
+    isPluginAlive,
+    killProcessTree,
+    getPidComm,
+    getPidStartTime,
+  )
+
+  reaped += outcome.reaped
+  skipped += outcome.skipped
+  if (outcome.scanned) scannedFiles++
+  if (outcome.deleted) deletedFiles++
+}
+```
+
+Run the reap at startup, before exposing tools, and never let reap failure block plugin initialization.
+If the state directory is read-only, missing, or otherwise broken, the plugin should still come up and continue functioning.
+
+Excerpt (`src/index.ts:31-48`):
+
+```ts
+const currentInstancePath = resolveInstancePidFilePath()
+const pidFileDir = dirname(currentInstancePath)
+try {
+  await mkdir(pidFileDir, { recursive: true, mode: 0o700 })
+  await reapOrphans({
+    pidFileDir,
+    currentInstancePath,
+    killProcessTree,
+    getPidComm,
+    getPidStartTime,
+  })
+} catch {
+  // mkdir or reap failure must not block plugin init.
+}
+```
+
+A useful mental model is:
+
+- filename answers "who owns this file?"
+- `kill(pid, 0)` answers "is that owner still around?"
+- `comm + lstart` answer "does this child PID still refer to the same process?"
+- only after all three checks pass do you kill anything
+
+The tests exercise the mixed-instance behavior directly: current file is processed, a dead foreign spawner file is processed and deleted, and a live foreign spawner file is skipped untouched (`tests/orphan-reaper.test.ts:78-133`).
+That is the core safety property of the pattern.
+
+## Why This Matters
+
+A shared PID file lets concurrent plugin instances overwrite, truncate, or reap each other's state.
+That creates the worst kind of startup bug: a fresh instance kills children that still belong to a different, healthy instance.
+A blind kill based only on recorded PID is even worse because PID reuse can redirect cleanup toward an unrelated process.
+Per-instance files remove clobber races, spawner-liveness probing preserves live ownership, and the `comm` + `lstart` gate closes the PID-reuse hole before any kill happens.
+
+## When to Apply
+
+- Anywhere a long-lived process spawns children whose lifecycle may outlive a parent crash, but should not survive a parent restart indefinitely.
+- Plugin systems, supervisors, daemon-managed worker pools, and IDE/editor extensions that manage subprocesses such as language servers or external CLIs.
+- Situations where multiple parent instances can run concurrently on the same machine and share a common state directory.
+- Cases where startup-time recovery is the only reliable cleanup point.
+- Do **not** use this when the framework already gives you a reliable dispose/shutdown hook; use the framework lifecycle directly instead.
+
+## Examples
+
+### Before: naive shared PID file
+
+This version has two bugs:
+
+1. all instances write to the same file
+2. startup reaper trusts the stored child PID without checking whether the file's owner is still alive
+
+```ts
+const pidFile = join(stateDir, 'opencode-copilot-delegate', 'orphans.pids')
+
+await appendFile(pidFile, `${child.pid}\n`)
+
+for (const pid of await readPids(pidFile)) {
+  await killProcessTree(pid)
+}
+
+await truncate(pidFile, 0)
+```
+
+Failure mode:
+
+- OpenCode session A and session B both append to `orphans.pids`
+- session B reloads first
+- B reads the shared file and kills every recorded child PID
+- A was still running, so B just killed A's active children
+- if one recorded PID has been reused, B may kill an unrelated process
+
+A session ID does not fix this if you use it as the filename:
+
+```ts
+const pidFile = join(stateDir, 'orphans', `${sessionId}.pids`)
+```
+
+That avoids one shared file, but now the filename cannot be used for liveness probing.
+You still need some other mapping from `sessionId` to a live OS process, which is exactly the problem `process.pid` already solves.
+
+### After: per-instance file + spawner-liveness gate
+
+Each parent instance writes only to its own file:
+
+```ts
+const pidFile = join(
+  stateDir,
+  'opencode-copilot-delegate',
+  'orphans',
+  `${process.pid}.pids`,
+)
+
+await appendPidEntry(pidFile, child.pid, childComm, childStartTime)
+```
+
+At startup, only reap files whose owning parent is gone:
+
+```ts
+for (const file of await readdir(pidFileDir)) {
+  const spawnerPid = Number(basename(file, '.pids'))
+
+  if (spawnerPid !== process.pid && isPluginAlive(spawnerPid)) {
+    continue
+  }
+
+  await reapEntriesFromDeadSpawner(join(pidFileDir, file))
+}
+```
+
+That closes the cross-instance kill bug:
+
+- session A owns `12345.pids`
+- session B owns `23456.pids`
+- B starts and scans the directory
+- B probes `12345` with `kill(12345, 0)`
+- if A is still alive, B skips `12345.pids` entirely
+- only files for dead parents are eligible for reap
+
+### Before: unverified child PID kill
+
+This version avoids shared-file clobbering but still trusts stale child PIDs:
+
+```ts
+for (const { pid } of entries) {
+  try {
+    process.kill(pid, 0)
+    await killProcessTree(pid)
+  } catch {
+    // already dead
+  }
+}
+```
+
+Failure mode:
+
+- child PID `8123` was recorded yesterday
+- that child died
+- the kernel reused `8123` for another process
+- `kill(8123, 0)` succeeds
+- your reaper kills the wrong process tree
+
+### After: identity-gated kill
+
+Re-check both executable identity and start time before killing:
+
+```ts
+for (const entry of entries) {
+  try {
+    process.kill(entry.pid, 0)
+  } catch {
+    continue
+  }
+
+  const [liveComm, liveLstart] = await Promise.all([
+    getPidComm(entry.pid),
+    getPidStartTime(entry.pid),
+  ])
+
+  if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+    continue
+  }
+
+  await killProcessTree(entry.pid)
+}
+```
+
+This closes the PID-reuse hole:
+
+- `comm` rejects "same PID, different executable"
+- `lstart` rejects "same PID, same executable name, different process lifetime"
+- the kill only happens when the live process still matches the exact recorded child identity
+
+### Real-source alignment
+
+The shipped implementation follows that exact shape:
+
+- per-instance file path keyed by `process.pid` (`src/runtime/pid-file.ts:33-42`)
+- peer-file owner liveness gate via `defaultIsPluginAlive` (`src/runtime/orphan-reaper.ts:20-27`)
+- `ps -p <pid> -o comm=` and `ps -p <pid> -o lstart=` for identity checks (`src/runtime/orphan-reaper.ts:29-63`)
+- strict `comm` and `lstart` equality before `killProcessTree` (`src/runtime/orphan-reaper.ts:109-120`)
+- startup-time directory scan and per-file reap (`src/runtime/orphan-reaper.ts:248-279`)
+- startup reap wrapped so plugin init never fails closed (`src/index.ts:31-48`)
+
+## Related
+
+- See [Secure process introspection with array-spawn ps and comm-field identity gate](secure-process-introspection-array-spawn-ps-comm-field-2026-04-28.md) for the kernel-truth identity check that runs inside the reap loop.
+- See [Centralized terminal-state idempotency for task lifecycle](centralized-terminal-state-idempotency-task-lifecycle-2026-04-28.md) for how PID-file cleanup is coupled to terminal status transitions in this codebase.
+- See [Atomic file append/remove with O_EXCL temp-file and in-process serialization queue](atomic-file-append-remove-o-excl-temp-file-2026-04-28.md) for the per-instance PID file's mutation pattern.
+- Tracking issue: [#49 — v0.1.x / v0.2.x runtime hardening follow-ups](https://github.com/marcusrbrown/opencode-copilot-delegate/issues/49)

--- a/docs/solutions/best-practices/secure-process-introspection-array-spawn-ps-comm-field-2026-04-28.md
+++ b/docs/solutions/best-practices/secure-process-introspection-array-spawn-ps-comm-field-2026-04-28.md
@@ -1,0 +1,259 @@
+---
+title: Secure Process Introspection with Array-Spawn ps and Comm-Field Identity Gate
+date: 2026-04-28
+category: best-practices
+module: process_introspection
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - Verifying process ownership securely
+  - Preventing PID reuse and tampering
+  - Using kernel-tracked process identity
+  - Safely spawning system commands
+tags:
+  - process-introspection
+  - ps-command
+  - comm-field
+  - lstart-matching
+  - secure-spawning
+  - injection-prevention
+  - kernel-truth
+---
+
+# Secure Process Introspection with Array-Spawn ps and Comm-Field Identity Gate
+
+## Context
+
+In a long-lived plugin, watchdog, or reaper, "I still have PID 1234, so it's safe to kill" is a bad assumption. PIDs get reused, so a stale pidfile can point at a completely unrelated process by the time cleanup runs. Matching `argv` is not enough either, because `args` is just process command-line presentation state and is much easier to spoof or mislead than a kernel-reported identity signal.
+
+In `src/runtime/orphan-reaper.ts`, the shipped fix closes both gaps: it re-reads the live process identity immediately before `killProcessTree`, and only proceeds when both `comm` and `lstart` still match the values captured at spawn time (`src/runtime/orphan-reaper.ts:109-115`). That combination defends against both stale PID reuse and "same PID, believable-looking argv" mistakes.
+
+## Guidance
+
+Use a two-part identity gate before signaling any PID you are recovering from persisted state:
+
+- **Never shell-string `ps`.** Spawn `ps` with an argv array so the OS passes discrete arguments directly to the process. That removes shell parsing from the equation and avoids command injection footguns.
+- **Use `comm`, not `args`, for the name check.** `comm` is a kernel-reported process/task name field, which is a materially stronger signal than `args` because it is not just the user-facing command-line string.
+- **Use `lstart` as the second identity leg.** A reused PID running the same binary can still pass a `comm` check. Matching start time closes that hole.
+- **Require both fields to match.** `comm` alone is insufficient; `lstart` alone is insufficient; both together are the gate.
+- **Treat introspection failure as "do not kill."** If `ps` times out, errors, exits non-zero, or returns empty output, collapse that to "identity unverifiable" and skip the signal.
+- **Drain `stderr`.** If you never read `stderr`, the child can block on a full pipe buffer under backpressure and hang the caller even though the command itself is trivial.
+
+The core wrapper is small and boring, which is exactly what you want in a safety check:
+
+```ts
+function psField(pid: number, field: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+    let stdout = ''
+    let timedOut = false
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+    }, 1000)
+```
+
+— `src/runtime/orphan-reaper.ts:29-38`
+
+That first excerpt is the important spawn pattern: no shell, no string interpolation into a shell command, and a bounded timeout so introspection cannot wedge startup or cleanup forever.
+
+The second detail is easy to miss and worth preserving as part of the pattern, not a throwaway implementation note:
+
+```ts
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf-8')
+    })
+    // Drain stderr so the OS pipe buffer never fills under backpressure.
+    // An unread stderr pipe on a long-running or backlogged ps invocation
+    // can stall the subprocess, blocking plugin init.
+    child.stderr?.resume()
+```
+
+— `src/runtime/orphan-reaper.ts:40-46`
+
+If a subprocess writes to `stderr` and the parent never drains it, the kernel pipe can fill. Once full, the child blocks on write, which means it may never exit, which means your seemingly harmless introspection helper can hang the system in exactly the path that is supposed to make cleanup safer.
+
+The wrapper also normalizes failure to a safe default:
+
+```ts
+    child.on('close', (code) => {
+      clearTimeout(timeout)
+      if (timedOut || code !== 0) {
+        resolve(null)
+      } else {
+        const trimmed = stdout.trim()
+        resolve(trimmed || null)
+      }
+    })
+
+    child.on('error', () => {
+      clearTimeout(timeout)
+      resolve(null)
+    })
+```
+
+— `src/runtime/orphan-reaper.ts:48-60`
+
+In the current implementation, timeout, spawn error, non-zero exit, and empty output all become `null`. That is fine here because the caller only needs one answer: "can I still prove this is the same process?" If not, skip the kill.
+
+The actual identity gate is the real win:
+
+```ts
+const [liveComm, liveLstart] = await Promise.all([
+  getPidComm(entry.pid),
+  getPidStartTime(entry.pid),
+])
+
+if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+  return { reaped: false, skipped: true }
+}
+```
+
+— `src/runtime/orphan-reaper.ts:109-115`
+
+That `||` is the contract. If either leg of identity moved, the process is no longer trusted. No "close enough," no partial match, no best-effort kill.
+
+A clean way to describe the pattern is:
+
+1. Record `pid`, `comm`, and `lstart` when you spawn or first adopt the child.
+2. When it is time to reap, re-read live `comm` and `lstart` with array-spawned `ps`.
+3. If either value differs, treat the PID as stale and skip signaling.
+4. Only call `kill`/`SIGTERM`/`killProcessTree` after both values match.
+
+That is the minimal, auditable version. No new dependencies, no process-table caching, no heroic heuristics.
+
+## Why This Matters
+
+Unverified kill paths are one of those bugs that stay invisible until they ruin someone's day. A stale PID can just as easily belong to a user's editor, terminal multiplexer, local database, or some other unrelated service as it can to the process you meant to reap. The blast radius is effectively unbounded because "wrong process" has no natural ceiling.
+
+The cost of getting this right is tiny: two `ps` lookups and one equality check. The cost of getting it wrong can be data loss, corrupted local state, broken sessions, or maddening "why did your plugin kill my stuff?" reports that are hard to reproduce. This is cheap insurance in exactly the code path where safety matters more than micro-optimization.
+
+## When to Apply
+
+- Process supervisors, watchdogs, orphan reapers, daemon managers, plugin cleanup code, or background-task registries.
+- Any code path that will signal or kill a PID loaded from disk, memory cache, or another process rather than from a still-live `ChildProcess` handle.
+- Long-lived runtimes where PID reuse is plausible: developer machines, CI workers, agents, plugin hosts, or services with restart churn.
+- Recovery code that runs after parent crashes, restarts, or partial state loss.
+- "Kill the old worker before starting the new one" flows where stale bookkeeping can outlive the original process.
+
+## When NOT to Apply
+
+- You still hold the original `ChildProcess` handle from `spawn()` and never lose it; that handle already disambiguates the process identity better than a PID file.
+- Single-shot scripts where the parent remains alive for the entire child lifetime and cleanup happens immediately.
+- Fully controlled, closed process namespaces where you own the whole table and have consciously accepted a simpler risk model.
+- Cases where you are not signaling an existing PID at all, but simply waiting on or disposing of a process object you already own directly.
+
+## Examples
+
+**Naive version: stale PID, wrong victim**
+
+```ts
+// recorded yesterday in a pidfile
+const recordedPid = 1234
+
+// Today, PID 1234 belongs to something else.
+process.kill(recordedPid, 'SIGTERM')
+```
+
+Failure mode:
+
+1. Worker A had PID `1234`.
+2. Worker A exited.
+3. The OS recycled PID `1234`.
+4. Some unrelated process B now owns `1234`.
+5. Your cleanup logic kills B.
+
+That bug does not care whether B is harmless or critical.
+
+**Safer version: verify identity before kill**
+
+```ts
+async function verifyIdentity(
+  pid: number,
+  expectedComm: string,
+  expectedLstart: string,
+): Promise<boolean> {
+  const [liveComm, liveLstart] = await Promise.all([
+    getPidComm(pid),
+    getPidStartTime(pid),
+  ])
+
+  return liveComm === expectedComm && liveLstart === expectedLstart
+}
+
+if (await verifyIdentity(recordedPid, recordedComm, recordedLstart)) {
+  await killProcessTree(recordedPid)
+}
+```
+
+Now the reused PID does not pass unless it is still the same process instance.
+
+**Why `comm` + `lstart`, not just `comm`**
+
+```ts
+// Still unsafe: a reused PID running the same binary can match this.
+if ((await getPidComm(recordedPid)) === recordedComm) {
+  await killProcessTree(recordedPid)
+}
+```
+
+Failure mode:
+
+1. Old process was `copilot`, PID `1234`.
+2. Old process exited.
+3. New, unrelated `copilot` process starts and receives PID `1234`.
+4. `comm` still matches.
+5. You kill the wrong `copilot` instance.
+
+Adding `lstart` distinguishes the old instance from the new one.
+
+**Shell-string `ps`: avoid this**
+
+```ts
+import { exec } from 'node:child_process'
+
+exec(`ps -p ${pid} -o comm=`, (err, stdout) => {
+  // ...
+})
+```
+
+Problems:
+
+- Shell parsing is back in play.
+- Variable interpolation becomes part of a command string.
+- Even if `pid` is "supposed to be numeric," this is an unnecessary footgun.
+
+**Array-spawn `ps`: do this**
+
+```ts
+import { spawn } from 'node:child_process'
+
+const child = spawn('ps', ['-p', String(pid), '-o', 'comm='])
+```
+
+Benefits:
+
+- No shell.
+- No quoting games.
+- Arguments are passed as discrete argv tokens.
+- Easier to reason about, test, and audit.
+
+**Practical wrapper shape**
+
+```ts
+async function getPidField(pid: number, field: 'comm' | 'lstart') {
+  const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+  child.stderr?.resume()
+  // collect stdout, enforce timeout, return trimmed value or null
+}
+```
+
+That is the boring core. The safety comes from combining it with "skip kill unless both live values still match the recorded values."
+
+## Related
+
+- See [Per-instance PID files with spawner-liveness gating](per-instance-pid-files-spawner-liveness-gating-2026-04-28.md) for the broader orphan-reaper context that consumes this identity gate.
+- See [Bounded-concurrency worker pool via chunked Promise.all](bounded-concurrency-worker-pool-chunked-promise-all-2026-04-28.md) for the parallelization strategy that runs these `ps` lookups.
+- Tracking issue: [#49 — v0.1.x / v0.2.x runtime hardening follow-ups](https://github.com/marcusrbrown/opencode-copilot-delegate/issues/49) (combined `ps -p <pid> -o comm=,lstart=` query, configurable timeout, missing test coverage for `psField` failure branches)


### PR DESCRIPTION
Two unrelated docs-only housekeeping items, both rolled out of the runtime hardening release at e2ea508 / npm 0.2.0.

## Decouple plan filenames and frontmatter from npm version

The runtime hardening plan was named v0.1.1 but shipped as the npm 0.2.0 release because the unstable 0.x repo policy bumps `minor` for every changeset. The TUI foundation plan named v0.2.0 would ship as 0.3.0 under the same rule. Rather than carry that mapping permanently:

- Drop the `target_release` frontmatter field from both plans. Plans now describe units of work; release versions are a deployment concern.
- Rename `2026-04-27-002-fix-runtime-hardening-pre-tui-plan.md` to `2026-04-27-002-fix-runtime-hardening-plan.md` (drop the "pre-tui" qualifier; the plan is its own unit, not a satellite of the TUI plan).
- Mark the runtime hardening plan as `status: completed` (it shipped at e2ea508).
- Replace v0.x.y references in plan body text with phase-relative language ("foundation phase", "drilled-view phase", "third phase"). Brainstorm section-heading citations stay literal because they point at real headings inside an external doc.
- Update both cross-link fields and the inline markdown link to the renamed file path.

No code, tests, or shipped artifacts change.

## Five orphan-reaper patterns captured as institutional knowledge

The runtime hardening release implemented several reusable patterns that other plugins / process-managers might reach for. Captured as five knowledge-track docs in `docs/solutions/best-practices/`:

- **Per-instance PID files with spawner-liveness gating** — per-pid-keyed PID file plus `process.kill(pid, 0)` liveness probe plus `comm`/`lstart` identity gate. Prevents both cross-instance kill of foreign-instance children and PID-reuse-of-unrelated-process.
- **Atomic file append/remove with O_EXCL temp-file and in-process serialization queue** — zero-dependency alternative to `proper-lockfile` for small per-instance state files. Includes a callout for the `os.constants.O_EXCL` vs `fs.constants.O_EXCL` gotcha.
- **Centralized terminal-state idempotency for task lifecycle** — the `setStatus` helper that no-ops on terminal-to-terminal transitions and couples PID-file cleanup to the same callsite, replacing the fragile inline-guard pattern.
- **Bounded-concurrency worker pool via chunked Promise.all** — explicit documentation of the chunks(K) plus Promise.all pattern with its head-of-line blocking tradeoff and the bounded-per-task-latency precondition that makes it acceptable here.
- **Secure process introspection with array-spawn ps and comm-field identity gate** — array-spawn `ps` (never shell-string), kernel-tracked `comm` plus `lstart` for identity verification, stderr drain to prevent pipe-buffer hang.

Each doc cites real `file:line` references in the shipped implementation, cross-links to its peers, and points at tracking issue #49 for the relevant follow-up work.

## Verification

- typecheck / lint / build: clean (docs-only change)
- Knowledge-track frontmatter validates against `references/schema.yaml` (all required fields present)
- All cross-links between the 5 new docs are symmetric
- AGENTS.md architecture tree (line 40) already surfaces `docs/solutions/`; no AGENTS.md edit needed
- No changeset (docs-only)