### PR TITLE
build(deps): bump @opencode-ai/plugin and sdk to ^1.14.29

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,8 +10,8 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
         "@changesets/cli": "^2.31.0",
-        "@opencode-ai/plugin": "^1.14.19",
-        "@opencode-ai/sdk": "^1.14.19",
+        "@opencode-ai/plugin": "^1.14.29",
+        "@opencode-ai/sdk": "^1.14.29",
         "@types/bun": "^1.2.0",
         "@types/node": "^24.0.0",
         "rimraf": "^6.0.1",
@@ -102,9 +102,9 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.14.20", "", { "dependencies": { "@opencode-ai/sdk": "1.14.20", "effect": "4.0.0-beta.48", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.1.99", "@opentui/solid": ">=0.1.99" }, "optionalPeers": ["@opentui/core", "@opentui/solid"] }, "sha512-txRfm6Y2DBqFxJtgo63vj5//d7TJS7/angWELUEQcsSK0llfvmVp60gox4e8zIwpGjDcDP9A4qO6oNe++pockg=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.14.29", "", { "dependencies": { "@opencode-ai/sdk": "1.14.29", "effect": "4.0.0-beta.57", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.1.105", "@opentui/solid": ">=0.1.105" }, "optionalPeers": ["@opentui/core", "@opentui/solid"] }, "sha512-GwmBg7dajawma/6tzpoK/JMbcRcUTg27XHlnxZOFWG85WDz4M67hxFYnvE+BnJj9k7tTLXTfSR+pgfcdqbUDAg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.20", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-kPZP1An1ZdWOfLfDYhNjh665HX4RcI8au6Lzjn0FktoQ3RpWHq1WXRLHrJO8rJqwWvQDOzS48cXt9jbr+uwQiA=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.29", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-y6wNTlHhgfwLdp01EwdnMFVxUS1FLgz7MZh7H3+jROG2v02GqGDy/gPH3ME0kI+sqQ4qSlk/9AJ+YbKAruPaZw=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
@@ -144,7 +144,7 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
-    "effect": ["effect@4.0.0-beta.48", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw=="],
+    "effect": ["effect@4.0.0-beta.57", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-rg32VgXnLKaPRs9tbRDaZ5jxmzNY7ojXt85gSHGUTwdlbWH5Ik+OCUY2q14TXliygPGoHwCAvNWS4bQJOqf00g=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@changesets/cli": "^2.31.0",
-    "@opencode-ai/plugin": "^1.14.19",
-    "@opencode-ai/sdk": "^1.14.19",
+    "@opencode-ai/plugin": "^1.14.29",
+    "@opencode-ai/sdk": "^1.14.29",
     "@types/bun": "^1.2.0",
     "@types/node": "^24.0.0",
     "rimraf": "^6.0.1",


### PR DESCRIPTION
The `mise.toml` pin is at `1.14.29` (via #59 / #60), but the `package.json` floor was lagging at `^1.14.19`. Bring them into sync.

## What changes

- `@opencode-ai/plugin`: `^1.14.19` → `^1.14.29`
- `@opencode-ai/sdk`: `^1.14.19` → `^1.14.29`
- `bun.lock` refreshed accordingly

## What stays

- `peerDependencies` floor stays at `>=1.14.0` — no 1.14.29-only API is in use; users on older host versions are still supported.
- `tool.js` export shape (`tool` identity factory + `tool.schema = z`) is identical between 1.14.20 and 1.14.29; bundled zod stays at 4.1.8.

## Why this matters beyond housekeeping

The version drift between our `node_modules` (1.14.20 → now 1.14.29) and the host opencode runtime (also 1.14.29 via mise) closes. That removes one variable from the upstream description-strip investigation parked from #57: if descriptions still strip on the next `mise run opencode:doctor` against `opencode-copilot-delegate@0.5.x`, the cause is purely server-side schema adaptation and the upstream issue can be filed without the version-drift caveat muddying the repro.

## Verification

- typecheck / lint / build clean
- 145 / 145 unit tests pass
- bundle 0.34 MB (unchanged)
