### PR TITLE
fix(tools): preserve per-parameter descriptions and drop unused sdk peer dep

### DIFF
--- a/.changeset/schema-describe-reorder-and-drop-sdk-peer.md
+++ b/.changeset/schema-describe-reorder-and-drop-sdk-peer.md
@@ -1,0 +1,9 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Surface per-parameter descriptions to host LLMs and drop the unused `@opencode-ai/sdk` peer dependency.
+
+OpenCode's tool-list endpoint serializes plugin schemas with Zod's `toJSONSchema(..., { io: 'input' })` mode, which unwraps `.optional()` wrappers and drops any `.describe()` text attached to the wrapper. The 5 optional parameters across `copilot_delegate` and `copilot_output` chained `.optional().describe(...)` and lost their descriptions in the rendered tool catalog. Reordering to `.describe(...).optional()` places the description on the leaf type so it survives the unwrap.
+
+Also drops `@opencode-ai/sdk` from `peerDependencies` and the build externals — the package was never imported from any source file, so the peer requirement was dead config that forced consumers to install an unused dependency.

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "@biomejs/biome": "^2.4.13",
         "@changesets/cli": "^2.31.0",
         "@opencode-ai/plugin": "^1.14.29",
-        "@opencode-ai/sdk": "^1.14.29",
         "@types/bun": "^1.2.0",
         "@types/node": "^24.0.0",
         "rimraf": "^6.0.1",
@@ -19,7 +18,6 @@
       },
       "peerDependencies": {
         "@opencode-ai/plugin": ">=1.14.0",
-        "@opencode-ai/sdk": ">=1.14.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -33,14 +33,12 @@
     "node": ">=24"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.14.0",
-    "@opencode-ai/sdk": ">=1.14.0"
+    "@opencode-ai/plugin": ">=1.14.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@changesets/cli": "^2.31.0",
     "@opencode-ai/plugin": "^1.14.29",
-    "@opencode-ai/sdk": "^1.14.29",
     "@types/bun": "^1.2.0",
     "@types/node": "^24.0.0",
     "rimraf": "^6.0.1",
@@ -48,7 +46,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "bun run clean && bun build src/index.ts --outdir dist --target bun --external @opencode-ai/plugin --external @opencode-ai/sdk && tsc --emitDeclarationOnly --noEmit false",
+    "build": "bun run clean && bun build src/index.ts --outdir dist --target bun --external @opencode-ai/plugin && tsc --emitDeclarationOnly --noEmit false",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:unit": "bun test tests/*.test.ts",

--- a/src/tools/delegate.ts
+++ b/src/tools/delegate.ts
@@ -67,37 +67,37 @@ export function createDelegateTool(options: DelegateToolOptions) {
         ),
       agent: tool.schema
         .string()
-        .optional()
         .describe(
           'Agent name (without .md extension) to use for this task. Must match a discovered agent file in `~/.copilot/agents` or `.github/agents`. The list of currently discovered agents appears at the bottom of this tool description; an empty list means no agents are discoverable and `agent` must be omitted. Omit to use the Copilot CLI default.',
-        ),
+        )
+        .optional(),
       model: tool.schema
         .string()
-        .optional()
         .describe(
           "Override the default model for this task. Accepts any model string Copilot CLI recognizes — for example `claude-opus-4.7`, `claude-sonnet-4.7`, or `gpt-5`. Omit to use the user's configured default.",
-        ),
+        )
+        .optional(),
       add_dir: tool.schema
         .string()
         .array()
-        .optional()
         .describe(
           'Additional repository paths to grant Copilot access to (multi-repo workflows). Each entry becomes a `--add-dir <path>` flag. Use absolute paths. Examples: `["/Users/me/repo-a", "/Users/me/repo-b"]`.',
-        ),
+        )
+        .optional(),
       allow_tool: tool.schema
         .string()
         .array()
-        .optional()
         .describe(
           'Copilot tool patterns to allow during this task. Each entry becomes an `--allow-tool <pattern>` flag. Examples: `"shell(*)"`, `"edit"`, `"fetch"`. See the Copilot CLI docs for the full pattern syntax. Layered with `deny_tool` when both are present.',
-        ),
+        )
+        .optional(),
       deny_tool: tool.schema
         .string()
         .array()
-        .optional()
         .describe(
           'Copilot tool patterns to deny during this task. Each entry becomes a `--deny-tool <pattern>` flag. Examples: `"shell(rm)"`, `"shell(curl)"`. Use to harden a task by blocking dangerous operations even if `allow_tool` would permit them.',
-        ),
+        )
+        .optional(),
     },
     async execute(args, ctx) {
       const runningCount = getAllTasks().filter(

--- a/src/tools/output.ts
+++ b/src/tools/output.ts
@@ -47,19 +47,19 @@ export function createOutputTool() {
         ),
       block: tool.schema
         .boolean()
-        .optional()
         .describe(
           'If the task is still running, wait for completion up to `timeout_ms` before returning. Default `false` — returns immediately with the current state. Set to `true` only when the agent has nothing else to do but wait.',
-        ),
+        )
+        .optional(),
       timeout_ms: tool.schema
         .number()
         .int()
         .min(0)
         .max(MAX_TIMEOUT_MS)
-        .optional()
         .describe(
           'Maximum wait in milliseconds when `block` is `true`. Default 30000. Range 0–120000 (the upper cap protects the OpenCode session from a single hung delegation). For long research tasks, prefer multiple non-blocking calls over a long block.',
-        ),
+        )
+        .optional(),
     },
     async execute(args) {
       if (!isValidTaskId(args.task_id)) {


### PR DESCRIPTION
## Why

OpenCode's `client.tool.list` endpoint (used by `mise run opencode:doctor` and delivered to the LLM) serializes plugin schemas with Zod's `toJSONSchema(..., { io: 'input' })` mode. In input mode, Zod unwraps `.optional()` wrappers — the property is moved to the parent's omitted-from-required list and only the inner schema is emitted. Any `.describe()` text attached to the wrapper is dropped.

Five of our six args (`agent`, `model`, `add_dir`, `allow_tool`, `deny_tool`, plus `block` and `timeout_ms` on `copilot_output`) chain `.optional().describe(...)`, putting the description on the wrapper. Result: parameter descriptions silently vanish from the rendered tool catalog. Only the leaf-attached `prompt` description survives.

Magic Context (`@cortexkit/opencode-magic-context`) and other working plugins either skip `.optional()` entirely or chain `.describe(...).optional()` so the description sits on the leaf and survives the unwrap.

## What

- **Reorder schema chains** on all 7 optional params across `delegate.ts` and `output.ts`: `.optional().describe(...)` → `.describe(...).optional()`. Pure source-only edit.
- **Drop `@opencode-ai/sdk` from peerDependencies, devDependencies, and the build's `--external` list.** The package is never imported from any source file (`grep -r '@opencode-ai/sdk' src/` returns zero hits). The peer requirement was dead config forcing consumers to install an unused dependency.

## Verification

- 145/145 unit tests pass.
- `typecheck`, `lint`, `build` all clean. Bundle unchanged at 0.34 MB.
- Verified `dist/index.js` has zero `@opencode-ai/sdk` references.
- Verified all 5 optional-param chains in delegate.ts now emit `.optional()` AFTER `.describe()`.

## Validation after release

The acid test is re-running `mise run opencode:doctor --only tools --full --format json` once 0.6.0 publishes and the dotfiles pin is bumped. Expected outcome: descriptions surface on `prompt`, `agent`, `model`, `add_dir`, `allow_tool`, `deny_tool`, `task_id`, `block`, `timeout_ms`. If `prompt` still strips (it has `.min(1).describe()` on the leaf — should survive — but currently doesn't), a `tool.definition` plugin hook follow-up will inject descriptions onto the JSON Schema directly, bypassing Zod's serializer.

## Bump

Minor — next release will be 0.6.0 under the 0.x unstable convention.