### PR TITLE
refactor(runtime): forbid terminal-to-non-terminal setStatus transitions

### DIFF
--- a/.changeset/setstatus-contract.md
+++ b/.changeset/setstatus-contract.md
@@ -1,0 +1,5 @@
+---
+'opencode-copilot-delegate': patch
+---
+
+Tighten the `setStatus` lifecycle helper to forbid terminal → non-terminal transitions. Once a task reaches `complete`, `failed`, or `cancelled`, every subsequent `setStatus` call is a no-op. Previously the helper short-circuited only when both old and new status were terminal, leaving an unintended resurrection path that no caller exercises but the contract permitted. Pure contract tightening; no caller behavior changes.

--- a/.changeset/setstatus-contract.md
+++ b/.changeset/setstatus-contract.md
@@ -1,5 +1,5 @@
 ---
-'opencode-copilot-delegate': patch
+'opencode-copilot-delegate': minor
 ---
 
-Tighten the `setStatus` lifecycle helper to forbid terminal → non-terminal transitions. Once a task reaches `complete`, `failed`, or `cancelled`, every subsequent `setStatus` call is a no-op. Previously the helper short-circuited only when both old and new status were terminal, leaving an unintended resurrection path that no caller exercises but the contract permitted. Pure contract tightening; no caller behavior changes.
+Tighten the `setStatus` lifecycle helper to forbid terminal → non-terminal transitions. Once a task reaches `complete`, `failed`, or `cancelled`, every subsequent `setStatus` call is a no-op. Previously the helper short-circuited only when both old and new status were terminal, leaving an unintended resurrection path that no caller exercises but the contract permitted. This narrows the public API contract; no caller behavior changes.

--- a/src/runtime/task-status.ts
+++ b/src/runtime/task-status.ts
@@ -20,7 +20,13 @@ export function setStatus(
   newStatus: TaskStatus,
   options?: SetStatusOptions,
 ): void {
-  if (isTerminal(task.status) && isTerminal(newStatus)) {
+  // Idempotent on terminal state: once a task is terminal (complete,
+  // failed, or cancelled), every subsequent setStatus call is a no-op.
+  // The forward-only lifecycle forbids both terminal -> terminal
+  // transitions (which would lose the original terminal classification)
+  // and terminal -> non-terminal transitions (which would resurrect a
+  // finalized task).
+  if (isTerminal(task.status)) {
     return
   }
 

--- a/tests/task-status.test.ts
+++ b/tests/task-status.test.ts
@@ -74,6 +74,12 @@ describe('setStatus', () => {
     expect(task.status).toBe('complete')
   })
 
+  it('preserves failed when setStatus is called with running', () => {
+    const task = makeTask('failed', 12345)
+    setStatus(task, 'running')
+    expect(task.status).toBe('failed')
+  })
+
   it('preserves cancelled when setStatus is called with running and options', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
     tempPaths.push(dir)

--- a/tests/task-status.test.ts
+++ b/tests/task-status.test.ts
@@ -68,6 +68,34 @@ describe('setStatus', () => {
     expect(task.status).toBe('failed')
   })
 
+  it('preserves complete when setStatus is called with running', () => {
+    const task = makeTask('complete', 12345)
+    setStatus(task, 'running')
+    expect(task.status).toBe('complete')
+  })
+
+  it('preserves cancelled when setStatus is called with running and options', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const task = makeTask('cancelled', 12345)
+    await appendPidEntry(
+      pidFilePath,
+      task.pid,
+      'bash',
+      'Mon Apr 27 10:00:00 2026',
+    )
+
+    setStatus(task, 'running', { pidFilePath })
+    expect(task.status).toBe('cancelled')
+
+    // PID file entry must remain — no removePidEntry should have fired.
+    await delay(100)
+    const content = readFileSync(pidFilePath, 'utf-8')
+    expect(content).toContain('12345')
+  })
+
   it('allows non-terminal transitions without removing PID entry', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'task-status-'))
     tempPaths.push(dir)


### PR DESCRIPTION
## What

Widen the terminal-state idempotency in `setStatus` from "terminal → terminal is a no-op" to "any `setStatus` call on a terminal task is a no-op". Once a task is `complete`, `failed`, or `cancelled`, every subsequent call is a no-op.

## Why

The forward-only lifecycle now explicitly forbids both branches:

- **terminal → terminal** — would lose the original terminal classification (e.g. a `cancelled` task being reclassified as `complete`)
- **terminal → non-terminal** — would resurrect a finalized task back into a running state

No caller currently triggers the resurrection path; this is contract tightening to prevent future regressions and to align the helper with the lifecycle the rest of the runtime assumes.

## Tests

Two regression tests cover the new branches:

- terminal → non-terminal without options: status preserved
- terminal → non-terminal with options: status preserved AND `removePidEntry` does not fire (PID file entry remains intact)

167 / 0 fail.

Closes one item on issue #49.
