### PR TITLE
refactor(runtime): tighten reap interfaces and route cleanup through serializeWrite

### DIFF
--- a/.changeset/reap-options-and-cleanup-serialize.md
+++ b/.changeset/reap-options-and-cleanup-serialize.md
@@ -1,0 +1,5 @@
+---
+'opencode-copilot-delegate': patch
+---
+
+Tighten orphan-reaper internals: export `ReapOptions` (consolidates `ReapDeps` + reap-specific opts via interface extension), consolidate `reapOneFile` to a single opts-bag parameter, and route `cleanupAfterReap` writes through the per-file `serializeWrite` lock via two new helpers (`truncatePidFile`, `unlinkPidFile`) so any future change that runs reap concurrent with task spawns is automatically race-safe. No user-visible behavior change in default usage.

--- a/.changeset/reap-options-and-cleanup-serialize.md
+++ b/.changeset/reap-options-and-cleanup-serialize.md
@@ -1,5 +1,12 @@
 ---
-'opencode-copilot-delegate': patch
+'opencode-copilot-delegate': minor
 ---
 
-Tighten orphan-reaper internals: export `ReapOptions` (consolidates `ReapDeps` + reap-specific opts via interface extension), consolidate `reapOneFile` to a single opts-bag parameter, and route `cleanupAfterReap` writes through the per-file `serializeWrite` lock via two new helpers (`truncatePidFile`, `unlinkPidFile`) so any future change that runs reap concurrent with task spawns is automatically race-safe. No user-visible behavior change in default usage.
+Tighten orphan-reaper internals and add two new exported helpers from `src/runtime/pid-file.ts`:
+
+- `truncatePidFile(filePath)` — truncate under the per-file `serializeWrite` lock; ENOENT (file or parent missing) silently swallowed.
+- `unlinkPidFile(filePath)` — unlink under the per-file `serializeWrite` lock; ENOENT silently swallowed.
+
+Also export `ReapOptions` from `src/runtime/orphan-reaper.ts` (consolidates `ReapDeps` + reap-specific opts via interface extension), and consolidate `reapOneFile` to a single opts-bag parameter. `cleanupAfterReap` now routes its truncate-on-current and unlink-on-foreign paths through the new helpers so any future change that runs reap concurrent with task spawns is automatically race-safe.
+
+No user-visible behavior change in default usage; the bump reflects the new exported surface.

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -306,6 +306,12 @@ async function cleanupAfterReap(
 ): Promise<boolean> {
   try {
     if (isCurrent) {
+      // For the current instance we always truncate via the canonical
+      // `currentInstancePath`, never `filePath`. The two are equal in
+      // practice today, but the canonical path is the contract: the
+      // serialize-lock is keyed on it, and any future caller passing a
+      // different `filePath` (e.g. a stale name resolution) must still
+      // truncate the same file the writers are appending to.
       await truncatePidFile(currentInstancePath)
       return false
     }

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -1,7 +1,8 @@
 import { spawn } from 'node:child_process'
-import { readdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import { basename, extname, join } from 'node:path'
 import { isErrnoException } from '../lib/errno'
+import { truncatePidFile, unlinkPidFile } from './pid-file'
 
 export interface ReapDeps {
   killProcessTree: (pid: number) => Promise<void>
@@ -305,10 +306,10 @@ async function cleanupAfterReap(
 ): Promise<boolean> {
   try {
     if (isCurrent) {
-      await writeFile(currentInstancePath, '')
+      await truncatePidFile(currentInstancePath)
       return false
     }
-    await unlink(filePath)
+    await unlinkPidFile(filePath)
     return true
   } catch {
     return false
@@ -322,17 +323,30 @@ interface ReapFileOutcome {
   deleted: boolean
 }
 
-async function reapOneFile(
-  filePath: string,
-  filePid: number,
-  isCurrent: boolean,
-  currentInstancePath: string,
-  isPluginAlive: ReapDeps['isPluginAlive'],
-  killProcessTree: ReapDeps['killProcessTree'],
-  getPidIdentity: ReapDeps['getPidIdentity'],
-  signal?: AbortSignal,
-  psTimeoutMs?: number,
-): Promise<ReapFileOutcome> {
+interface ReapOneFileArgs {
+  filePath: string
+  filePid: number
+  isCurrent: boolean
+  currentInstancePath: string
+  isPluginAlive: ReapDeps['isPluginAlive']
+  killProcessTree: ReapDeps['killProcessTree']
+  getPidIdentity: ReapDeps['getPidIdentity']
+  signal?: AbortSignal
+  psTimeoutMs?: number
+}
+
+async function reapOneFile(args: ReapOneFileArgs): Promise<ReapFileOutcome> {
+  const {
+    filePath,
+    filePid,
+    isCurrent,
+    currentInstancePath,
+    isPluginAlive,
+    killProcessTree,
+    getPidIdentity,
+    signal,
+    psTimeoutMs,
+  } = args
   const empty: ReapFileOutcome = {
     reaped: 0,
     skipped: 0,
@@ -373,11 +387,9 @@ async function reapOneFile(
   return { reaped, skipped, scanned: true, deleted }
 }
 
-interface ReapOpts {
+export interface ReapOptions extends Omit<ReapDeps, 'isPluginAlive'> {
   pidFileDir: string
   currentInstancePath: string
-  killProcessTree: ReapDeps['killProcessTree']
-  getPidIdentity: ReapDeps['getPidIdentity']
   isPluginAlive?: ReapDeps['isPluginAlive']
   signal?: AbortSignal
   // Per-probe ps timeout forwarded to every `getPidIdentity(pid, timeoutMs)`
@@ -385,7 +397,7 @@ interface ReapOpts {
   psTimeoutMs?: number
 }
 
-async function doReap(opts: ReapOpts): Promise<ReapResult> {
+async function doReap(opts: ReapOptions): Promise<ReapResult> {
   const {
     pidFileDir,
     currentInstancePath,
@@ -428,17 +440,17 @@ async function doReap(opts: ReapOpts): Promise<ReapResult> {
     }
     const filePid = Number(stem)
 
-    const outcome = await reapOneFile(
+    const outcome = await reapOneFile({
       filePath,
       filePid,
-      filePid === process.pid,
+      isCurrent: filePid === process.pid,
       currentInstancePath,
       isPluginAlive,
       killProcessTree,
       getPidIdentity,
       signal,
       psTimeoutMs,
-    )
+    })
 
     reaped += outcome.reaped
     skipped += outcome.skipped
@@ -460,7 +472,7 @@ async function doReap(opts: ReapOpts): Promise<ReapResult> {
 const DEFAULT_REAP_TIMEOUT_MS = 15_000
 
 export async function reapOrphans(
-  opts: Omit<ReapOpts, 'signal'> & { reapTimeoutMs?: number },
+  opts: Omit<ReapOptions, 'signal'> & { reapTimeoutMs?: number },
 ): Promise<ReapResult> {
   const reapTimeoutMs = opts.reapTimeoutMs ?? DEFAULT_REAP_TIMEOUT_MS
   // Zero-counts shape used both as the cold-start success default and as

--- a/src/runtime/pid-file.ts
+++ b/src/runtime/pid-file.ts
@@ -124,7 +124,9 @@ export async function removePidEntry(
 /**
  * Truncate a PID file under the same per-file serialize lock used by
  * appendPidEntry/removePidEntry, so a concurrent writer cannot interleave
- * with the truncation. ENOENT is silently swallowed (file already gone).
+ * with the truncation. ENOENT is silently swallowed in both forms:
+ * file-already-gone AND parent-directory-missing. Other errno values
+ * propagate.
  */
 export async function truncatePidFile(filePath: string): Promise<void> {
   await serializeWrite(filePath, async () => {

--- a/src/runtime/pid-file.ts
+++ b/src/runtime/pid-file.ts
@@ -7,6 +7,7 @@ import {
   readFile,
   rename,
   unlink,
+  writeFile,
 } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -116,6 +117,35 @@ export async function removePidEntry(
 
     if (content.trim().length === 0) {
       await unlink(filePath)
+    }
+  })
+}
+
+/**
+ * Truncate a PID file under the same per-file serialize lock used by
+ * appendPidEntry/removePidEntry, so a concurrent writer cannot interleave
+ * with the truncation. ENOENT is silently swallowed (file already gone).
+ */
+export async function truncatePidFile(filePath: string): Promise<void> {
+  await serializeWrite(filePath, async () => {
+    try {
+      await writeFile(filePath, '')
+    } catch (e) {
+      if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
+    }
+  })
+}
+
+/**
+ * Remove a PID file under the same per-file serialize lock. ENOENT is
+ * silently swallowed (file already gone). Other errno values propagate.
+ */
+export async function unlinkPidFile(filePath: string): Promise<void> {
+  await serializeWrite(filePath, async () => {
+    try {
+      await unlink(filePath)
+    } catch (e) {
+      if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
     }
   })
 }

--- a/tests/pid-file.test.ts
+++ b/tests/pid-file.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'bun:test'
-import { mkdtempSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, statSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   appendPidEntry,
   removePidEntry,
   resolveInstancePidFilePath,
+  truncatePidFile,
+  unlinkPidFile,
 } from '../src/runtime/pid-file'
 
 function makeTempDir(): string {
@@ -208,6 +211,73 @@ describe('pid-file', () => {
         pids.add(Number(parts[0]))
       }
       expect(pids.size).toBe(10)
+    })
+  })
+
+  describe('truncatePidFile', () => {
+    it('clears file content', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+      await writeFile(filePath, '12345\tbash\tMon Apr 27 10:00:00 2026\n')
+
+      await truncatePidFile(filePath)
+
+      expect(readFileSync(filePath, 'utf-8')).toBe('')
+    })
+
+    it('swallows ENOENT silently', async () => {
+      const dir = makeTempDir()
+      // Parent dir does not exist -> writeFile rejects with ENOENT
+      const filePath = join(dir, 'missing-subdir', 'missing.pids')
+
+      await expect(truncatePidFile(filePath)).resolves.toBeUndefined()
+      expect(existsSync(filePath)).toBe(false)
+    })
+  })
+
+  describe('unlinkPidFile', () => {
+    it('removes the file', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+      await writeFile(filePath, '12345\tbash\tMon Apr 27 10:00:00 2026\n')
+
+      await unlinkPidFile(filePath)
+
+      expect(existsSync(filePath)).toBe(false)
+    })
+
+    it('swallows ENOENT silently', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'missing.pids')
+
+      await expect(unlinkPidFile(filePath)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('serialize lock interaction', () => {
+    it('truncatePidFile and appendPidEntry serialize against each other', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'concurrent.pids')
+
+      // Seed: one entry already present
+      await appendPidEntry(filePath, 1111, 'bash', 'Mon Apr 27 10:00:00 2026')
+
+      // Concurrently fire append + truncate. Whichever queues first wins
+      // on ordering, but neither must observe a torn write.
+      await Promise.all([
+        appendPidEntry(filePath, 2222, 'node', 'Mon Apr 27 10:00:01 2026'),
+        truncatePidFile(filePath),
+      ])
+
+      const final = existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+
+      // Acceptable terminal states (any serial ordering of the two ops
+      // over the seeded baseline produces one of these; no torn / partial
+      // line is permitted):
+      //   A) seed -> append -> truncate         => ''
+      //   B) seed -> truncate -> append         => '2222\tnode\t...\n'
+      const acceptable = new Set(['', '2222\tnode\tMon Apr 27 10:00:01 2026\n'])
+      expect(acceptable.has(final)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## What

Three coordinated refactors inside the orphan reaper, all closing items on issue #49.

1. **Export `ReapOptions`** — was the internal `ReapOpts` interface that duplicated `ReapDeps`. Now defined via `extends Omit<ReapDeps, 'isPluginAlive'>` so the public dependency interface and the reap-call options share a single source of truth, and consumers can name the call shape by its exported type.

2. **Consolidate `reapOneFile` parameters** — replace 8 positional params with a single named `ReapOneFileArgs` opts bag. The single call site in `doReap` becomes a clearer named object, and adding new params no longer perturbs the order of every existing one.

3. **Route `cleanupAfterReap` writes through `serializeWrite`** — both the truncate-on-current and unlink-on-foreign paths now go through the same per-file lock used by `appendPidEntry`/`removePidEntry`. Two new helpers encapsulate the locked operations:
   - `truncatePidFile(filePath)` — locked `writeFile(path, '')`, ENOENT silently swallowed
   - `unlinkPidFile(filePath)` — locked `unlink(path)`, ENOENT silently swallowed

   Currently safe (reap awaits at init before task writers exist); this hardens against any future change that runs reap concurrent with spawning so a torn write between truncate and append cannot occur.

## Why

No user-visible behavior change in default usage. The interface tightening removes a long-standing duplication; the cleanup-routing change is defensive and converts a load-bearing-by-coincidence safety property into a load-bearing-by-construction one.

## Tests

5 new tests in `tests/pid-file.test.ts` cover the new helpers and the serialize-lock interaction with concurrent appends. Existing tests unchanged. 170 / 0 fail.
