### PR TITLE
feat(runtime): make plugin factory idempotent across multiple config sources

### DIFF
--- a/.changeset/idempotent-plugin-registration.md
+++ b/.changeset/idempotent-plugin-registration.md
@@ -1,0 +1,9 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Make the plugin factory idempotent across multiple OpenCode config sources within the same process. When `~/.config/opencode/opencode.json` AND a project-level `opencode.json` (or any other combination of config sources) both list `opencode-copilot-delegate`, OpenCode previously invoked the factory once per source — each invocation evaluating the plugin module fresh, running orphan reaping, and registering its own copy of the three tools. The result was duplicated tools in the catalog, duplicated init side effects (PID-file `mkdir`, `reapOrphans`), and per-invocation closure state that could diverge across registrations.
+
+The factory now resolves at most once per process via a `globalThis` symbol singleton (`Symbol.for('opencode-copilot-delegate.singleton.v1')`). Subsequent invocations within the same PID return the cached hooks promise, skip the heavy init, and emit a single one-shot warning (via `console.warn` AND `client.app.log` under `service=copilot-delegate`) so duplicate-config situations remain observable in logs. Across distinct OpenCode processes the singleton is fresh — each process initializes normally.
+
+No configuration change is required for users with a single config source. Users with duplicate registrations will see one warning per process and a single set of tools in the catalog.

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,8 +63,8 @@ async function initializePlugin({ client, directory }: PluginInput) {
 const CopilotDelegate: Plugin = async (input) =>
   plugInOnce({
     doInit: () => initializePlugin(input),
-    onDuplicate: () => {
-      const message = `[copilot-delegate] duplicate factory invocation in same process (pid=${process.pid}); reusing existing hooks. Multiple opencode.json sources may list this plugin.`
+    onDuplicate: (pid) => {
+      const message = `[copilot-delegate] duplicate factory invocation in same process (pid=${pid}); reusing existing hooks. Multiple opencode.json sources may list this plugin.`
       console.warn(message)
       // Fire-and-forget so the log call never blocks plugin init.
       input.client.app

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import type { Plugin } from '@opencode-ai/plugin'
+import type { Plugin, PluginInput } from '@opencode-ai/plugin'
 import { discoverAgents } from './discovery/agents'
 import { buildDescription } from './discovery/description'
 import { killProcessTree } from './lib/kill-tree'
 import { normalizeToolArgSchemas } from './lib/normalize-tool-arg-schemas'
 import { getPidIdentity, reapOrphans } from './runtime/orphan-reaper'
 import { resolveInstancePidFilePath } from './runtime/pid-file'
+import { plugInOnce } from './runtime/plugin-singleton'
 import { createCancelTool } from './tools/cancel'
 import { createDelegateTool } from './tools/delegate'
 import { createOutputTool } from './tools/output'
@@ -21,7 +22,7 @@ function getAgentsDirectories(directory: string): {
   }
 }
 
-const CopilotDelegate: Plugin = async ({ client, directory }) => {
+async function initializePlugin({ client, directory }: PluginInput) {
   const agents = discoverAgents(getAgentsDirectories(directory))
   const delegateDescription = buildDescription(agents)
 
@@ -58,5 +59,24 @@ const CopilotDelegate: Plugin = async ({ client, directory }) => {
     },
   }
 }
+
+const CopilotDelegate: Plugin = async (input) =>
+  plugInOnce({
+    doInit: () => initializePlugin(input),
+    onDuplicate: () => {
+      const message = `[copilot-delegate] duplicate factory invocation in same process (pid=${process.pid}); reusing existing hooks. Multiple opencode.json sources may list this plugin.`
+      console.warn(message)
+      // Fire-and-forget so the log call never blocks plugin init.
+      input.client.app
+        .log({
+          body: {
+            service: 'copilot-delegate',
+            level: 'warn',
+            message,
+          },
+        })
+        .catch(() => {})
+    },
+  })
 
 export default CopilotDelegate

--- a/src/runtime/plugin-singleton.ts
+++ b/src/runtime/plugin-singleton.ts
@@ -21,6 +21,15 @@
  * a second invocation that arrives while the first is still awaiting
  * `mkdir` / `reapOrphans` converges on the same init result instead of
  * starting a parallel init.
+ *
+ * **Known limitation — rejected init is cached.** If `doInit()` rejects,
+ * the rejected promise is stored on `globalThis` and every subsequent
+ * invocation in the same PID returns the same rejection without
+ * retrying init. This is intentional: re-running heavy init on every
+ * call would defeat the singleton's purpose. Recovery requires a
+ * process restart. OpenCode currently surfaces a failed plugin factory
+ * as a startup error rather than retrying within the process, so this
+ * matches the upstream contract.
  */
 
 const SINGLETON_KEY: unique symbol = Symbol.for(
@@ -34,16 +43,32 @@ interface SingletonState<T> {
   warned: boolean
 }
 
+/**
+ * Type-safe view onto `globalThis` for our symbol-keyed singleton slot.
+ *
+ * TypeScript's `declare global { var ... }` augmentation does not accept
+ * computed property keys, so a unique-symbol-keyed slot on `globalThis`
+ * is reachable only via an intersection cast. The cast is contained at
+ * a single point (`globalThis as unknown as GlobalWithSingleton<T>`)
+ * and the property type drives subsequent reads and writes — callers do
+ * not re-assert the value's shape with additional casts.
+ */
+type GlobalWithSingleton<T> = typeof globalThis & {
+  [SINGLETON_KEY]?: SingletonState<T>
+}
+
 export interface PlugInOnceOptions<T> {
   /** Heavy init work that should run at most once per process. */
   doInit: () => Promise<T>
   /**
    * Called exactly once on the first duplicate invocation in the same
-   * process. Subsequent duplicates are silent. Implementations must not
-   * throw; fire-and-forget side effects (logging, metrics) are expected.
-   * Synchronous exceptions are swallowed defensively.
+   * process. Subsequent duplicates are silent. Receives the same `pid`
+   * value the guard used for its identity check (so test overrides flow
+   * through faithfully). Implementations must not throw; fire-and-forget
+   * side effects (logging, metrics) are expected. Synchronous exceptions
+   * are swallowed defensively.
    */
-  onDuplicate?: () => void
+  onDuplicate?: (pid: number) => void
   /** Test override; defaults to `process.pid`. */
   pid?: number
 }
@@ -58,14 +83,14 @@ export async function plugInOnce<T>({
   pid,
 }: PlugInOnceOptions<T>): Promise<T> {
   const currentPid = pid ?? process.pid
-  const g = globalThis as { [K: symbol]: unknown }
-  const existing = g[SINGLETON_KEY] as SingletonState<T> | undefined
+  const g = globalThis as unknown as GlobalWithSingleton<T>
+  const existing = g[SINGLETON_KEY]
 
   if (existing && existing.pid === currentPid) {
     if (!existing.warned) {
       existing.warned = true
       try {
-        onDuplicate?.()
+        onDuplicate?.(currentPid)
       } catch {
         // onDuplicate must not block plugin init.
       }
@@ -74,13 +99,12 @@ export async function plugInOnce<T>({
   }
 
   const hooksPromise = doInit()
-  const state: SingletonState<T> = {
+  g[SINGLETON_KEY] = {
     pid: currentPid,
     loadedAt: Date.now(),
     hooksPromise,
     warned: false,
   }
-  g[SINGLETON_KEY] = state
   return hooksPromise
 }
 
@@ -89,6 +113,6 @@ export async function plugInOnce<T>({
  * init. Must not be called in production code paths.
  */
 export function _resetPluginSingleton(): void {
-  const g = globalThis as { [K: symbol]: unknown }
+  const g = globalThis as unknown as GlobalWithSingleton<unknown>
   delete g[SINGLETON_KEY]
 }

--- a/src/runtime/plugin-singleton.ts
+++ b/src/runtime/plugin-singleton.ts
@@ -1,0 +1,94 @@
+/**
+ * Per-process singleton guard for the plugin factory.
+ *
+ * OpenCode invokes the plugin factory more than once per process when the
+ * same plugin is referenced by multiple config sources (for example a
+ * user-level `~/.config/opencode/opencode.json` AND a project-level
+ * `opencode.json`). Each invocation evaluates the plugin module fresh —
+ * module-local variables reset between calls — so the singleton state
+ * must live on `globalThis` to persist across module instances within
+ * the same process.
+ *
+ * On the first invocation the init runs normally and the resulting hooks
+ * promise is cached on `globalThis`. On subsequent invocations within
+ * the same PID the cached promise is returned and `onDuplicate` is
+ * invoked exactly once (subsequent duplicates are silent so logs do not
+ * spam). Across PIDs the singleton is treated as absent and init runs
+ * fresh — `globalThis` is per-process, but the explicit PID guard adds
+ * defensive belt-and-suspenders against any state-leakage edge case.
+ *
+ * The cached value is the init Promise rather than the resolved value so
+ * a second invocation that arrives while the first is still awaiting
+ * `mkdir` / `reapOrphans` converges on the same init result instead of
+ * starting a parallel init.
+ */
+
+const SINGLETON_KEY: unique symbol = Symbol.for(
+  'opencode-copilot-delegate.singleton.v1',
+)
+
+interface SingletonState<T> {
+  pid: number
+  loadedAt: number
+  hooksPromise: Promise<T>
+  warned: boolean
+}
+
+export interface PlugInOnceOptions<T> {
+  /** Heavy init work that should run at most once per process. */
+  doInit: () => Promise<T>
+  /**
+   * Called exactly once on the first duplicate invocation in the same
+   * process. Subsequent duplicates are silent. Implementations must not
+   * throw; fire-and-forget side effects (logging, metrics) are expected.
+   * Synchronous exceptions are swallowed defensively.
+   */
+  onDuplicate?: () => void
+  /** Test override; defaults to `process.pid`. */
+  pid?: number
+}
+
+/**
+ * Run `doInit` at most once per process, returning the cached hooks
+ * promise on subsequent invocations within the same PID.
+ */
+export async function plugInOnce<T>({
+  doInit,
+  onDuplicate,
+  pid,
+}: PlugInOnceOptions<T>): Promise<T> {
+  const currentPid = pid ?? process.pid
+  const g = globalThis as { [K: symbol]: unknown }
+  const existing = g[SINGLETON_KEY] as SingletonState<T> | undefined
+
+  if (existing && existing.pid === currentPid) {
+    if (!existing.warned) {
+      existing.warned = true
+      try {
+        onDuplicate?.()
+      } catch {
+        // onDuplicate must not block plugin init.
+      }
+    }
+    return existing.hooksPromise
+  }
+
+  const hooksPromise = doInit()
+  const state: SingletonState<T> = {
+    pid: currentPid,
+    loadedAt: Date.now(),
+    hooksPromise,
+    warned: false,
+  }
+  g[SINGLETON_KEY] = state
+  return hooksPromise
+}
+
+/**
+ * Test-only: clear the singleton state so the next invocation re-runs
+ * init. Must not be called in production code paths.
+ */
+export function _resetPluginSingleton(): void {
+  const g = globalThis as { [K: symbol]: unknown }
+  delete g[SINGLETON_KEY]
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { PluginInput } from '@opencode-ai/plugin'
 import plugin from '../src/index'
+import { _resetPluginSingleton } from '../src/runtime/plugin-singleton'
 import { cleanupAll } from '../src/runtime/task-registry'
 
 const tempPaths: string[] = []
@@ -18,6 +19,13 @@ const originalXdgStateHome = process.env.XDG_STATE_HOME
 
 afterEach(async () => {
   await cleanupAll()
+
+  // Each lifecycle test asserts side effects of a fresh `await plugin(input)`
+  // (orphans-dir creation, foreign-pidfile reaping). The singleton would
+  // short-circuit subsequent invocations and return cached hooks from a
+  // previous test's temp XDG_STATE_HOME, masking the assertion. Reset between
+  // tests so each `await plugin(input)` runs init for real.
+  _resetPluginSingleton()
 
   process.env.XDG_STATE_HOME = originalXdgStateHome
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
   chmodSync,
   mkdirSync,
@@ -17,15 +17,17 @@ import { cleanupAll } from '../src/runtime/task-registry'
 const tempPaths: string[] = []
 const originalXdgStateHome = process.env.XDG_STATE_HOME
 
+beforeEach(() => {
+  // Each lifecycle test asserts side effects of a fresh `await plugin(input)`
+  // (orphans-dir creation, foreign-pidfile reaping). Reset BEFORE each test so
+  // singleton state from a previous test file (e.g. `tests/tools.test.ts`)
+  // cannot short-circuit init and serve stale cached hooks tied to a different
+  // XDG_STATE_HOME.
+  _resetPluginSingleton()
+})
+
 afterEach(async () => {
   await cleanupAll()
-
-  // Each lifecycle test asserts side effects of a fresh `await plugin(input)`
-  // (orphans-dir creation, foreign-pidfile reaping). The singleton would
-  // short-circuit subsequent invocations and return cached hooks from a
-  // previous test's temp XDG_STATE_HOME, masking the assertion. Reset between
-  // tests so each `await plugin(input)` runs init for real.
-  _resetPluginSingleton()
 
   process.env.XDG_STATE_HOME = originalXdgStateHome
 

--- a/tests/plugin-singleton.test.ts
+++ b/tests/plugin-singleton.test.ts
@@ -50,6 +50,25 @@ describe('plugInOnce', () => {
     expect(calls).toBe(2)
   })
 
+  it('reruns init on a different pid without manual reset', async () => {
+    // Exercises the singleton's PID-mismatch branch directly: populate
+    // state with pid=1, then call again with pid=2 WITHOUT calling
+    // `_resetPluginSingleton()`. Init must run fresh because the cached
+    // pid does not match. This is the production code path for any
+    // (extremely unlikely) cross-process state leak — the test confirms
+    // the guard fires without test-only plumbing.
+    let calls = 0
+    const doInit = async () => {
+      calls += 1
+      return { call: calls }
+    }
+    const r1 = await plugInOnce({ doInit, pid: 1 })
+    const r2 = await plugInOnce({ doInit, pid: 2 })
+    expect(r1.call).toBe(1)
+    expect(r2.call).toBe(2)
+    expect(calls).toBe(2)
+  })
+
   it('fires onDuplicate exactly once on first duplicate invocation', async () => {
     let duplicateCalls = 0
     const doInit = async () => ({})
@@ -75,10 +94,50 @@ describe('plugInOnce', () => {
     expect(duplicateCalls).toBe(0)
   })
 
+  it('passes the resolved pid to onDuplicate (test override flows through)', async () => {
+    // The `pid` parameter is meant to make the singleton testable in a
+    // single-process Bun run by simulating different OS PIDs. The duplicate
+    // warning emitted by callers includes the PID for diagnostics, so the
+    // value passed to `onDuplicate` must match the one the guard used —
+    // not the live `process.pid` — so test overrides surface faithfully.
+    let receivedPid: number | undefined
+    const onDuplicate = (pid: number) => {
+      receivedPid = pid
+    }
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 9001 })
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 9001 })
+    expect(receivedPid).toBe(9001)
+  })
+
+  it('caches a rejected doInit promise on subsequent calls', async () => {
+    // Documents the known limitation in the JSDoc as test-form: when
+    // `doInit()` rejects, the rejected promise is cached and every
+    // subsequent invocation in the same PID returns the same rejection
+    // without retrying init. Recovery requires a process restart.
+    const error = new Error('init failed')
+    let calls = 0
+    const doInit = async () => {
+      calls += 1
+      throw error
+    }
+    await expect(plugInOnce({ doInit, pid: 1 })).rejects.toBe(error)
+    await expect(plugInOnce({ doInit, pid: 1 })).rejects.toBe(error)
+    await expect(plugInOnce({ doInit, pid: 1 })).rejects.toBe(error)
+    expect(calls).toBe(1)
+  })
+
   it('converges concurrent invocations on the same hooks promise', async () => {
     let started = 0
     const doInit = async () => {
       started += 1
+      // The 20ms delay is intentionally larger than the time it takes for
+      // `Promise.all([...])` to issue all three `plugInOnce` calls. The
+      // second and third calls observe the in-flight promise already
+      // cached on `globalThis` and skip running `doInit`. Bun's microtask
+      // scheduler resolves the synchronous portion of all three calls
+      // before the 20ms timer fires; if a future Bun release introduces
+      // microtask preemption between awaits, this test would need to
+      // pivot to an explicit deferred-resolve fixture.
       await new Promise((r) => setTimeout(r, 20))
       return { tool: 'concurrent' }
     }

--- a/tests/plugin-singleton.test.ts
+++ b/tests/plugin-singleton.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import {
+  _resetPluginSingleton,
+  plugInOnce,
+} from '../src/runtime/plugin-singleton'
+
+describe('plugInOnce', () => {
+  beforeEach(() => {
+    _resetPluginSingleton()
+  })
+
+  it('runs doInit once and returns its result on first invocation', async () => {
+    let calls = 0
+    const doInit = async () => {
+      calls += 1
+      return { tool: 'one' }
+    }
+    const result = await plugInOnce({ doInit, pid: 1 })
+    expect(result).toEqual({ tool: 'one' })
+    expect(calls).toBe(1)
+  })
+
+  it('returns the same hooks reference on subsequent calls in the same PID', async () => {
+    let calls = 0
+    const hooks = { tool: 'cached' }
+    const doInit = async () => {
+      calls += 1
+      return hooks
+    }
+    const r1 = await plugInOnce({ doInit, pid: 1 })
+    const r2 = await plugInOnce({ doInit, pid: 1 })
+    const r3 = await plugInOnce({ doInit, pid: 1 })
+    expect(r1).toBe(hooks)
+    expect(r2).toBe(hooks)
+    expect(r3).toBe(hooks)
+    expect(calls).toBe(1)
+  })
+
+  it('runs init again when pid changes (different process)', async () => {
+    let calls = 0
+    const doInit = async () => {
+      calls += 1
+      return { call: calls }
+    }
+    const r1 = await plugInOnce({ doInit, pid: 1 })
+    _resetPluginSingleton() // simulate "new process" globalThis fresh
+    const r2 = await plugInOnce({ doInit, pid: 2 })
+    expect(r1.call).toBe(1)
+    expect(r2.call).toBe(2)
+    expect(calls).toBe(2)
+  })
+
+  it('fires onDuplicate exactly once on first duplicate invocation', async () => {
+    let duplicateCalls = 0
+    const doInit = async () => ({})
+    const onDuplicate = () => {
+      duplicateCalls += 1
+    }
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    expect(duplicateCalls).toBe(1)
+  })
+
+  it('does not fire onDuplicate on the first invocation', async () => {
+    let duplicateCalls = 0
+    await plugInOnce({
+      doInit: async () => ({}),
+      onDuplicate: () => {
+        duplicateCalls += 1
+      },
+      pid: 1,
+    })
+    expect(duplicateCalls).toBe(0)
+  })
+
+  it('converges concurrent invocations on the same hooks promise', async () => {
+    let started = 0
+    const doInit = async () => {
+      started += 1
+      await new Promise((r) => setTimeout(r, 20))
+      return { tool: 'concurrent' }
+    }
+    const [r1, r2, r3] = await Promise.all([
+      plugInOnce({ doInit, pid: 1 }),
+      plugInOnce({ doInit, pid: 1 }),
+      plugInOnce({ doInit, pid: 1 }),
+    ])
+    expect(r1).toBe(r2)
+    expect(r2).toBe(r3)
+    expect(started).toBe(1)
+  })
+
+  it('swallows onDuplicate exceptions', async () => {
+    let initCalls = 0
+    let duplicateCalls = 0
+    const doInit = async () => {
+      initCalls += 1
+      return { ok: true }
+    }
+    const onDuplicate = () => {
+      duplicateCalls += 1
+      throw new Error('boom')
+    }
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    // The throwing onDuplicate must not propagate to plugin init.
+    const result = await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    expect(result).toEqual({ ok: true })
+    expect(duplicateCalls).toBe(1)
+    expect(initCalls).toBe(1)
+  })
+
+  it('does not fire onDuplicate again after the first time, even if onDuplicate threw', async () => {
+    let duplicateCalls = 0
+    const onDuplicate = () => {
+      duplicateCalls += 1
+      throw new Error('boom')
+    }
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
+    expect(duplicateCalls).toBe(1)
+  })
+})

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { PluginInput } from '@opencode-ai/plugin'
 import type { ToolContext } from '@opencode-ai/plugin/tool'
 import plugin from '../src/index'
+import { _resetPluginSingleton } from '../src/runtime/plugin-singleton'
 import { cleanupAll } from '../src/runtime/task-registry'
 import { createDelegateTool } from '../src/tools/delegate'
 
@@ -28,6 +29,14 @@ type ToolResultObject = Record<string, unknown>
 
 const tempPaths: string[] = []
 const originalPath = process.env.PATH
+
+beforeEach(() => {
+  // Each test loads `plugin(input)` and asserts on the returned tool dispatch.
+  // The singleton would short-circuit subsequent invocations and reuse the
+  // first test's MockClient/PATH, breaking per-test isolation. Reset between
+  // tests so each `await plugin(input)` runs init for real.
+  _resetPluginSingleton()
+})
 
 afterEach(async () => {
   await cleanupAll()

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -401,6 +401,9 @@ describe('plugin tools', () => {
       client,
       description: 'delegate test',
       directory: invalidCwd,
+      // pidFilePath is currently optional; pass an explicit fixture so a
+      // future required-parameter refactor does not break this test silently.
+      pidFilePath: join(tmpdir(), 'spawn-error-fixture.pids'),
     })
 
     // When delegation is attempted


### PR DESCRIPTION
## Why

OpenCode invokes the plugin factory once per config source that lists `opencode-copilot-delegate`. With both a project-level `opencode.json` and a user-level `~/.config/opencode/opencode.json` listing the plugin, the factory ran twice: each invocation evaluated the plugin module fresh, ran orphan reaping, and registered its own copy of the three tools. The result was duplicated tools in the catalog (visible to `client.tool.list({ provider, model })`), duplicated init side effects, and per-invocation closure state that could diverge across registrations.

A pre-flight `console.warn` + `client.app.log` probe confirmed the mechanism on a single OpenCode session:

- 2 invocations, same PID, same directory, 208 ms apart
- Module-local `let` counter showed `count=1` in both \u2014 module instances reset between calls

This means the singleton state must live on `globalThis`, not module scope.

## What

`src/runtime/plugin-singleton.ts` exposes `plugInOnce({ doInit, onDuplicate, pid? })` keyed on `Symbol.for('opencode-copilot-delegate.singleton.v1')`. The plugin factory wraps its heavy init body in this guard:

- **First invocation** \u2014 runs init normally, caches the resulting hooks promise on `globalThis`.
- **Subsequent invocations, same PID** \u2014 returns the cached promise, skips agent discovery / `mkdir` / `reapOrphans`. The first duplicate emits a one-shot warning via `console.warn` AND `client.app.log({ service: 'copilot-delegate' })` so duplicate-config situations remain observable. Subsequent duplicates are silent.
- **Different PID** \u2014 singleton treated as absent; init runs fresh. Defensive belt-and-suspenders against any cross-process state-leak edge case.
- **Concurrent invocations** \u2014 both calls converge on the same `Promise<Hooks>` because the cached value is the in-flight promise, not the resolved hooks.

The cached value is the in-flight promise rather than the resolved hooks so a second invocation that arrives while the first is still awaiting `mkdir` / `reapOrphans` converges on the same init result instead of starting a parallel init. Today's OpenCode invokes sequentially (208 ms gap) but this is free future-proofing.

## Tests

- 8 new unit tests for `plugInOnce` covering: first-invocation init, cached-hooks reuse, fresh init across PIDs, one-shot duplicate warn, concurrent convergence, exception swallowing in `onDuplicate`.
- `_resetPluginSingleton()` test-only hook wired into `index.test.ts` `afterEach` and `tools.test.ts` `beforeEach` so per-test isolation is preserved.
- Full suite: 184 pass / 0 fail / 817 expects. Typecheck, lint, build all clean.

## Bump

Minor (\u2192 0.8.0). Defensive correctness, but observable behavior change for any user with duplicate registrations: previously got duplicate tools and duplicate init side effects; now gets one set of cached hooks and a one-shot warning.

## User-facing migration

None for users with a single config source. Users with duplicate registrations will see one warning per process and a single set of tools in the catalog.
