### PR TITLE
perf(runtime): streaming orphan-reaper pool + combined ps probe

### DIFF
--- a/.changeset/orphan-reaper-streaming-pool-and-combined-ps.md
+++ b/.changeset/orphan-reaper-streaming-pool-and-combined-ps.md
@@ -1,0 +1,14 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Eliminate head-of-line blocking and halve fork/exec cost in the orphan reaper
+
+Two performance improvements to the plugin-init orphan-subprocess reaper, both surfaced in the `v0.1.x / v0.2.x runtime hardening follow-ups` tracking issue:
+
+- **Streaming worker pool replaces chunked `Promise.all`**: under loaded conditions a single slow `ps` invocation (300-500ms is realistic) used to idle four sibling workers in the same chunk, blowing the soft init budget by 5-10x. The reaper now spawns up to `MAX_CONCURRENT_PROBES = 5` workers that drain a shared queue independently — a slow probe blocks only its own worker.
+- **Combined `ps -p <pid> -o comm=,lstart=` query**: the two separate `comm` and `lstart` lookups (per entry, plus per task spawn) consolidate into a single `getPidIdentity(pid)` call. Halves fork/exec cost on the reap hot path, makes the concurrency-cap math match reality (5 workers ⇒ at most 5 concurrent `ps` subprocesses, not 10), and gets an atomic kernel snapshot of both identity legs.
+
+Net wall-clock impact for a 10-entry orphan file with one slow `ps` probe: the chunked-of-5 worst case (~210ms) drops to roughly 200ms, but the streaming pool eliminates the artificial wave-boundary stall — the 9 fast probes complete in ~30ms instead of being trapped behind the slow one.
+
+No public API changes. All callers and tests updated to use the combined `getPidIdentity` dependency.

--- a/docs/solutions/best-practices/bounded-concurrency-worker-pool-chunked-promise-all-2026-04-28.md
+++ b/docs/solutions/best-practices/bounded-concurrency-worker-pool-chunked-promise-all-2026-04-28.md
@@ -24,25 +24,24 @@ tags:
 
 ## Context
 
-Bounded concurrency is useful when you have a batch of independent async tasks, you want more throughput than a plain `for` loop, but a full worker-pool abstraction would be gratuitous. In this repo, `processEntries` in `src/runtime/orphan-reaper.ts` runs a small one-shot batch during plugin init, and each probe has an explicit 1-second ceiling via `psField` (`src/runtime/orphan-reaper.ts:29-38`). That bounded per-task latency is what makes a chunked `Promise.all` pattern viable here: the worst-case stall per chunk is known up front.
+Bounded concurrency is useful when you have a batch of independent async tasks, you want more throughput than a plain `for` loop, but a full worker-pool abstraction would be gratuitous. The orphan reaper in `src/runtime/orphan-reaper.ts` shipped this pattern in v0.1.1 (chunked-of-5 with `Promise.all`) and then moved to a streaming worker pool in the v0.1.1 → next-release work because the head-of-line blocking property became visible under loaded conditions. Both patterns are documented here: chunked is the simpler tradeoff when per-task latency is bounded and uniform; streaming is the right pick when one slow task should not delay the next ready task.
 
 ## Guidance
 
 Use a fixed chunk size, slice the input into waves, and `await Promise.all(chunk.map(...))` for each wave. That gives you "at most K entries in flight" with no dependency, semaphore, queue, or token bucket.
 
-In the shipped code, the cap is currently an inline literal `5` in `src/runtime/orphan-reaper.ts:99-100`, not a named `MAX_CONCURRENT_PROBES` constant. The learning still holds: make the cap explicit, keep it small, and treat it as a deliberate latency-vs-simplicity tradeoff, not a magic number.
+Make the cap explicit, keep it small, and treat it as a deliberate latency-vs-simplicity tradeoff, not a magic number. The orphan reaper now extracts `MAX_CONCURRENT_PROBES = 5` as a named top-level constant alongside the streaming pool implementation.
 
-`5` is a reasonable choice here because it cuts a 10-entry file from roughly 10 sequential waves to 2 waves, while keeping the implementation tiny. The cost is explicit head-of-line blocking: chunk `N+1` cannot start until the slowest task in chunk `N` finishes.
+`5` is a reasonable choice for orphan-reap workloads because it cuts a 10-entry file from roughly 10 sequential waves to 2 waves, while keeping the implementation tiny. The cost is explicit head-of-line blocking: chunk `N+1` cannot start until the slowest task in chunk `N` finishes.
 
-One nuance from the real code: the cap is on **entries**, not individual `ps` children. Each entry then fans out into `getPidComm` and `getPidStartTime` concurrently (`src/runtime/orphan-reaper.ts:109-112`), so a 5-entry chunk can mean up to **10 concurrent `ps` subprocesses**. The current concurrency test only tracks `getPidComm`, so it proves the entry-wave shape, not total subprocess concurrency (`tests/orphan-reaper.test.ts:311-343`).
+One nuance worth preserving from the v0.1.1 implementation: the cap was on **entries**, not individual `ps` children. Each entry fanned out into `getPidComm` and `getPidStartTime` concurrently, so a 5-entry chunk could mean up to **10 concurrent `ps` subprocesses**. The next-release work consolidates those two calls into a single `getPidIdentity(pid)` invocation that returns `{ comm, lstart }` from one `ps -p <pid> -o comm=,lstart=` call, halving the fork/exec cost and making the concurrency-cap math match reality (5 workers ⇒ at most 5 concurrent `ps` subprocesses).
 
-Actual timeout bound:
+Timeout bound (still applies in the streaming pool):
 
 ```ts
-// src/runtime/orphan-reaper.ts:29-38
-function psField(pid: number, field: string): Promise<string | null> {
+function runPs(args: string[]): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+    const child = spawn('ps', args)
     let stdout = ''
     let timedOut = false
 
@@ -52,10 +51,9 @@ function psField(pid: number, field: string): Promise<string | null> {
     }, 1000)
 ```
 
-Actual chunked loop:
+The v0.1.1 chunked loop (since replaced):
 
 ```ts
-// src/runtime/orphan-reaper.ts:99-125
 for (let i = 0; i < entries.length; i += 5) {
   const chunk = entries.slice(i, i + 5)
   const results = await Promise.all(
@@ -76,26 +74,7 @@ for (let i = 0; i < entries.length; i += 5) {
       }
 ```
 
-Actual concurrency-cap test:
-
-```ts
-// tests/orphan-reaper.test.ts:311-343
-it('should cap concurrent getPidComm invocations at 5 for 10 entries', async () => {
-  let maxConcurrent = 0
-  let currentConcurrent = 0
-
-  const res = await reapOrphans({
-    // ...
-    getPidComm: async () => {
-      currentConcurrent++
-      maxConcurrent = Math.max(maxConcurrent, currentConcurrent)
-      await new Promise((r) => setTimeout(r, 30))
-      currentConcurrent--
-      return 'copilot'
-    },
-```
-
-If you present this pattern as guidance, be explicit about the head-of-line property:
+If you present the chunked pattern as guidance, be explicit about the head-of-line property:
 
 - wave 1 starts up to 5 entries
 - fast entries in wave 1 still wait for the slowest sibling
@@ -105,9 +84,11 @@ That is not a bug. It is the cost you are accepting in exchange for radical simp
 
 ## Why This Matters
 
-This pattern sits in the useful middle ground between "totally sequential" and "build a real worker pool." Here, that middle ground is justified because the work runs once at plugin init, each probe has a hard 1-second timeout (`src/runtime/orphan-reaper.ts:35-38`), and each file contains at most 10 entries, so even the chunked worst case is still within a soft startup budget. On a hot path, or anywhere tail latency matters, the same head-of-line blocking would be the wrong trade.
+Chunked `Promise.all` sits in the useful middle ground between "totally sequential" and "build a real worker pool." It was justified for v0.1.1 because the work runs once at plugin init, each probe has a hard 1-second timeout, and each file contains at most 10 entries, so even the chunked worst case is still within a soft startup budget.
 
-Documenting that tradeoff matters because the current implementation is intentionally the pragmatic minimum, not the universally best concurrency pattern. Future contributors should feel free to upgrade it to a streaming pool if the batch size grows, the timeout bound disappears, or init latency starts mattering more; that is exactly the kind of follow-up tracked by issue #49.
+The move to a streaming worker pool came from a real observation: under loaded conditions a single slow `ps` invocation (occasionally 100s of milliseconds) blocks four sibling probes idly until the slow one returns, which can blow that soft init budget by 5–10x. A streaming pool keeps the same `MAX_CONCURRENT_PROBES = 5` cap without that blocking.
+
+The chunked pattern is still the right choice when per-task latency is genuinely bounded and uniform, when the batch is tiny, or when reading the code without context is more important than tail-latency tuning. The decision is a tradeoff between simplicity and tail-latency behavior, not a one-way upgrade.
 
 ## When to Apply
 
@@ -159,9 +140,9 @@ for (const entry of entries) {
 
 Use this when the batch is tiny or clarity matters more than total wall time.
 
-### 2) Current repo pattern — chunked waves of 5
+### 2) Chunked waves of 5 — the v0.1.1 shipped pattern (since replaced)
 
-This is the actual shipped approach in `src/runtime/orphan-reaper.ts:99-125`. It processes 10 entries in two waves of 5, so with bounded 1-second probes the batch is roughly `2 * timeout` in the "one slow entry per wave" shape.
+This was the v0.1.1 approach. It processes 10 entries in two waves of 5, so with bounded 1-second probes the batch is roughly `2 * timeout` in the "one slow entry per wave" shape.
 
 ```ts
 // src/runtime/orphan-reaper.ts:99-125
@@ -200,59 +181,45 @@ for (let i = 0; i < entries.length; i += 5) {
 }
 ```
 
-Why this is fine here:
+Why chunked was fine for v0.1.1:
 
-- bounded per-task timeout: `psField(..., 1000ms)` in `src/runtime/orphan-reaper.ts:35-38`
+- bounded per-task timeout (1s SIGTERM ceiling)
 - cold path: orphan cleanup during plugin init
 - small batch: up to 10 entries per file
 - tiny implementation surface
 
-Why it is not ideal:
+Why chunked stopped being the right tradeoff:
 
-- chunk `2` waits for the slowest task in chunk `1`
-- the literal `5` is currently inline, so the cap is implicit rather than named
-- real subprocess fan-out is higher than the test suggests because each entry does two probe calls in parallel
+- chunk `N+1` waits for the slowest task in chunk `N`
+- one slow `ps` (300-500ms is realistic on loaded systems) idles four sibling workers
+- batch wall time becomes `chunk_count * slowest_in_each_chunk`, which dominates init under load
 
-### 3) Streaming worker pool sketch — better tail behavior, more machinery
+### 3) Streaming worker pool — the now-shipped pattern
 
-A streaming pool keeps `K` tasks in flight and starts the next task as soon as any slot frees up. For the same "two slow entries total, everything else fast" distribution that makes chunked-of-5 take about 2 seconds, a streaming pool of 5 can overlap both slow entries and finish in about 1 second.
+A streaming pool spawns up to `K` workers that drain a shared queue independently. A slow probe blocks only its own worker; the others keep making progress. For the same "one slow entry, rest fast" distribution that takes the chunked pattern about 2 seconds, a streaming pool of 5 finishes in about 1 second, because the 9 fast probes don't have to wait for chunk-boundary synchronization.
 
 ```ts
-// illustrative streaming pool sketch, not the shipped code
 const queue = [...entries]
-const workers = Array.from({ length: 5 }, async () => {
-  while (queue.length > 0) {
+const workerCount = Math.min(MAX_CONCURRENT_PROBES, entries.length)
+const workers = Array.from({ length: workerCount }, async () => {
+  while (true) {
     const entry = queue.shift()
     if (!entry) return
-
-    try {
-      process.kill(entry.pid, 0)
-    } catch {
-      skipped++
-      continue
-    }
-
-    const [liveComm, liveLstart] = await Promise.all([
-      getPidComm(entry.pid),
-      getPidStartTime(entry.pid),
-    ])
-
-    if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
-      skipped++
-      continue
-    }
-
-    try {
-      await killProcessTree(entry.pid)
-      reaped++
-    } catch {
-      skipped++
-    }
+    const result = await processEntry(entry, killProcessTree, getPidIdentity)
+    if (result.reaped) reaped++
+    else if (result.skipped) skipped++
   }
 })
 
 await Promise.all(workers)
 ```
+
+Key properties:
+
+- `queue.shift()` is atomic in single-threaded JS — no race between the length check and the shift
+- `reaped`/`skipped` increments are also atomic from the perspective of concurrent async functions; no yield happens between the `++` read and write
+- a slow probe in worker `i` doesn't block workers `j ≠ i` from picking up new entries
+- the cap stays at `MAX_CONCURRENT_PROBES = 5`, so concurrency math is unchanged
 
 This is the better pattern when:
 
@@ -260,8 +227,6 @@ This is the better pattern when:
 - task runtimes vary a lot
 - the batch is larger
 - you want the queue to keep draining as soon as a fast task finishes
-
-But it is also more moving parts, more shared-state care, and more code than the repo currently needs.
 
 ### Timing summary
 

--- a/docs/solutions/best-practices/secure-process-introspection-array-spawn-ps-comm-field-2026-04-28.md
+++ b/docs/solutions/best-practices/secure-process-introspection-array-spawn-ps-comm-field-2026-04-28.md
@@ -27,7 +27,7 @@ tags:
 
 In a long-lived plugin, watchdog, or reaper, "I still have PID 1234, so it's safe to kill" is a bad assumption. PIDs get reused, so a stale pidfile can point at a completely unrelated process by the time cleanup runs. Matching `argv` is not enough either, because `args` is just process command-line presentation state and is much easier to spoof or mislead than a kernel-reported identity signal.
 
-In `src/runtime/orphan-reaper.ts`, the shipped fix closes both gaps: it re-reads the live process identity immediately before `killProcessTree`, and only proceeds when both `comm` and `lstart` still match the values captured at spawn time (`src/runtime/orphan-reaper.ts:109-115`). That combination defends against both stale PID reuse and "same PID, believable-looking argv" mistakes.
+In `src/runtime/orphan-reaper.ts`, the shipped fix closes both gaps: it re-reads the live process identity immediately before `killProcessTree`, and only proceeds when both `comm` and `lstart` still match the values captured at spawn time. That combination defends against both stale PID reuse and "same PID, believable-looking argv" mistakes.
 
 ## Guidance
 
@@ -43,9 +43,9 @@ Use a two-part identity gate before signaling any PID you are recovering from pe
 The core wrapper is small and boring, which is exactly what you want in a safety check:
 
 ```ts
-function psField(pid: number, field: string): Promise<string | null> {
+function runPs(args: string[]): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+    const child = spawn('ps', args)
     let stdout = ''
     let timedOut = false
 
@@ -55,9 +55,7 @@ function psField(pid: number, field: string): Promise<string | null> {
     }, 1000)
 ```
 
-— `src/runtime/orphan-reaper.ts:29-38`
-
-That first excerpt is the important spawn pattern: no shell, no string interpolation into a shell command, and a bounded timeout so introspection cannot wedge startup or cleanup forever.
+That is the important spawn pattern: no shell, no string interpolation into a shell command, and a bounded timeout so introspection cannot wedge startup or cleanup forever. The wrapper is generic over args (any ps invocation), which lets the caller decide what fields to read in a single shot.
 
 The second detail is easy to miss and worth preserving as part of the pattern, not a throwaway implementation note:
 
@@ -66,12 +64,8 @@ The second detail is easy to miss and worth preserving as part of the pattern, n
       stdout += chunk.toString('utf-8')
     })
     // Drain stderr so the OS pipe buffer never fills under backpressure.
-    // An unread stderr pipe on a long-running or backlogged ps invocation
-    // can stall the subprocess, blocking plugin init.
     child.stderr?.resume()
 ```
-
-— `src/runtime/orphan-reaper.ts:40-46`
 
 If a subprocess writes to `stderr` and the parent never drains it, the kernel pipe can fill. Once full, the child blocks on write, which means it may never exit, which means your seemingly harmless introspection helper can hang the system in exactly the path that is supposed to make cleanup safer.
 
@@ -94,26 +88,40 @@ The wrapper also normalizes failure to a safe default:
     })
 ```
 
-— `src/runtime/orphan-reaper.ts:48-60`
+Timeout, spawn error, non-zero exit, and empty output all become `null`. That is fine here because the caller only needs one answer: "can I still prove this is the same process?" If not, skip the kill.
 
-In the current implementation, timeout, spawn error, non-zero exit, and empty output all become `null`. That is fine here because the caller only needs one answer: "can I still prove this is the same process?" If not, skip the kill.
+For identity verification, prefer reading both `comm` and `lstart` in a single `ps` invocation. The combined query is atomic (one snapshot of the process table), halves fork/exec cost, and removes the small window where a PID could be reused between the `comm` query and the `lstart` query:
+
+```ts
+export async function getPidIdentity(
+  pid: number,
+): Promise<{ comm: string; lstart: string } | null> {
+  const raw = await runPs(['-p', String(pid), '-o', 'comm=,lstart='])
+  if (raw === null) return null
+  const firstWs = raw.search(/\s/)
+  if (firstWs === -1) return null
+  const comm = raw.slice(0, firstWs)
+  const lstart = raw.slice(firstWs).trim()
+  if (!comm || !lstart) return null
+  return { comm, lstart }
+}
+```
 
 The actual identity gate is the real win:
 
 ```ts
-const [liveComm, liveLstart] = await Promise.all([
-  getPidComm(entry.pid),
-  getPidStartTime(entry.pid),
-])
+const live = await getPidIdentity(entry.pid)
 
-if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+if (
+  live === null ||
+  live.comm !== entry.comm ||
+  live.lstart !== entry.lstart
+) {
   return { reaped: false, skipped: true }
 }
 ```
 
-— `src/runtime/orphan-reaper.ts:109-115`
-
-That `||` is the contract. If either leg of identity moved, the process is no longer trusted. No "close enough," no partial match, no best-effort kill.
+That triple `||` is the contract. If introspection failed at all, or if either leg of identity moved, the process is no longer trusted. No "close enough," no partial match, no best-effort kill.
 
 A clean way to describe the pattern is:
 
@@ -175,12 +183,9 @@ async function verifyIdentity(
   expectedComm: string,
   expectedLstart: string,
 ): Promise<boolean> {
-  const [liveComm, liveLstart] = await Promise.all([
-    getPidComm(pid),
-    getPidStartTime(pid),
-  ])
-
-  return liveComm === expectedComm && liveLstart === expectedLstart
+  const live = await getPidIdentity(pid)
+  if (!live) return false
+  return live.comm === expectedComm && live.lstart === expectedLstart
 }
 
 if (await verifyIdentity(recordedPid, recordedComm, recordedLstart)) {
@@ -194,7 +199,8 @@ Now the reused PID does not pass unless it is still the same process instance.
 
 ```ts
 // Still unsafe: a reused PID running the same binary can match this.
-if ((await getPidComm(recordedPid)) === recordedComm) {
+const live = await getPidIdentity(recordedPid)
+if (live && live.comm === recordedComm) {
   await killProcessTree(recordedPid)
 }
 ```
@@ -207,7 +213,7 @@ Failure mode:
 4. `comm` still matches.
 5. You kill the wrong `copilot` instance.
 
-Adding `lstart` distinguishes the old instance from the new one.
+Matching both `comm` and `lstart` distinguishes the old instance from the new one.
 
 **Shell-string `ps`: avoid this**
 
@@ -243,12 +249,17 @@ Benefits:
 **Practical wrapper shape**
 
 ```ts
-async function getPidField(pid: number, field: 'comm' | 'lstart') {
-  const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+async function getPidIdentity(
+  pid: number,
+): Promise<{ comm: string; lstart: string } | null> {
+  const child = spawn('ps', ['-p', String(pid), '-o', 'comm=,lstart='])
   child.stderr?.resume()
-  // collect stdout, enforce timeout, return trimmed value or null
+  // collect stdout, enforce timeout, parse `<comm> <lstart>`, return
+  // { comm, lstart } or null on any failure mode.
 }
 ```
+
+Reading both fields in one `ps` call is preferable to two separate calls: it is atomic from the kernel's perspective (no window between the queries), it halves fork/exec cost, and the parse is trivial because `comm` is a single token and `lstart` is everything after the first whitespace.
 
 That is the boring core. The safety comes from combining it with "skip kill unless both live values still match the recorded values."
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,7 @@ import type { Plugin } from '@opencode-ai/plugin'
 import { discoverAgents } from './discovery/agents'
 import { buildDescription } from './discovery/description'
 import { killProcessTree } from './lib/kill-tree'
-import {
-  getPidComm,
-  getPidStartTime,
-  reapOrphans,
-} from './runtime/orphan-reaper'
+import { getPidIdentity, reapOrphans } from './runtime/orphan-reaper'
 import { resolveInstancePidFilePath } from './runtime/pid-file'
 import { createCancelTool } from './tools/cancel'
 import { createDelegateTool } from './tools/delegate'
@@ -40,8 +36,7 @@ const CopilotDelegate: Plugin = async ({ client, directory }) => {
       pidFileDir,
       currentInstancePath,
       killProcessTree,
-      getPidComm,
-      getPidStartTime,
+      getPidIdentity,
     })
   } catch {
     // mkdir or reap failure must not block plugin init.

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -87,6 +87,14 @@ export async function getPidIdentity(
 ): Promise<{ comm: string; lstart: string } | null> {
   const raw = await runPs(['-p', String(pid), '-o', 'comm=,lstart='])
   if (raw === null) return null
+  // Splitting on the first whitespace is safe because `comm` is the kernel-
+  // tracked process name field, which is a single non-whitespace token capped
+  // at 15 chars on Linux and 16 chars on macOS. `lstart` is the multi-word
+  // date string that follows. If a future refactor adds different `-o` fields
+  // or runs on a platform that pads `comm` differently, this parse silently
+  // truncates at the first whitespace — the identity gate would then fail
+  // safe (skip, not kill) because the truncated value won't match the
+  // recorded one.
   const firstWs = raw.search(/\s/)
   if (firstWs === -1) return null
   const comm = raw.slice(0, firstWs)
@@ -171,6 +179,10 @@ async function processEntries(
       const entry = queue.shift()
       if (!entry) return
       const result = await processEntry(entry, killProcessTree, getPidIdentity)
+      // Mutating shared `reaped`/`skipped` from concurrent workers is safe
+      // because JS executes each ++ as a single synchronous read-modify-write
+      // with no yield between the read and the store. Workers only interleave
+      // at await boundaries, never inside a ++.
       if (result.reaped) reaped++
       else if (result.skipped) skipped++
     }

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -5,8 +5,9 @@ import { isErrnoException } from '../lib/errno'
 
 export interface ReapDeps {
   killProcessTree: (pid: number) => Promise<void>
-  getPidComm: (pid: number) => Promise<string | null>
-  getPidStartTime: (pid: number) => Promise<string | null>
+  getPidIdentity: (
+    pid: number,
+  ) => Promise<{ comm: string; lstart: string } | null>
   isPluginAlive: (pid: number) => boolean
 }
 
@@ -26,9 +27,18 @@ export function defaultIsPluginAlive(pid: number): boolean {
   }
 }
 
-function psField(pid: number, field: string): Promise<string | null> {
+/**
+ * Spawn `ps` with the given args, return trimmed stdout, or null on any
+ * failure mode (timeout, spawn error, non-zero exit, empty output).
+ *
+ * Bounded 1-second SIGTERM timeout. Stderr is drained via resume() so the
+ * OS pipe buffer never fills under backpressure — an unread stderr pipe on
+ * a long-running or backlogged ps invocation can stall the subprocess and
+ * block plugin init.
+ */
+function runPs(args: string[]): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = spawn('ps', ['-p', String(pid), '-o', `${field}=`])
+    const child = spawn('ps', args)
     let stdout = ''
     let timedOut = false
 
@@ -40,9 +50,6 @@ function psField(pid: number, field: string): Promise<string | null> {
     child.stdout?.on('data', (chunk: Buffer) => {
       stdout += chunk.toString('utf-8')
     })
-    // Drain stderr so the OS pipe buffer never fills under backpressure.
-    // An unread stderr pipe on a long-running or backlogged ps invocation
-    // can stall the subprocess, blocking plugin init.
     child.stderr?.resume()
 
     child.on('close', (code) => {
@@ -62,12 +69,30 @@ function psField(pid: number, field: string): Promise<string | null> {
   })
 }
 
-export async function getPidComm(pid: number): Promise<string | null> {
-  return psField(pid, 'comm')
-}
-
-export async function getPidStartTime(pid: number): Promise<string | null> {
-  return psField(pid, 'lstart')
+/**
+ * Read both comm (kernel-tracked executable name) and lstart (process
+ * start time) for a PID via a single ps invocation.
+ *
+ * Halves the fork/exec cost of identity verification compared with two
+ * separate `ps -o comm=` and `ps -o lstart=` calls. The combined output
+ * format is `<comm> <lstart>` where comm is a single token and lstart is
+ * a multi-word date string (e.g., `Tue Apr 28 23:45:30 2026`).
+ *
+ * Returns null on any failure mode (timeout, spawn error, non-zero exit,
+ * empty output, malformed output). Callers must treat null as "identity
+ * unverifiable; do not trust this PID."
+ */
+export async function getPidIdentity(
+  pid: number,
+): Promise<{ comm: string; lstart: string } | null> {
+  const raw = await runPs(['-p', String(pid), '-o', 'comm=,lstart='])
+  if (raw === null) return null
+  const firstWs = raw.search(/\s/)
+  if (firstWs === -1) return null
+  const comm = raw.slice(0, firstWs)
+  const lstart = raw.slice(firstWs).trim()
+  if (!comm || !lstart) return null
+  return { comm, lstart }
 }
 
 interface PidEntry {
@@ -90,8 +115,7 @@ function parseLine(line: string): PidEntry | null {
 async function processEntries(
   entries: PidEntry[],
   killProcessTree: ReapDeps['killProcessTree'],
-  getPidComm: ReapDeps['getPidComm'],
-  getPidStartTime: ReapDeps['getPidStartTime'],
+  getPidIdentity: ReapDeps['getPidIdentity'],
 ): Promise<{ reaped: number; skipped: number }> {
   let reaped = 0
   let skipped = 0
@@ -106,12 +130,13 @@ async function processEntries(
           return { reaped: false, skipped: true }
         }
 
-        const [liveComm, liveLstart] = await Promise.all([
-          getPidComm(entry.pid),
-          getPidStartTime(entry.pid),
-        ])
+        const live = await getPidIdentity(entry.pid)
 
-        if (liveComm !== entry.comm || liveLstart !== entry.lstart) {
+        if (
+          live === null ||
+          live.comm !== entry.comm ||
+          live.lstart !== entry.lstart
+        ) {
           return { reaped: false, skipped: true }
         }
 
@@ -183,8 +208,7 @@ async function reapOneFile(
   currentInstancePath: string,
   isPluginAlive: ReapDeps['isPluginAlive'],
   killProcessTree: ReapDeps['killProcessTree'],
-  getPidComm: ReapDeps['getPidComm'],
-  getPidStartTime: ReapDeps['getPidStartTime'],
+  getPidIdentity: ReapDeps['getPidIdentity'],
 ): Promise<ReapFileOutcome> {
   const empty: ReapFileOutcome = {
     reaped: 0,
@@ -205,8 +229,7 @@ async function reapOneFile(
   const { reaped, skipped } = await processEntries(
     entries,
     killProcessTree,
-    getPidComm,
-    getPidStartTime,
+    getPidIdentity,
   )
   const deleted = await cleanupAfterReap(
     filePath,
@@ -220,16 +243,14 @@ export async function reapOrphans(opts: {
   pidFileDir: string
   currentInstancePath: string
   killProcessTree: ReapDeps['killProcessTree']
-  getPidComm: ReapDeps['getPidComm']
-  getPidStartTime: ReapDeps['getPidStartTime']
+  getPidIdentity: ReapDeps['getPidIdentity']
   isPluginAlive?: ReapDeps['isPluginAlive']
 }): Promise<ReapResult> {
   const {
     pidFileDir,
     currentInstancePath,
     killProcessTree,
-    getPidComm,
-    getPidStartTime,
+    getPidIdentity,
     isPluginAlive = defaultIsPluginAlive,
   } = opts
 
@@ -265,8 +286,7 @@ export async function reapOrphans(opts: {
       currentInstancePath,
       isPluginAlive,
       killProcessTree,
-      getPidComm,
-      getPidStartTime,
+      getPidIdentity,
     )
 
     reaped += outcome.reaped

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -112,6 +112,42 @@ function parseLine(line: string): PidEntry | null {
   return { pid, comm: parts[1], lstart: parts[2] }
 }
 
+/**
+ * Maximum concurrent ps probes during reap. A streaming worker pool of
+ * this size drains the entry queue without head-of-line blocking: a slow
+ * probe in one worker doesn't stall the others.
+ */
+const MAX_CONCURRENT_PROBES = 5
+
+async function processEntry(
+  entry: PidEntry,
+  killProcessTree: ReapDeps['killProcessTree'],
+  getPidIdentity: ReapDeps['getPidIdentity'],
+): Promise<{ reaped: boolean; skipped: boolean }> {
+  try {
+    process.kill(entry.pid, 0)
+  } catch {
+    return { reaped: false, skipped: true }
+  }
+
+  const live = await getPidIdentity(entry.pid)
+
+  if (
+    live === null ||
+    live.comm !== entry.comm ||
+    live.lstart !== entry.lstart
+  ) {
+    return { reaped: false, skipped: true }
+  }
+
+  try {
+    await killProcessTree(entry.pid)
+    return { reaped: true, skipped: false }
+  } catch {
+    return { reaped: false, skipped: true }
+  }
+}
+
 async function processEntries(
   entries: PidEntry[],
   killProcessTree: ReapDeps['killProcessTree'],
@@ -120,40 +156,27 @@ async function processEntries(
   let reaped = 0
   let skipped = 0
 
-  for (let i = 0; i < entries.length; i += 5) {
-    const chunk = entries.slice(i, i + 5)
-    const results = await Promise.all(
-      chunk.map(async (entry) => {
-        try {
-          process.kill(entry.pid, 0)
-        } catch {
-          return { reaped: false, skipped: true }
-        }
-
-        const live = await getPidIdentity(entry.pid)
-
-        if (
-          live === null ||
-          live.comm !== entry.comm ||
-          live.lstart !== entry.lstart
-        ) {
-          return { reaped: false, skipped: true }
-        }
-
-        try {
-          await killProcessTree(entry.pid)
-          return { reaped: true, skipped: false }
-        } catch {
-          return { reaped: false, skipped: true }
-        }
-      }),
-    )
-
-    for (const r of results) {
-      if (r.reaped) reaped++
-      else if (r.skipped) skipped++
+  // Streaming worker pool: spawn up to MAX_CONCURRENT_PROBES workers that
+  // drain a shared queue independently. Each worker pulls the next entry,
+  // processes it, and loops until the queue is empty. A slow probe blocks
+  // only its own worker; the other workers keep making progress.
+  //
+  // Single-threaded JS guarantees `queue.shift()` is atomic: there is no
+  // window between the length check and the shift where another worker
+  // can interleave.
+  const queue = [...entries]
+  const workerCount = Math.min(MAX_CONCURRENT_PROBES, entries.length)
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const entry = queue.shift()
+      if (!entry) return
+      const result = await processEntry(entry, killProcessTree, getPidIdentity)
+      if (result.reaped) reaped++
+      else if (result.skipped) skipped++
     }
-  }
+  })
+
+  await Promise.all(workers)
 
   return { reaped, skipped }
 }

--- a/src/runtime/task-registry.ts
+++ b/src/runtime/task-registry.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { killProcessTree } from '../lib/kill-tree'
-import { getPidComm, getPidStartTime } from './orphan-reaper'
+import { getPidIdentity } from './orphan-reaper'
 import { appendPidEntry } from './pid-file'
 import type { SpawnCopilotResult } from './subprocess'
 
@@ -36,15 +36,19 @@ export function createTask(
   }
 
   if (task.pid > 0 && pidFilePath) {
-    Promise.all([getPidComm(task.pid), getPidStartTime(task.pid)])
-      .then(([comm, lstart]) => {
-        if (comm && lstart) {
-          appendPidEntry(pidFilePath, task.pid, comm, lstart).catch(() => {})
+    getPidIdentity(task.pid)
+      .then((identity) => {
+        if (identity) {
+          appendPidEntry(
+            pidFilePath,
+            task.pid,
+            identity.comm,
+            identity.lstart,
+          ).catch(() => {})
         } else {
-          // ps lookup returned null for at least one field. Most likely the
-          // process has already exited (e.g., copilot CLI failed to launch),
-          // but it could also mean the kernel hasn't surfaced the entry yet.
-          // Either way, we cannot append without both fields, so the
+          // ps lookup returned null. Most likely the process has already
+          // exited (e.g., copilot CLI failed to launch), but it could also
+          // mean the kernel hasn't surfaced the entry yet. Either way, the
           // subprocess is invisible to the orphan reaper. Surface a warning
           // so degraded coverage is observable.
           console.warn(

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -332,10 +332,14 @@ describe('orphan-reaper', () => {
       })
 
       expect(res.reaped).toBe(10)
-      // With a streaming worker pool, the 9 fast probes proceed past the
-      // slow first probe instead of being trapped behind a Promise.all
-      // wave. With chunked-of-5, only 4 fast probes can finish before the
-      // slow one (the rest wait for the next chunk).
+      // With a streaming worker pool: the slow probe occupies worker 0 for
+      // 200ms; workers 1–4 each handle ~2-3 of the remaining 9 fast probes
+      // (10ms each) and finish well before t=200ms. All 9 fast probes complete
+      // before the slow one, hence the >= 9 lower bound.
+      //
+      // With chunked-of-5: the first chunk of 5 (1 slow + 4 fast) waits for
+      // the slow probe at t=200ms; the next chunk of 5 fast probes only starts
+      // at t=200ms and all finish AFTER the slow one, yielding exactly 4.
       expect(finishedBeforeSlow).toBeGreaterThanOrEqual(9)
     })
 

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -299,6 +299,46 @@ describe('orphan-reaper', () => {
   })
 
   describe('concurrency', () => {
+    it('should not block subsequent entries on a single slow probe (streaming worker pool)', async () => {
+      const dir = makeTempDir()
+      const currentPath = join(dir, `${process.pid}.pids`)
+      let callCount = 0
+      let slowFinished = false
+      let finishedBeforeSlow = 0
+
+      const entries = Array.from({ length: 10 }, () => ({
+        pid: process.pid,
+        comm: 'copilot',
+        lstart: 't0',
+      }))
+      writePidFile(currentPath, entries)
+
+      const res = await reapOrphans({
+        pidFileDir: dir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidIdentity: async () => {
+          callCount++
+          const isSlow = callCount === 1
+          const delay = isSlow ? 200 : 10
+          await new Promise((r) => setTimeout(r, delay))
+          if (isSlow) {
+            slowFinished = true
+          } else if (!slowFinished) {
+            finishedBeforeSlow++
+          }
+          return { comm: 'copilot', lstart: 't0' }
+        },
+      })
+
+      expect(res.reaped).toBe(10)
+      // With a streaming worker pool, the 9 fast probes proceed past the
+      // slow first probe instead of being trapped behind a Promise.all
+      // wave. With chunked-of-5, only 4 fast probes can finish before the
+      // slow one (the rest wait for the next chunk).
+      expect(finishedBeforeSlow).toBeGreaterThanOrEqual(9)
+    })
+
     it('should cap concurrent getPidIdentity invocations at 5 for 10 entries', async () => {
       const dir = makeTempDir()
       const currentPath = join(dir, `${process.pid}.pids`)

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   defaultIsPluginAlive,
+  getPidIdentity,
   type ReapResult,
   reapOrphans,
 } from '../src/runtime/orphan-reaper'
@@ -42,8 +43,7 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => null,
-        getPidStartTime: async () => null,
+        getPidIdentity: async () => null,
       })
 
       expect(res).toEqual(result())
@@ -64,8 +64,7 @@ describe('orphan-reaper', () => {
         killProcessTree: async (pid) => {
           killedPids.push(pid)
         },
-        getPidComm: async () => 'copilot',
-        getPidStartTime: async () => 't1',
+        getPidIdentity: async () => ({ comm: 'copilot', lstart: 't1' }),
       })
 
       expect(res).toEqual(
@@ -105,13 +104,9 @@ describe('orphan-reaper', () => {
         killProcessTree: async (pid) => {
           killedPids.push(pid)
         },
-        getPidComm: async (pid) => {
-          if (pid === process.pid || pid === process.ppid) return 'copilot'
-          return null
-        },
-        getPidStartTime: async (pid) => {
-          if (pid === process.pid) return 't1'
-          if (pid === process.ppid) return 't3'
+        getPidIdentity: async (pid) => {
+          if (pid === process.pid) return { comm: 'copilot', lstart: 't1' }
+          if (pid === process.ppid) return { comm: 'copilot', lstart: 't3' }
           return null
         },
         isPluginAlive: (pid) => {
@@ -150,8 +145,7 @@ describe('orphan-reaper', () => {
         killProcessTree: async (pid) => {
           killedPids.push(pid)
         },
-        getPidComm: async () => 'copilot',
-        getPidStartTime: async () => 't1',
+        getPidIdentity: async () => ({ comm: 'copilot', lstart: 't1' }),
         isPluginAlive: () => true,
       })
 
@@ -180,8 +174,7 @@ describe('orphan-reaper', () => {
           pidFileDir: dir,
           currentInstancePath: currentPath,
           killProcessTree: async () => {},
-          getPidComm: async () => null,
-          getPidStartTime: async () => null,
+          getPidIdentity: async () => null,
         })
 
         expect(res).toEqual(result())
@@ -207,8 +200,7 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => null,
-        getPidStartTime: async () => null,
+        getPidIdentity: async () => null,
         isPluginAlive: (pid) => pid !== 9999,
       })
 
@@ -231,8 +223,7 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => 'not-copilot',
-        getPidStartTime: async () => 't1',
+        getPidIdentity: async () => ({ comm: 'not-copilot', lstart: 't1' }),
         isPluginAlive: (pid) => pid !== 9999,
       })
 
@@ -254,8 +245,7 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => 'not-copilot',
-        getPidStartTime: async () => 't1',
+        getPidIdentity: async () => ({ comm: 'not-copilot', lstart: 't1' }),
       })
 
       expect(res).toEqual(
@@ -276,8 +266,10 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => 'copilot',
-        getPidStartTime: async () => 'different-time',
+        getPidIdentity: async () => ({
+          comm: 'copilot',
+          lstart: 'different-time',
+        }),
       })
 
       expect(res).toEqual(
@@ -296,8 +288,7 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => null,
-        getPidStartTime: async () => null,
+        getPidIdentity: async () => null,
       })
 
       expect(res).toEqual(
@@ -308,7 +299,7 @@ describe('orphan-reaper', () => {
   })
 
   describe('concurrency', () => {
-    it('should cap concurrent getPidComm invocations at 5 for 10 entries', async () => {
+    it('should cap concurrent getPidIdentity invocations at 5 for 10 entries', async () => {
       const dir = makeTempDir()
       const currentPath = join(dir, `${process.pid}.pids`)
       let maxConcurrent = 0
@@ -325,16 +316,12 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => {
+        getPidIdentity: async () => {
           currentConcurrent++
           maxConcurrent = Math.max(maxConcurrent, currentConcurrent)
           await new Promise((r) => setTimeout(r, 30))
           currentConcurrent--
-          return 'copilot'
-        },
-        getPidStartTime: async () => {
-          await new Promise((r) => setTimeout(r, 30))
-          return 't0'
+          return { comm: 'copilot', lstart: 't0' }
         },
       })
 
@@ -360,8 +347,7 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => 'copilot',
-        getPidStartTime: async () => 't1',
+        getPidIdentity: async () => ({ comm: 'copilot', lstart: 't1' }),
       })
 
       expect(res).toEqual(
@@ -386,13 +372,9 @@ describe('orphan-reaper', () => {
           if (pid === process.pid) throw new Error('kill failed')
           killedPids.push(pid)
         },
-        getPidComm: async (pid) => {
-          if (pid === process.pid || pid === process.ppid) return 'copilot'
-          return null
-        },
-        getPidStartTime: async (pid) => {
-          if (pid === process.pid) return 't1'
-          if (pid === process.ppid) return 't2'
+        getPidIdentity: async (pid) => {
+          if (pid === process.pid) return { comm: 'copilot', lstart: 't1' }
+          if (pid === process.ppid) return { comm: 'copilot', lstart: 't2' }
           return null
         },
       })
@@ -403,7 +385,7 @@ describe('orphan-reaper', () => {
       expect(killedPids).toEqual([process.ppid])
     })
 
-    it('should skip when getPidStartTime returns null for alive PID', async () => {
+    it('should skip when getPidIdentity returns null for alive PID', async () => {
       const dir = makeTempDir()
       const currentPath = join(dir, `${process.pid}.pids`)
 
@@ -415,8 +397,7 @@ describe('orphan-reaper', () => {
         pidFileDir: dir,
         currentInstancePath: currentPath,
         killProcessTree: async () => {},
-        getPidComm: async () => 'copilot',
-        getPidStartTime: async () => null,
+        getPidIdentity: async () => null,
       })
 
       expect(res).toEqual(
@@ -429,8 +410,7 @@ describe('orphan-reaper', () => {
         pidFileDir: '/nonexistent/dir/for/sure',
         currentInstancePath: '/nonexistent/dir/for/sure/test.pids',
         killProcessTree: async () => {},
-        getPidComm: async () => null,
-        getPidStartTime: async () => null,
+        getPidIdentity: async () => null,
       })
 
       expect(res).toEqual(result())
@@ -444,6 +424,23 @@ describe('orphan-reaper', () => {
 
     it('should return false for non-existent PID', () => {
       expect(defaultIsPluginAlive(99999)).toBe(false)
+    })
+  })
+
+  describe('getPidIdentity', () => {
+    it('should return both comm and lstart for the current process from a single ps call', async () => {
+      const identity = await getPidIdentity(process.pid)
+      expect(identity).not.toBeNull()
+      expect(typeof identity?.comm).toBe('string')
+      expect(identity?.comm.length).toBeGreaterThan(0)
+      expect(typeof identity?.lstart).toBe('string')
+      expect(identity?.lstart.length).toBeGreaterThan(0)
+    })
+
+    it('should return null for a non-existent PID', async () => {
+      // 4_194_305 is above pid_max on Linux/macOS, guaranteed not assigned.
+      const identity = await getPidIdentity(4_194_305)
+      expect(identity).toBeNull()
     })
   })
 })

--- a/tests/task-registry.test.ts
+++ b/tests/task-registry.test.ts
@@ -114,8 +114,10 @@ describe('task registry PID-file hooks', () => {
           cwd: process.cwd(),
           stdoutLineBuffer: '',
           events: [],
-          // biome-ignore lint/suspicious/noExplicitAny: ghost-pid fixture has no real child
-          child: { pid: ghostPid } as any,
+          // Double-cast through unknown: this fixture intentionally only sets
+          // pid because the silent-skip path under test exits before any other
+          // child property is read.
+          child: { pid: ghostPid } as unknown as ReturnType<typeof Bun.spawn>,
           completionPromise: Promise.resolve(),
           abortController,
           pidFilePath,

--- a/tests/task-registry.test.ts
+++ b/tests/task-registry.test.ts
@@ -89,7 +89,7 @@ describe('task registry PID-file hooks', () => {
   })
 
   it('warns and skips append when ps lookup returns null', async () => {
-    // Use a never-existed PID so getPidComm/getPidStartTime return null.
+    // Use a never-existed PID so getPidIdentity returns null.
     // PIDs above 2^22 are guaranteed unused on Linux/macOS (kernel pid_max).
     const ghostPid = 4_194_305
 


### PR DESCRIPTION
Two performance improvements to the plugin-init orphan-subprocess reaper, both surfaced in the runtime hardening follow-ups tracking issue (#49). Resolves four of its eighteen items in one focused branch.

## Streaming worker pool replaces chunked Promise.all

The reaper previously processed PID entries in chunks of 5 with `Promise.all`. A single slow `ps` invocation (300-500ms is realistic on loaded systems) would idle four sibling workers in the same chunk until it returned, blowing the soft init budget by 5-10x.

Replace the chunked loop with a streaming worker pool: spawn up to `MAX_CONCURRENT_PROBES = 5` workers that drain a shared queue independently. A slow probe blocks only its own worker; the other workers keep making progress. Single-threaded JS guarantees `queue.shift()` is atomic between workers.

The TDD test demonstrates the head-of-line blocking fix: with 10 entries where the first probe takes 200ms and the rest take 10ms, the streaming pool finishes 9 fast probes before the slow one. The chunked implementation only finished 4.

## Combined ps probe halves fork/exec cost

Replace the two separate `ps` invocations (`getPidComm` + `getPidStartTime`) with a single `getPidIdentity(pid)` call that uses `ps -p <pid> -o comm=,lstart=` to read both fields atomically. Halves fork/exec cost on the reap hot path and at task spawn time.

Side benefit: also resolves the related "Concurrency-cap test scope" item from #49. The test previously tracked only `getPidComm` concurrency, missing the parallel `getPidStartTime` invocations. With one combined function, the cap test now naturally captures the actual `ps` subprocess concurrency (5 workers ⇒ at most 5 concurrent `ps` subprocesses, not 10).

## Maintainability cleanup

Extract `MAX_CONCURRENT_PROBES = 5` as a named top-level constant alongside the streaming pool implementation, also from the #49 maintainability bucket.

## Documentation refresh

Both pattern docs in `docs/solutions/best-practices/` referenced the v0.1.1 implementations:

- The bounded-concurrency-worker-pool doc previously framed chunked `Promise.all` as "the actual shipped approach." Reframe as a tradeoff comparison: chunked is the simpler choice when per-task latency is bounded and uniform; streaming is the right pick when one slow task should not delay the next ready task. The streaming pool example now reflects the real implementation.
- The secure-process-introspection doc previously documented the two separate `getPidComm` / `getPidStartTime` calls. Update to show the combined `getPidIdentity` invocation, with a note explaining why the combined approach is preferable (atomic kernel snapshot, halved fork/exec cost, no PID-reuse window between queries).

## Verification

- typecheck / lint / build clean
- 134 unit tests pass / 0 fail (was 131 on main; +2 for `getPidIdentity` real-PID and ghost-PID cases, +1 for the streaming-pool head-of-line blocking test)
- TDD discipline: both new behaviors tested RED first, implementation written to make the assertion pass, no after-the-fact tests
- No drift with main
- Bundle size unchanged at 0.33 MB
- No public API changes