### PR TITLE
feat(runtime): improve runtime observability

### DIFF
--- a/.changeset/runtime-observability.md
+++ b/.changeset/runtime-observability.md
@@ -1,0 +1,10 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Improve runtime observability and fix a silent failure in completion notifications.
+
+- `killProcessTree` now classifies fkill failures by probing the process group with `process.kill(-pid, 0)`. ESRCH is reported as an already-gone group and the failure is suppressed; alive or unknown states preserve the original throw with a more accurate warning. The probe targets `-pid` (the process group) rather than the leader so children leaking after a leader exit are no longer misclassified as benign.
+- `notifyCompletion`'s fallback `client.app.log` call now uses the structured SDK shape (`{ body: { service, level, message } }`) and is wrapped in `try/catch` so synchronous SDK throws can no longer escape the documented "never throws" contract.
+- All runtime warnings now share the `[copilot-delegate]` prefix across `kill-tree`, `orphan-reaper`, `pid-file`, `task-registry`, and `task-status`, making operator log filtering predictable.
+- Internal contract documentation: `setStatus` and `writeChains` carry JSDoc covering terminal-state transitions and the per-file serialize chain.

--- a/src/lib/kill-tree.ts
+++ b/src/lib/kill-tree.ts
@@ -1,4 +1,43 @@
 import fkill from 'fkill'
+import { isErrnoException } from './errno'
+
+function formatError(error: unknown): string {
+  if (error instanceof AggregateError && error.errors.length > 0) {
+    return error.errors.map((entry) => String(entry)).join('; ')
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
+function probeRootPid(
+  pid: number,
+):
+  | { state: 'alive' }
+  | { state: 'gone' }
+  | { state: 'unknown'; code?: string } {
+  // Probe the process group (-pid), not just the leader. fkill(-pid) targets
+  // the whole group, so the question we actually want answered is "does the
+  // group still have members?". Probing only the leader (process.kill(pid, 0))
+  // would report ESRCH after a leader exit even if children remain, leading
+  // us to suppress an error while children leak.
+  try {
+    process.kill(-pid, 0)
+    return { state: 'alive' }
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ESRCH') {
+      return { state: 'gone' }
+    }
+
+    return {
+      state: 'unknown',
+      code: isErrnoException(error) ? error.code : undefined,
+    }
+  }
+}
 
 export async function killProcessTree(pid: number): Promise<void> {
   // Refuse pid <= 1: pid 0 means "caller's process group" and pid 1 is init.
@@ -19,5 +58,29 @@ export async function killProcessTree(pid: number): Promise<void> {
     waitForExit: 5000,
   }
 
-  await fkill(-pid, options)
+  try {
+    await fkill(-pid, options)
+  } catch (error) {
+    const probe = probeRootPid(pid)
+    const failure = formatError(error)
+
+    if (probe.state === 'gone') {
+      console.warn(
+        `[copilot-delegate] fkill failed for pid ${pid}, but root pid ${pid} is already gone; skipping follow-up kill handling (${failure})`,
+      )
+      return
+    }
+
+    if (probe.state === 'alive') {
+      console.warn(
+        `[copilot-delegate] fkill failed for pid ${pid}, and root pid ${pid} is still alive; processes may remain running (${failure})`,
+      )
+      throw error
+    }
+
+    console.warn(
+      `[copilot-delegate] fkill failed for pid ${pid}, and root pid probe failed with ${probe.code ?? 'unknown error'}; process state is uncertain (${failure})`,
+    )
+    throw error
+  }
 }

--- a/src/runtime/notify.ts
+++ b/src/runtime/notify.ts
@@ -32,7 +32,9 @@ export type NotifyClient = {
     }) => unknown
   }
   app: {
-    log: (...args: unknown[]) => void
+    log: (opts: {
+      body: { service: string; level: string; message: string; extra?: unknown }
+    }) => Promise<unknown>
   }
 }
 
@@ -140,10 +142,23 @@ export async function notifyCompletion(
       },
     })
   } catch (error) {
-    client.app.log(
-      'notify',
-      `Failed to inject notification for ${task.taskId}: ${error}`,
-    )
+    // Wrap in try/catch as well as .catch() because client.app.log may throw
+    // synchronously (e.g., shape validation, dead session binding) before
+    // returning a Promise; .catch() alone would let those escape and violate
+    // notifyCompletion's "never throws" contract.
+    try {
+      client.app
+        .log({
+          body: {
+            service: 'copilot-delegate',
+            level: 'warn',
+            message: `Failed to inject notification for ${task.taskId}: ${error}`,
+          },
+        })
+        .catch(() => {})
+    } catch {
+      // Swallow synchronous throws from client.app.log
+    }
   }
 
   try {

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -87,7 +87,7 @@ function runPs(
     const timeout = setTimeout(() => {
       timedOut = true
       console.warn(
-        `[orphan-reaper] ps invocation exceeded ${timeoutMs}ms timeout: ps ${args.join(' ')}`,
+        `[copilot-delegate] ps invocation exceeded ${timeoutMs}ms timeout: ps ${args.join(' ')}`,
       )
       child.kill('SIGTERM')
     }, timeoutMs)
@@ -304,6 +304,11 @@ async function cleanupAfterReap(
   isCurrent: boolean,
   currentInstancePath: string,
 ): Promise<boolean> {
+  // Both truncatePidFile and unlinkPidFile route through the per-file
+  // writeChains serialize lock in pid-file.ts, so cleanup is sequenced
+  // behind any concurrent appendPidEntry/removePidEntry callers. This
+  // ensures no entry written after the reap decision can be silently
+  // wiped by a truncate or unlink that was already in flight.
   try {
     if (isCurrent) {
       // For the current instance we always truncate via the canonical
@@ -441,7 +446,7 @@ async function doReap(opts: ReapOptions): Promise<ReapResult> {
     // Strict integer parse: filename stem must be a positive integer; reject
     // negative, zero, decimal, and partial-parse oddities like '1234abc'.
     if (!/^[1-9]\d*$/.test(stem)) {
-      console.warn(`[orphan-reaper] Skipping non-numeric PID file: ${file}`)
+      console.warn(`[copilot-delegate] Skipping non-numeric PID file: ${file}`)
       continue
     }
     const filePid = Number(stem)
@@ -503,7 +508,7 @@ export async function reapOrphans(
   const timeoutPromise = new Promise<ReapResult>((resolve) => {
     timeoutId = setTimeout(() => {
       console.warn(
-        `[orphan-reaper] reapOrphans exceeded ${reapTimeoutMs}ms budget; returning empty result`,
+        `[copilot-delegate] reapOrphans exceeded ${reapTimeoutMs}ms budget; returning empty result`,
       )
       controller.abort()
       resolve({ ...zeros, timedOut: true })

--- a/src/runtime/pid-file.ts
+++ b/src/runtime/pid-file.ts
@@ -13,6 +13,11 @@ import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { isErrnoException } from '../lib/errno'
 
+// Per-file write serializer: maps each file path to the tail of its pending
+// work chain. Each new write operation appends to this chain via .then(), so
+// concurrent callers for the same path are sequenced without a mutex. Entries
+// are deleted once the tail promise settles and no new work has been enqueued,
+// preventing unbounded map growth over long-lived sessions.
 const writeChains = new Map<string, Promise<void>>()
 
 async function serializeWrite(

--- a/src/runtime/task-registry.ts
+++ b/src/runtime/task-registry.ts
@@ -52,7 +52,7 @@ export function createTask(
           // subprocess is invisible to the orphan reaper. Surface a warning
           // so degraded coverage is observable.
           console.warn(
-            `[task-registry] ps lookup returned null for pid ${task.pid}; subprocess will not be tracked for orphan reaping`,
+            `[copilot-delegate] ps lookup returned null for pid ${task.pid}; subprocess will not be tracked for orphan reaping`,
           )
         }
       })

--- a/src/runtime/task-status.ts
+++ b/src/runtime/task-status.ts
@@ -15,17 +15,20 @@ function isTerminal(s: TaskStatus): boolean {
   return TERMINAL_STATUSES.has(s)
 }
 
+/**
+ * Transition `task` to `newStatus`, enforcing the forward-only lifecycle.
+ *
+ * Idempotent on any terminal state (complete, failed, cancelled): once a task
+ * reaches a terminal status every subsequent call is a no-op. This prevents
+ * both terminal→terminal re-classification and terminal→non-terminal
+ * resurrection. When transitioning to a terminal state and `pidFilePath` is
+ * provided, the task's PID entry is removed from the orphan-reaper file.
+ */
 export function setStatus(
   task: { status: TaskStatus; pid: number },
   newStatus: TaskStatus,
   options?: SetStatusOptions,
 ): void {
-  // Idempotent on terminal state: once a task is terminal (complete,
-  // failed, or cancelled), every subsequent setStatus call is a no-op.
-  // The forward-only lifecycle forbids both terminal -> terminal
-  // transitions (which would lose the original terminal classification)
-  // and terminal -> non-terminal transitions (which would resurrect a
-  // finalized task).
   if (isTerminal(task.status)) {
     return
   }

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -7,10 +7,11 @@ import {
   resetInFlightCounters,
 } from '../src/runtime/notify'
 
-/** Create a mock client that records prompt and toast calls. */
+/** Create a mock client that records prompt, toast, and app.log calls. */
 function mockClient(): NotifyClient & {
   promptCalls: Array<{ sessionId: string; noReply: boolean; text: string }>
   toastCalls: Array<{ message: string; variant: string }>
+  logCalls: Array<unknown>
 } {
   const promptCalls: Array<{
     sessionId: string
@@ -18,10 +19,12 @@ function mockClient(): NotifyClient & {
     text: string
   }> = []
   const toastCalls: Array<{ message: string; variant: string }> = []
+  const logCalls: Array<unknown> = []
 
   return {
     promptCalls,
     toastCalls,
+    logCalls,
     session: {
       prompt: async (opts: {
         path: { id: string }
@@ -46,7 +49,10 @@ function mockClient(): NotifyClient & {
       },
     },
     app: {
-      log: () => {},
+      log: (arg: unknown) => {
+        logCalls.push(arg)
+        return Promise.resolve()
+      },
     },
   }
 }
@@ -313,6 +319,30 @@ describe('notification injection', () => {
       await expect(
         notifyCompletion(client, makeTaskInfo()),
       ).resolves.toBeUndefined()
+    })
+
+    it('should call app.log with structured body shape when prompt fails', async () => {
+      // Given a client whose prompt throws
+      const client = mockClient()
+      client.session.prompt = async () => {
+        throw new Error('session expired')
+      }
+      incrementInFlight('session-A')
+
+      // When notified
+      await notifyCompletion(client, makeTaskInfo({ taskId: 'cpl_log-test' }))
+
+      // Then app.log is called with a structured body object, not positional args
+      expect(client.logCalls).toHaveLength(1)
+      const logArg = client.logCalls[0]
+      expect(typeof logArg).toBe('object')
+      expect(logArg).not.toBeNull()
+      const arg = logArg as {
+        body: { service: string; level: string; message: string }
+      }
+      expect(arg.body.service).toBe('copilot-delegate')
+      expect(arg.body.level).toBe('warn')
+      expect(arg.body.message).toContain('cpl_log-test')
     })
   })
 })

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -234,6 +234,9 @@ describe('orphan-reaper', () => {
 
         expect(res).toEqual(result())
         expect(warnings.some((w) => w.includes('garbage'))).toBe(true)
+        expect(warnings.some((w) => w.startsWith('[copilot-delegate]'))).toBe(
+          true,
+        )
         expect(readFileSync(garbagePath, 'utf-8')).toBeDefined()
       } finally {
         console.warn = origWarn
@@ -608,7 +611,7 @@ describe('orphan-reaper', () => {
         expect(res).toEqual(result({ timedOut: true }))
         const matched = warnings.find(
           (w) =>
-            w.includes('orphan-reaper') &&
+            w.includes('copilot-delegate') &&
             w.includes('reapOrphans') &&
             w.includes('50'),
         )
@@ -692,7 +695,7 @@ describe('orphan-reaper', () => {
       try {
         await getPidIdentity(process.pid, 1)
         const matched = warnings.find(
-          (w) => w.includes('orphan-reaper') && w.includes('timeout'),
+          (w) => w.includes('copilot-delegate') && w.includes('timeout'),
         )
         expect(matched).toBeTruthy()
       } finally {

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
 import type { ChildProcess } from 'node:child_process'
 import {
   chmodSync,
@@ -89,6 +89,24 @@ async function loadModules() {
   }
 }
 
+let killTreeImportNonce = 0
+
+// Cache-bust the dynamic import so each test gets a fresh module evaluation.
+// Bun's loader keys on the full URL, so appending `?test=N` (with N
+// monotonically increasing) forces re-evaluation; without this trick, the
+// `mock.module('fkill', ...)` setup from a prior test leaks into the next.
+async function loadIsolatedKillProcessTree(): Promise<KillProcessTreeFn> {
+  killTreeImportNonce += 1
+
+  const killTreeModule = await import(
+    `../src/lib/kill-tree.ts?test=${killTreeImportNonce}`
+  )
+
+  return requireFunction<KillProcessTreeFn>(
+    Reflect.get(killTreeModule, 'killProcessTree'),
+  )
+}
+
 function makeFakeCopilotBin(): string {
   const binDir = mkdtempSync(join(tmpdir(), 'copilot-bin-'))
   const copilotPath = join(binDir, 'copilot')
@@ -124,6 +142,8 @@ function expectProcessToBeGone(pid: number): void {
 const tempPaths: string[] = []
 
 afterEach(async () => {
+  mock.restore()
+
   const { cleanupAll } = await loadModules()
   await cleanupAll()
 
@@ -423,6 +443,123 @@ describe('subprocess runtime', () => {
       await killProcessTree(0)
 
       // Then the helper exits without throwing
+    })
+
+    describe('killProcessTree observability', () => {
+      it('logs and skips when fkill fails after the root pid is already gone', async () => {
+        // Given fkill fails and the root pid probe reports ESRCH
+        const fkillError = new AggregateError(
+          ['Killing process -1234 failed: Process does not exist'],
+          'Failed to kill processes',
+        )
+        const fkillMock = mock(async () => {
+          throw fkillError
+        })
+        await mock.module('fkill', () => ({ default: fkillMock }))
+
+        const killProcessTree = await loadIsolatedKillProcessTree()
+        const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+        const probeError = new Error('no such process') as NodeJS.ErrnoException
+        probeError.code = 'ESRCH'
+        const killSpy = spyOn(process, 'kill').mockImplementation(() => {
+          throw probeError
+        })
+
+        // When killProcessTree handles the failed fkill
+        await expect(killProcessTree(1234)).resolves.toBeUndefined()
+
+        // Then it logs the benign race and suppresses the failure
+        expect(fkillMock).toHaveBeenCalledWith(-1234, {
+          force: false,
+          forceAfterTimeout: 2000,
+          waitForExit: 5000,
+        })
+        expect(killSpy).toHaveBeenCalledWith(-1234, 0)
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        const goneMessage = warnSpy.mock.calls[0]?.[0]
+        expect(goneMessage).toEqual(
+          expect.stringContaining('[copilot-delegate]'),
+        )
+        expect(goneMessage).toEqual(
+          expect.stringContaining('root pid 1234 is already gone'),
+        )
+      })
+
+      it('warns and rethrows when fkill fails while the root pid is still alive', async () => {
+        // Given fkill fails but the root pid still exists
+        const fkillError = new AggregateError(
+          ['Killing process -4321 failed: Operation not permitted'],
+          'Failed to kill processes',
+        )
+        const fkillMock = mock(async () => {
+          throw fkillError
+        })
+        await mock.module('fkill', () => ({ default: fkillMock }))
+
+        const killProcessTree = await loadIsolatedKillProcessTree()
+        const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+        const killSpy = spyOn(process, 'kill').mockImplementation(() => true)
+
+        // When killProcessTree handles the failed fkill
+        await expect(killProcessTree(4321)).rejects.toBe(fkillError)
+
+        // Then it warns that live processes may remain and preserves failure
+        expect(fkillMock).toHaveBeenCalledWith(-4321, {
+          force: false,
+          forceAfterTimeout: 2000,
+          waitForExit: 5000,
+        })
+        expect(killSpy).toHaveBeenCalledWith(-4321, 0)
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        const aliveMessage = warnSpy.mock.calls[0]?.[0]
+        expect(aliveMessage).toEqual(
+          expect.stringContaining('[copilot-delegate]'),
+        )
+        expect(aliveMessage).toEqual(
+          expect.stringContaining('root pid 4321 is still alive'),
+        )
+      })
+
+      it('warns and rethrows when the root pid probe fails with an unexpected errno', async () => {
+        // Given fkill fails and the follow-up root pid probe also errors
+        const fkillError = new AggregateError(
+          ['Killing process -9876 failed: Operation not permitted'],
+          'Failed to kill processes',
+        )
+        const fkillMock = mock(async () => {
+          throw fkillError
+        })
+        await mock.module('fkill', () => ({ default: fkillMock }))
+
+        const killProcessTree = await loadIsolatedKillProcessTree()
+        const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+        const probeError = new Error(
+          'operation not permitted',
+        ) as NodeJS.ErrnoException
+        probeError.code = 'EPERM'
+        const killSpy = spyOn(process, 'kill').mockImplementation(() => {
+          throw probeError
+        })
+
+        // When killProcessTree handles the failed fkill
+        await expect(killProcessTree(9876)).rejects.toBe(fkillError)
+
+        // Then it surfaces the unexpected probe errno and preserves failure
+        expect(fkillMock).toHaveBeenCalledWith(-9876, {
+          force: false,
+          forceAfterTimeout: 2000,
+          waitForExit: 5000,
+        })
+        expect(killSpy).toHaveBeenCalledWith(-9876, 0)
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        const probeMessage = warnSpy.mock.calls[0]?.[0]
+        expect(probeMessage).toEqual(
+          expect.stringContaining('[copilot-delegate]'),
+        )
+        expect(probeMessage).toEqual(
+          expect.stringContaining('root pid probe failed with EPERM'),
+        )
+      })
     })
   })
 

--- a/tests/task-registry.test.ts
+++ b/tests/task-registry.test.ts
@@ -345,7 +345,7 @@ describe('task registry PID-file hooks', () => {
       const warningObserved = await waitUntil(() =>
         warnings.some((warning) =>
           warning.includes(
-            `[task-registry] ps lookup returned null for pid ${ghostPid}`,
+            `[copilot-delegate] ps lookup returned null for pid ${ghostPid}`,
           ),
         ),
       )
@@ -357,7 +357,7 @@ describe('task registry PID-file hooks', () => {
       expect(warningObserved).toBe(true)
       const matched = warnings.find((w) =>
         w.includes(
-          `[task-registry] ps lookup returned null for pid ${ghostPid}`,
+          `[copilot-delegate] ps lookup returned null for pid ${ghostPid}`,
         ),
       )
       expect(matched).toBeTruthy()


### PR DESCRIPTION
## Summary
- Improve kill-tree failure diagnostics by classifying `fkill` errors with a process-group liveness probe and suppressing already-gone races.
- Make completion notification fallback logging use the structured SDK `app.log` shape while preserving the non-throwing notification contract.
- Normalize runtime warning prefixes and document PID-file serialization and terminal-state lifecycle contracts.

## Verification
- `bun test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`