### PR TITLE
test(runtime): replace wall-clock sleeps with poll-with-retry helpers

### DIFF
--- a/tests/task-registry.test.ts
+++ b/tests/task-registry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -74,7 +75,11 @@ describe('task registry PID-file hooks', () => {
       undefined,
     )
 
-    await delay(200)
+    await waitUntil(
+      () =>
+        existsSync(pidFilePath) &&
+        readFileSync(pidFilePath, 'utf-8').includes(`${child.pid}\t`),
+    )
 
     const content = readFileSync(pidFilePath, 'utf-8')
     expect(content).toContain(`${child.pid}\t`)
@@ -108,12 +113,16 @@ describe('task registry PID-file hooks', () => {
       undefined,
     )
 
-    await delay(200)
+    await waitUntil(
+      () =>
+        existsSync(pidFilePath) &&
+        readFileSync(pidFilePath, 'utf-8').includes(`${child.pid}\t`),
+    )
     expect(readFileSync(pidFilePath, 'utf-8')).toContain(`${child.pid}\t`)
 
     setStatus(task, 'cancelled', { pidFilePath })
 
-    await delay(200)
+    await waitUntil(() => !existsSync(pidFilePath))
     expect(() => readFileSync(pidFilePath, 'utf-8')).toThrow()
   })
 


### PR DESCRIPTION
Replaces three `await delay(200)` calls in `tests/task-registry.test.ts` with `waitUntil()` polls. The sleeps were waiting for fire-and-forget `appendPidEntry` chains to land file content; the polls assert the expected file state directly with no fixed budget, removing CI flake risk on slow runners and tightening the loop on fast machines.

Closes the test-stability item in #49.

## Verification

- typecheck, lint, build, unit tests all green
- 164 / 164 pass / 780 expect calls (count unchanged \u2014 same tests, no fixed delay)
- No behavior change to runtime code