### PR TITLE
fix(tools): drop BUILTIN_AGENTS and enrich copilot_* tool schemas

### DIFF
--- a/.changeset/agents-and-schema-enrichment.md
+++ b/.changeset/agents-and-schema-enrichment.md
@@ -1,0 +1,11 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Drop `BUILTIN_AGENTS` and enrich tool schema descriptions
+
+**`BUILTIN_AGENTS` removal.** The plugin previously advertised six "built-in" agent names — `default`, `explore`, `task`, `general-purpose`, `code-review`, `research` — inherited from VS Code Copilot Chat / OpenCode conventions. The standalone `@github/copilot` CLI v1.0.36 ships zero of these; passing any of them as `--agent <name>` causes Copilot CLI to fail at spawn time with `Error: No such agent: <name>, available:`. The constant has been removed. `discoverAgents` now returns user agents (filtered by repo override) followed by repo agents; `Agent.source` is `'user' | 'repo'`. `buildDescription` handles the empty-discovery case by emitting an actionable hint pointing at `~/.copilot/agents` and `.github/agents`.
+
+**Tool schema enrichment.** The three exposed tools — `copilot_delegate`, `copilot_output`, `copilot_cancel` — now ship multi-paragraph tool descriptions covering what they do, when to use them, lifecycle, common pitfalls, and return-value shape. Per-parameter `.describe()` text spells out type, default, when-required, example values, and constraints. Examples follow the patterns Magic Context's `ctx_*` tools established. The new descriptions surface in OpenCode's tool registry exposure to LLMs and via `mise run opencode:doctor --only tools`.
+
+No runtime behavior change beyond the agent discovery fix. Tool argument shapes are unchanged; existing callers continue to work without modification.

--- a/src/discovery/agents.ts
+++ b/src/discovery/agents.ts
@@ -3,17 +3,8 @@ import { basename } from 'node:path'
 
 export interface Agent {
   name: string
-  source: 'builtin' | 'user' | 'repo'
+  source: 'user' | 'repo'
 }
-
-const BUILTIN_AGENTS: readonly string[] = [
-  'default',
-  'explore',
-  'task',
-  'general-purpose',
-  'code-review',
-  'research',
-]
 
 interface DiscoverOptions {
   userAgentsDir?: string
@@ -34,12 +25,19 @@ function scanDir(dir: string, source: 'user' | 'repo'): Agent[] {
   }
 }
 
+/**
+ * Discover Copilot agents from the user and repo agent directories.
+ *
+ * Copilot CLI v1.0.36 ships zero built-in agents. Every `--agent <name>`
+ * argument must resolve to a discoverable `<name>.md` file in one of the
+ * standard agent directories (`~/.copilot/agents`, `.github/agents`, or
+ * `~/.copilot/installed-plugins/<plugin>/agents`). The plugin discovers the
+ * first two; bundled-with-plugin agents are out of scope for this discovery
+ * helper.
+ *
+ * Repo agents override user agents with the same name; the repo entry wins.
+ */
 export function discoverAgents(opts: DiscoverOptions): Agent[] {
-  const builtins: Agent[] = BUILTIN_AGENTS.map((name) => ({
-    name,
-    source: 'builtin',
-  }))
-
   const userAgents = opts.userAgentsDir
     ? scanDir(opts.userAgentsDir, 'user')
     : []
@@ -48,13 +46,9 @@ export function discoverAgents(opts: DiscoverOptions): Agent[] {
     ? scanDir(opts.repoAgentsDir, 'repo')
     : []
 
-  // Repo overrides user with same name; builtins are never overridden
-  const builtinNames = new Set(BUILTIN_AGENTS)
+  // Repo overrides user with same name.
   const overriddenNames = new Set(repoAgents.map((a) => a.name))
-  const filteredUser = userAgents
-    .filter((a) => !builtinNames.has(a.name))
-    .filter((a) => !overriddenNames.has(a.name))
-  const filteredRepo = repoAgents.filter((a) => !builtinNames.has(a.name))
+  const filteredUser = userAgents.filter((a) => !overriddenNames.has(a.name))
 
-  return [...builtins, ...filteredUser, ...filteredRepo]
+  return [...filteredUser, ...repoAgents]
 }

--- a/src/discovery/description.ts
+++ b/src/discovery/description.ts
@@ -2,7 +2,21 @@ import type { Agent } from './agents'
 
 const MAX_DISPLAYED = 20
 
+/**
+ * Render a human-readable list of discovered agents for inclusion in the
+ * `copilot_delegate` tool description. Lists user and repo agents (no
+ * builtins; Copilot CLI v1.0.36 ships none). Truncates at MAX_DISPLAYED
+ * entries with a count of the rest.
+ */
 export function buildDescription(agents: Agent[]): string {
+  if (agents.length === 0) {
+    return [
+      'No Copilot agents discovered.',
+      'Add `.agent.md` files to `~/.copilot/agents` (user-level) or',
+      '`.github/agents` (repo-level) to make them available here.',
+    ].join('\n')
+  }
+
   const displayed = agents.slice(0, MAX_DISPLAYED)
   const remaining = agents.length - MAX_DISPLAYED
 
@@ -14,7 +28,7 @@ export function buildDescription(agents: Agent[]): string {
 
   if (remaining > 0) {
     lines.push(
-      `  ... and ${remaining} more (use copilot_list_agents to see all)`,
+      `  ... and ${remaining} more (see ~/.copilot/agents or .github/agents)`,
     )
   }
 

--- a/src/tools/cancel.ts
+++ b/src/tools/cancel.ts
@@ -1,13 +1,33 @@
 import { tool } from '@opencode-ai/plugin/tool'
 import { getTask } from '../runtime/task-registry'
 
+const TOOL_DESCRIPTION = [
+  'Cancel a running Copilot delegation.',
+  '',
+  'Aborts the in-flight subprocess via its `AbortController`; the subprocess receives SIGTERM through',
+  'its process tree and the task transitions to `cancelled`. Any pending `copilot_output` block calls',
+  'unblock immediately with the cancelled envelope.',
+  '',
+  'Returns `{ cancelled, was_running }`:',
+  '- `cancelled: true, was_running: true`  — task was running and the abort signal was sent.',
+  '- `cancelled: false, was_running: false` — task is unknown to this process, or already terminal',
+  '  (`succeeded` / `failed` / `cancelled`). Idempotent — safe to call multiple times.',
+  '',
+  'Use when:',
+  "- The user changes direction during a long-running delegation and the task's output is no longer needed.",
+  '- The agent has determined a delegation has gone wrong (e.g., wrong agent selected) and a fresh delegate is preferable to waiting.',
+  '- Concurrency limit pressure — cancel a stale low-priority task to free a slot for a higher-priority delegation.',
+].join('\n')
+
 export function createCancelTool() {
   return tool({
-    description: 'Cancel a running Copilot delegation.',
+    description: TOOL_DESCRIPTION,
     args: {
       task_id: tool.schema
         .string()
-        .describe('Task ID returned by copilot_delegate.'),
+        .describe(
+          'The task ID returned by `copilot_delegate(...)`. Format: `cpl_<...>`. Required. Idempotent — non-running task IDs return `{ cancelled: false, was_running: false }` without error.',
+        ),
     },
     async execute(args) {
       const task = getTask(args.task_id)

--- a/src/tools/delegate.ts
+++ b/src/tools/delegate.ts
@@ -26,42 +26,78 @@ function appendRepeatedFlag(
   }
 }
 
+const TOOL_DESCRIPTION = [
+  'Delegate a task to GitHub Copilot CLI as a background subprocess.',
+  '',
+  'Returns a `task_id` immediately so the parent agent can continue other work in parallel.',
+  'When Copilot completes, a `system-reminder` is injected into this OpenCode session and the',
+  'agent retrieves the structured result with `copilot_output(task_id)`.',
+  '',
+  'Use for:',
+  '- Long-running research, implementation, or multi-step automation that would otherwise stall the parent session.',
+  '- Running multiple Copilot calls in parallel (subject to a 10-call concurrency cap, enforced here).',
+  '- Isolating Copilot tool permissions per-task via `allow_tool` / `deny_tool`.',
+  '',
+  'Do not use for:',
+  '- Short single-turn prompts the parent session can answer directly.',
+  '- Tasks where the prompt would contain secrets — Copilot CLI exposes prompts in `ps` output (upstream limitation).',
+  '',
+  'Lifecycle:',
+  '1. `copilot_delegate(...)` → returns `{ task_id }`. The subprocess starts immediately.',
+  '2. Continue with other work; do not poll `copilot_output` while the task is running.',
+  '3. When the task ends (success, error, or cancellation) a `system-reminder` arrives in this session.',
+  '4. `copilot_output(task_id)` returns the structured envelope (status, exit_code, final_message, summary, events, ...).',
+  '5. `copilot_cancel(task_id)` aborts a running task at any time.',
+  '',
+  'Concurrency: at most 10 Copilot delegations may be running concurrently per OpenCode session. Exceeding the cap returns `{ error: ... }` and the agent should wait for an in-flight task to complete or cancel.',
+  '',
+  'Agent argument: `--agent <name>` must resolve to a discovered `<name>.md` file in `~/.copilot/agents` (user-level) or `.github/agents` (repo-level). An unrecognized name is rejected by Copilot CLI at spawn time.',
+  '',
+].join('\n')
+
 export function createDelegateTool(options: DelegateToolOptions) {
   return tool({
-    description:
-      'Delegate a task to GitHub Copilot CLI as a background subprocess.\n' +
-      'Returns a task_id immediately; parent agent continues other work.\n' +
-      'When Copilot completes, a system-reminder is injected into this session.\n' +
-      'Retrieve the structured result with `copilot_output(task_id)`.\n\n' +
-      options.description,
+    description: `${TOOL_DESCRIPTION}${options.description}`,
     args: {
       prompt: tool.schema
         .string()
         .min(1)
-        .describe('The prompt to send to Copilot CLI.'),
+        .describe(
+          'The instruction Copilot should execute. The prompt body is the entire user-visible task; Copilot owns the planning, tool selection, and execution. Required and must be non-empty. Visible in `ps` output (upstream limitation) — never include secrets, tokens, or PII.',
+        ),
       agent: tool.schema
         .string()
         .optional()
-        .describe('Copilot agent name. Omit for default.'),
+        .describe(
+          'Agent name (without .md extension) to use for this task. Must match a discovered agent file in `~/.copilot/agents` or `.github/agents`. The list of currently discovered agents appears at the bottom of this tool description; an empty list means no agents are discoverable and `agent` must be omitted. Omit to use the Copilot CLI default.',
+        ),
       model: tool.schema
         .string()
         .optional()
-        .describe('Model override. Omit for default.'),
+        .describe(
+          "Override the default model for this task. Accepts any model string Copilot CLI recognizes — for example `claude-opus-4.7`, `claude-sonnet-4.7`, or `gpt-5`. Omit to use the user's configured default.",
+        ),
       add_dir: tool.schema
         .string()
         .array()
         .optional()
-        .describe('Additional directories to allow.'),
+        .describe(
+          'Additional repository paths to grant Copilot access to (multi-repo workflows). Each entry becomes a `--add-dir <path>` flag. Use absolute paths. Examples: `["/Users/me/repo-a", "/Users/me/repo-b"]`.',
+        ),
       allow_tool: tool.schema
         .string()
         .array()
         .optional()
-        .describe('Tool patterns to allow.'),
+        .describe(
+          'Copilot tool patterns to allow during this task. Each entry becomes an `--allow-tool <pattern>` flag. Examples: `"shell(*)"`, `"edit"`, `"fetch"`. See the Copilot CLI docs for the full pattern syntax. Layered with `deny_tool` when both are present.',
+        ),
       deny_tool: tool.schema
         .string()
         .array()
         .optional()
-        .describe('Tool patterns to deny.'),
+        .describe(
+          'Copilot tool patterns to deny during this task. Each entry becomes a `--deny-tool <pattern>` flag. Examples: `"shell(rm)"`, `"shell(curl)"`. Use to harden a task by blocking dangerous operations even if `allow_tool` would permit them.',
+        ),
     },
     async execute(args, ctx) {
       const runningCount = getAllTasks().filter(

--- a/src/tools/output.ts
+++ b/src/tools/output.ts
@@ -2,29 +2,64 @@ import { tool } from '@opencode-ai/plugin/tool'
 import { buildEnvelope } from '../runtime/envelope'
 import { getTask } from '../runtime/task-registry'
 
+const DEFAULT_TIMEOUT_MS = 30000
+const MAX_TIMEOUT_MS = 120000
+
 function isValidTaskId(taskId: string): boolean {
   return taskId.length > 0 && taskId.startsWith('cpl_')
 }
 
+const TOOL_DESCRIPTION = [
+  'Retrieve the structured result envelope for a delegated Copilot task.',
+  '',
+  'Most calls happen after a `copilot_delegate(...)` task triggers its completion `system-reminder`',
+  'in this session. The envelope contains everything the agent needs to act on the result:',
+  '',
+  '- `task_id`, `status` (`running` | `succeeded` | `failed` | `cancelled` | `unknown`)',
+  '- `exit_code`, `duration_ms`, `started_at`, `ended_at`',
+  '- `agent_name`, `model_name`, `args` (the original CLI args)',
+  "- `final_message`: the assistant's last user-visible response, or null",
+  '- `error_text`: stderr tail when the subprocess failed',
+  '- `summary`: counts of tool calls, files changed, and tokens consumed',
+  '- `events` (when present): the sequence of parsed JSONL events from Copilot',
+  '',
+  'When to call:',
+  '- After receiving a completion `system-reminder` for a known `task_id`.',
+  '- On demand if the agent needs to inspect a still-running task — pass `block: true` to wait briefly for completion.',
+  '- On task IDs the parent agent saved earlier in the session.',
+  '',
+  'Block mode (`block: true`):',
+  '- If the task is still running, wait up to `timeout_ms` (default 30000, capped at 120000) for completion.',
+  '- On timeout, returns the envelope with `timed_out: true` and the agent should call again later.',
+  '- For research-style delegations that may exceed 120s, prefer non-blocking polling — call this tool again after each `system-reminder` instead of holding open a single long block.',
+  '',
+  'Unknown task IDs return `{ task_id, status: "unknown", error }` rather than throwing.',
+].join('\n')
+
 export function createOutputTool() {
   return tool({
-    description:
-      'Retrieve the structured result envelope for a delegated Copilot task.',
+    description: TOOL_DESCRIPTION,
     args: {
       task_id: tool.schema
         .string()
-        .describe('Task ID returned by copilot_delegate.'),
+        .describe(
+          'The task ID returned by `copilot_delegate(...)`. Format: `cpl_<...>`. Required.',
+        ),
       block: tool.schema
         .boolean()
         .optional()
-        .describe('Wait for completion. Default false.'),
+        .describe(
+          'If the task is still running, wait for completion up to `timeout_ms` before returning. Default `false` — returns immediately with the current state. Set to `true` only when the agent has nothing else to do but wait.',
+        ),
       timeout_ms: tool.schema
         .number()
         .int()
         .min(0)
-        .max(120000)
+        .max(MAX_TIMEOUT_MS)
         .optional()
-        .describe('Max wait ms when block is true. Default 30000.'),
+        .describe(
+          'Maximum wait in milliseconds when `block` is `true`. Default 30000. Range 0–120000 (the upper cap protects the OpenCode session from a single hung delegation). For long research tasks, prefer multiple non-blocking calls over a long block.',
+        ),
     },
     async execute(args) {
       if (!isValidTaskId(args.task_id)) {
@@ -47,7 +82,7 @@ export function createOutputTool() {
       if (args.block && task.status === 'running') {
         const timeoutMs = Math.max(
           0,
-          Math.min(args.timeout_ms ?? 30000, 120000),
+          Math.min(args.timeout_ms ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS),
         )
         let timer: ReturnType<typeof setTimeout> | undefined
         const completed = await Promise.race([

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -8,254 +8,171 @@ const userDir = join(fixturesDir, 'user')
 const repoDir = join(fixturesDir, 'repo')
 
 describe('discoverAgents', () => {
-  describe('built-in agents', () => {
-    it('should return built-in agents when no directories are provided', () => {
-      // Given no user or repo agent directories
-      // When discovering agents
+  describe('empty discovery', () => {
+    it('should return an empty list when no directories are provided', () => {
       const agents = discoverAgents({})
-
-      // Then only built-in agents are returned
-      const builtins = agents.filter((a) => a.source === 'builtin')
-      expect(builtins).toHaveLength(6)
-      expect(builtins.map((a) => a.name)).toEqual([
-        'default',
-        'explore',
-        'task',
-        'general-purpose',
-        'code-review',
-        'research',
-      ])
+      expect(agents).toEqual([])
     })
 
-    it('should mark all built-in agents with source "builtin"', () => {
-      // Given no external directories
-      // When discovering agents
-      const agents = discoverAgents({})
-
-      // Then every agent has source "builtin"
-      for (const agent of agents) {
-        expect(agent.source).toBe('builtin')
-      }
+    it('should return an empty list when both directories are missing', () => {
+      const agents = discoverAgents({
+        userAgentsDir: '/tmp/nope-user',
+        repoAgentsDir: '/tmp/nope-repo',
+      })
+      expect(agents).toEqual([])
     })
   })
 
   describe('user agents', () => {
     it('should include user agents from the user directory', () => {
-      // Given a user agents directory with .md files
-      // When discovering agents
       const agents = discoverAgents({ userAgentsDir: userDir })
 
-      // Then user agents appear after built-ins
       const userAgents = agents.filter((a) => a.source === 'user')
-      expect(userAgents.length).toBe(2)
+      expect(userAgents.length).toBe(3)
       expect(userAgents.map((a) => a.name).sort()).toEqual([
         'custom-helper',
+        'default',
         'my-reviewer',
       ])
     })
 
-    it('should place user agents after built-in agents', () => {
-      // Given a user agents directory
-      // When discovering agents
-      const agents = discoverAgents({ userAgentsDir: userDir })
-
-      // Then built-ins come first, then user agents
-      const firstUserIndex = agents.findIndex((a) => a.source === 'user')
-      const lastBuiltinIndex = agents.findLastIndex(
-        (a) => a.source === 'builtin',
-      )
-      expect(firstUserIndex).toBeGreaterThan(lastBuiltinIndex)
+    it('should return an empty list when only a missing user dir is given', () => {
+      const agents = discoverAgents({
+        userAgentsDir: '/tmp/nonexistent-user-agents-dir',
+      })
+      expect(agents).toEqual([])
     })
   })
 
   describe('repo agents', () => {
     it('should include repo agents from the repo directory', () => {
-      // Given a repo agents directory with .md files
-      // When discovering agents
       const agents = discoverAgents({ repoAgentsDir: repoDir })
 
-      // Then repo agents appear after built-ins
       const repoAgents = agents.filter((a) => a.source === 'repo')
-      expect(repoAgents.length).toBe(2)
+      expect(repoAgents.length).toBe(3)
       expect(repoAgents.map((a) => a.name).sort()).toEqual([
         'custom-helper',
+        'default',
         'project-bot',
       ])
+    })
+
+    it('should return an empty list when only a missing repo dir is given', () => {
+      const agents = discoverAgents({
+        repoAgentsDir: '/tmp/nonexistent-repo-agents-dir',
+      })
+      expect(agents).toEqual([])
     })
   })
 
   describe('merge and override behavior', () => {
-    it('should merge built-in, user, and repo agents in order', () => {
-      // Given both user and repo directories
-      // When discovering agents
+    it('should merge user and repo agents with user appearing before repo', () => {
       const agents = discoverAgents({
         userAgentsDir: userDir,
         repoAgentsDir: repoDir,
       })
 
-      // Then agents appear in order: builtin, user, repo
       const sources = agents.map((a) => a.source)
       const firstUser = sources.indexOf('user')
       const firstRepo = sources.indexOf('repo')
-      const lastBuiltin = sources.lastIndexOf('builtin')
-
-      expect(lastBuiltin).toBeLessThan(firstUser)
+      expect(firstUser).toBeGreaterThanOrEqual(0)
+      expect(firstRepo).toBeGreaterThanOrEqual(0)
       expect(firstUser).toBeLessThan(firstRepo)
     })
 
     it('should let repo agents override user agents with the same name', () => {
-      // Given user has "custom-helper" and repo also has "custom-helper"
-      // When discovering agents
       const agents = discoverAgents({
         userAgentsDir: userDir,
         repoAgentsDir: repoDir,
       })
 
-      // Then only one "custom-helper" exists, with source "repo"
       const customHelpers = agents.filter((a) => a.name === 'custom-helper')
       expect(customHelpers).toHaveLength(1)
       expect(customHelpers[0].source).toBe('repo')
     })
 
-    it('should not override built-in agents with user or repo agents of the same name', () => {
-      // Given user and repo dirs that BOTH contain a "default.md" fixture
-      // When discovering agents
+    it('should keep colliding user/repo `default` entries with repo winning', () => {
+      // The fixtures include a `default.md` in both user and repo dirs to
+      // verify the override behavior survives the BUILTIN_AGENTS removal.
       const agents = discoverAgents({
         userAgentsDir: userDir,
         repoAgentsDir: repoDir,
       })
 
-      // Then built-in "default" remains as the only "default" entry
       const defaults = agents.filter((a) => a.name === 'default')
       expect(defaults).toHaveLength(1)
-      expect(defaults[0].source).toBe('builtin')
+      expect(defaults[0].source).toBe('repo')
 
-      // And the total count excludes both colliding fixtures
-      // builtins(6) + user(my-reviewer) + repo(custom-helper, project-bot) = 9
-      expect(agents).toHaveLength(9)
-    })
-  })
-
-  describe('missing directories', () => {
-    it('should return only built-ins when user directory does not exist', () => {
-      // Given a non-existent user directory
-      // When discovering agents
-      const agents = discoverAgents({
-        userAgentsDir: '/tmp/nonexistent-user-agents-dir',
-      })
-
-      // Then only built-in agents are returned
-      expect(agents).toHaveLength(6)
-      expect(agents.every((a) => a.source === 'builtin')).toBe(true)
-    })
-
-    it('should return only built-ins when repo directory does not exist', () => {
-      // Given a non-existent repo directory
-      // When discovering agents
-      const agents = discoverAgents({
-        repoAgentsDir: '/tmp/nonexistent-repo-agents-dir',
-      })
-
-      // Then only built-in agents are returned
-      expect(agents).toHaveLength(6)
-    })
-
-    it('should handle both directories missing gracefully', () => {
-      // Given both directories are non-existent
-      // When discovering agents
-      const agents = discoverAgents({
-        userAgentsDir: '/tmp/nope-user',
-        repoAgentsDir: '/tmp/nope-repo',
-      })
-
-      // Then only built-in agents are returned, no errors thrown
-      expect(agents).toHaveLength(6)
+      // Total: user(my-reviewer) + repo(custom-helper, default, project-bot) = 4
+      expect(agents).toHaveLength(4)
     })
   })
 })
 
 describe('buildDescription', () => {
-  it('should format agents as a multi-line string', () => {
-    // Given a list of agents
+  it('should produce an empty-list message when no agents are discovered', () => {
+    const desc = buildDescription([])
+    expect(desc).toContain('No Copilot agents discovered.')
+    expect(desc).toContain('~/.copilot/agents')
+    expect(desc).toContain('.github/agents')
+  })
+
+  it('should format discovered agents as a multi-line string', () => {
     const agents: Agent[] = [
-      { name: 'default', source: 'builtin' },
-      { name: 'explore', source: 'builtin' },
-      { name: 'my-agent', source: 'user' },
+      { name: 'custom-helper', source: 'user' },
+      { name: 'my-reviewer', source: 'user' },
+      { name: 'project-bot', source: 'repo' },
     ]
 
-    // When building the description
     const desc = buildDescription(agents)
 
-    // Then it contains a header and formatted entries
     expect(desc).toContain('Available Copilot agents:')
-    expect(desc).toContain('  - default (builtin)')
-    expect(desc).toContain('  - explore (builtin)')
-    expect(desc).toContain('  - my-agent (user)')
+    expect(desc).toContain('  - custom-helper (user)')
+    expect(desc).toContain('  - my-reviewer (user)')
+    expect(desc).toContain('  - project-bot (repo)')
   })
 
   it('should list agents in the provided order', () => {
-    // Given ordered agents
     const agents: Agent[] = [
-      { name: 'default', source: 'builtin' },
-      { name: 'custom', source: 'user' },
-      { name: 'repo-bot', source: 'repo' },
+      { name: 'a-user', source: 'user' },
+      { name: 'b-user', source: 'user' },
+      { name: 'c-repo', source: 'repo' },
     ]
 
-    // When building the description
     const desc = buildDescription(agents)
 
-    // Then lines appear in order
     const lines = desc.split('\n')
-    const defaultIdx = lines.findIndex((l) => l.includes('default'))
-    const customIdx = lines.findIndex((l) => l.includes('custom'))
-    const repoBotIdx = lines.findIndex((l) => l.includes('repo-bot'))
-    expect(defaultIdx).toBeLessThan(customIdx)
-    expect(customIdx).toBeLessThan(repoBotIdx)
+    const aIdx = lines.findIndex((l) => l.includes('a-user'))
+    const bIdx = lines.findIndex((l) => l.includes('b-user'))
+    const cIdx = lines.findIndex((l) => l.includes('c-repo'))
+    expect(aIdx).toBeLessThan(bIdx)
+    expect(bIdx).toBeLessThan(cIdx)
   })
 
-  it('should cap at 20 entries and show truncation message', () => {
-    // Given 25 agents
+  it('should cap at 20 entries and show a truncation count', () => {
     const agents: Agent[] = Array.from({ length: 25 }, (_, i) => ({
       name: `agent-${String(i).padStart(2, '0')}`,
-      source: 'builtin' as const,
+      source: 'user' as const,
     }))
 
-    // When building the description
     const desc = buildDescription(agents)
 
-    // Then only 20 are listed, with a truncation notice
     const agentLines = desc.split('\n').filter((l) => l.trim().startsWith('- '))
     expect(agentLines).toHaveLength(20)
     expect(desc).toContain(
-      '... and 5 more (use copilot_list_agents to see all)',
+      '... and 5 more (see ~/.copilot/agents or .github/agents)',
     )
   })
 
   it('should not show truncation message for exactly 20 agents', () => {
-    // Given exactly 20 agents
     const agents: Agent[] = Array.from({ length: 20 }, (_, i) => ({
       name: `agent-${i}`,
-      source: 'builtin' as const,
+      source: 'user' as const,
     }))
 
-    // When building the description
     const desc = buildDescription(agents)
 
-    // Then no truncation message
     expect(desc).not.toContain('... and')
-    expect(desc).not.toContain('more')
-  })
-
-  it('should handle an empty agent list', () => {
-    // Given no agents
-    const agents: Agent[] = []
-
-    // When building the description
-    const desc = buildDescription(agents)
-
-    // Then it still has the header
-    expect(desc).toContain('Available Copilot agents:')
-    const agentLines = desc.split('\n').filter((l) => l.trim().startsWith('- '))
-    expect(agentLines).toHaveLength(0)
+    expect(desc).not.toContain('more (see')
   })
 })


### PR DESCRIPTION
Two tooling improvements that surfaced from `mise run opencode:doctor --only tools --full --format json`:

## What changes

**1. Drop `BUILTIN_AGENTS`.** The plugin previously advertised six "built-in" agent names — `default`, `explore`, `task`, `general-purpose`, `code-review`, `research` — inherited from VS Code Copilot Chat / OpenCode conventions. The standalone `@github/copilot` CLI ships none of them; passing any as `--agent <name>` returns `Error: No such agent: <name>, available:` with an empty available list. The constant is gone. `Agent.source` is now `'user' | 'repo'`. `discoverAgents` returns user agents (filtered by repo override) followed by repo agents. `buildDescription` handles the empty-discovery case with an actionable hint pointing at `~/.copilot/agents` and `.github/agents`.

**2. Enrich tool schema descriptions.** `copilot_delegate`, `copilot_output`, and `copilot_cancel` now ship multi-paragraph tool descriptions (what + when + lifecycle + pitfalls + return shape) and rich per-parameter `.describe()` text (type, default, when-required, examples, constraints). Patterns follow Magic Context's `ctx_note` / `ctx_search` / `ctx_memory` tools as the reference.

## Notes

- Tool argument shapes are unchanged; existing callers keep working.
- The dist bundle preserves all 10 `.describe()` calls verbatim.
- The doctor output currently strips per-parameter descriptions on `copilot_*` tools while preserving them on `ctx_*` tools that use the identical `tool.schema.string().describe(...)` pattern. Source code, bundling, and direct schema serialization (`tool.schema.toJSONSchema()`) all produce full descriptions; the strip happens downstream of plugin source. Plausible cause: provider-specific schema adaptation in OpenCode's `/tool` endpoint behaves differently for plugins that externalize `@opencode-ai/plugin` (host's zod, schemas with host-runtime prototypes) vs plugins that bundle their own copy (Magic Context bundles `@opencode-ai/plugin@1.14.28` inline). To be filed upstream after this PR merges and the strip behavior is verified against the enriched content.

## Verification

- typecheck / lint / build clean
- 145 / 145 unit tests pass
- bundle 0.34 MB (no growth)
