### PR TITLE
feat(runtime): harden pid file symlink handling

### DIFF
--- a/.changeset/symlink-hardening.md
+++ b/.changeset/symlink-hardening.md
@@ -1,0 +1,8 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Harden PID file and orphan-reaper state path handling against same-user symlink attacks.
+
+- Use no-follow PID file opens for read and truncate paths so symlinked `.pids` files are rejected instead of read or truncated.
+- Reject symlinked PID file parent directories before orphan reaping, cleanup, and plugin init state-directory creation so `orphans/` scans and cleanup do not follow attacker-controlled links.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,11 @@ import { buildDescription } from './discovery/description'
 import { killProcessTree } from './lib/kill-tree'
 import { normalizeToolArgSchemas } from './lib/normalize-tool-arg-schemas'
 import { getPidIdentity, reapOrphans } from './runtime/orphan-reaper'
-import { resolveInstancePidFilePath } from './runtime/pid-file'
+import {
+  assertOrphansDirNotSymlink,
+  assertPluginStateDirNotSymlink,
+  resolveInstancePidFilePath,
+} from './runtime/pid-file'
 import { plugInOnce } from './runtime/plugin-singleton'
 import { createCancelTool } from './tools/cancel'
 import { createDelegateTool } from './tools/delegate'
@@ -33,7 +37,9 @@ async function initializePlugin({ client, directory }: PluginInput) {
     // filesystems (EROFS) or permission-denied state dirs (EACCES). Both
     // failure modes degrade gracefully: reapOrphans's own readdir guard
     // returns an empty result when the directory cannot be enumerated.
+    await assertPluginStateDirNotSymlink(currentInstancePath)
     await mkdir(pidFileDir, { recursive: true, mode: 0o700 })
+    await assertOrphansDirNotSymlink(currentInstancePath)
     await reapOrphans({
       pidFileDir,
       currentInstancePath,

--- a/src/runtime/orphan-reaper.ts
+++ b/src/runtime/orphan-reaper.ts
@@ -1,8 +1,13 @@
 import { spawn } from 'node:child_process'
-import { readdir, readFile } from 'node:fs/promises'
+import { readdir } from 'node:fs/promises'
 import { basename, extname, join } from 'node:path'
 import { isErrnoException } from '../lib/errno'
-import { truncatePidFile, unlinkPidFile } from './pid-file'
+import {
+  assertOrphansDirNotSymlink,
+  readPidFileNoFollow,
+  truncatePidFile,
+  unlinkPidFile,
+} from './pid-file'
 
 export interface ReapDeps {
   killProcessTree: (pid: number) => Promise<void>
@@ -285,7 +290,8 @@ async function readPidFileEntries(
 ): Promise<PidEntry[] | null> {
   let content: string
   try {
-    content = await readFile(filePath, 'utf-8')
+    await assertOrphansDirNotSymlink(filePath)
+    content = await readPidFileNoFollow(filePath)
   } catch {
     return null
   }
@@ -310,6 +316,9 @@ async function cleanupAfterReap(
   // ensures no entry written after the reap decision can be silently
   // wiped by a truncate or unlink that was already in flight.
   try {
+    // Keep cleanup's own contract explicit; truncate/unlink repeat this check
+    // under the serialize lock as the authoritative enforcement point.
+    await assertOrphansDirNotSymlink(isCurrent ? currentInstancePath : filePath)
     if (isCurrent) {
       // For the current instance we always truncate via the canonical
       // `currentInstancePath`, never `filePath`. The two are equal in
@@ -421,6 +430,7 @@ async function doReap(opts: ReapOptions): Promise<ReapResult> {
 
   let files: string[]
   try {
+    await assertOrphansDirNotSymlink(currentInstancePath)
     files = await readdir(pidFileDir)
   } catch {
     return {

--- a/src/runtime/pid-file.ts
+++ b/src/runtime/pid-file.ts
@@ -2,12 +2,11 @@ import { randomBytes } from 'node:crypto'
 import {
   chmod,
   constants as fsConstants,
+  lstat,
   mkdir,
   open,
-  readFile,
   rename,
   unlink,
-  writeFile,
 } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -19,6 +18,42 @@ import { isErrnoException } from '../lib/errno'
 // are deleted once the tail promise settles and no new work has been enqueued,
 // preventing unbounded map growth over long-lived sessions.
 const writeChains = new Map<string, Promise<void>>()
+
+function symlinkPathError(path: string): Error {
+  return new Error(`[copilot-delegate] refusing symlink path: ${path}`)
+}
+
+async function assertNotSymlink(path: string): Promise<void> {
+  const stats = await lstat(path)
+  if (stats.isSymbolicLink()) {
+    throw symlinkPathError(path)
+  }
+}
+
+export async function assertPluginStateDirNotSymlink(
+  filePath: string,
+): Promise<void> {
+  try {
+    await assertNotSymlink(dirname(dirname(filePath)))
+  } catch (e) {
+    if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
+  }
+}
+
+export async function assertOrphansDirNotSymlink(
+  filePath: string,
+): Promise<void> {
+  await assertNotSymlink(dirname(filePath))
+}
+
+export async function readPidFileNoFollow(filePath: string): Promise<string> {
+  const fd = await open(filePath, fsConstants.O_NOFOLLOW | fsConstants.O_RDONLY)
+  try {
+    return await fd.readFile({ encoding: 'utf-8' })
+  } finally {
+    await fd.close()
+  }
+}
 
 async function serializeWrite(
   filePath: string,
@@ -54,11 +89,13 @@ export async function appendPidEntry(
   lstart: string,
 ): Promise<void> {
   await serializeWrite(filePath, async () => {
+    await assertPluginStateDirNotSymlink(filePath)
     await mkdir(dirname(filePath), { recursive: true, mode: 0o700 })
+    await assertOrphansDirNotSymlink(filePath)
 
     let existing = ''
     try {
-      existing = await readFile(filePath, 'utf-8')
+      existing = await readPidFileNoFollow(filePath)
     } catch (e) {
       if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
     }
@@ -69,7 +106,10 @@ export async function appendPidEntry(
     const tempPath = `${filePath}.tmp.${randomBytes(8).toString('hex')}`
     const fd = await open(
       tempPath,
-      fsConstants.O_EXCL | fsConstants.O_CREAT | fsConstants.O_WRONLY,
+      fsConstants.O_EXCL |
+        fsConstants.O_CREAT |
+        fsConstants.O_NOFOLLOW |
+        fsConstants.O_WRONLY,
       0o600,
     )
     try {
@@ -90,7 +130,8 @@ export async function removePidEntry(
   await serializeWrite(filePath, async () => {
     let existing = ''
     try {
-      existing = await readFile(filePath, 'utf-8')
+      await assertOrphansDirNotSymlink(filePath)
+      existing = await readPidFileNoFollow(filePath)
     } catch (e) {
       if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
       return
@@ -108,7 +149,10 @@ export async function removePidEntry(
     const tempPath = `${filePath}.tmp.${randomBytes(8).toString('hex')}`
     const fd = await open(
       tempPath,
-      fsConstants.O_EXCL | fsConstants.O_CREAT | fsConstants.O_WRONLY,
+      fsConstants.O_EXCL |
+        fsConstants.O_CREAT |
+        fsConstants.O_NOFOLLOW |
+        fsConstants.O_WRONLY,
       0o600,
     )
     try {
@@ -136,7 +180,16 @@ export async function removePidEntry(
 export async function truncatePidFile(filePath: string): Promise<void> {
   await serializeWrite(filePath, async () => {
     try {
-      await writeFile(filePath, '')
+      await assertOrphansDirNotSymlink(filePath)
+      const fd = await open(
+        filePath,
+        fsConstants.O_NOFOLLOW | fsConstants.O_WRONLY,
+      )
+      try {
+        await fd.truncate(0)
+      } finally {
+        await fd.close()
+      }
     } catch (e) {
       if (!isErrnoException(e) || e.code !== 'ENOENT') throw e
     }
@@ -150,6 +203,7 @@ export async function truncatePidFile(filePath: string): Promise<void> {
 export async function unlinkPidFile(filePath: string): Promise<void> {
   await serializeWrite(filePath, async () => {
     try {
+      await assertOrphansDirNotSymlink(filePath)
       await unlink(filePath)
     } catch (e) {
       if (!isErrnoException(e) || e.code !== 'ENOENT') throw e

--- a/src/runtime/pid-file.ts
+++ b/src/runtime/pid-file.ts
@@ -19,6 +19,8 @@ import { isErrnoException } from '../lib/errno'
 // preventing unbounded map growth over long-lived sessions.
 const writeChains = new Map<string, Promise<void>>()
 
+const oNoFollow = fsConstants.O_NOFOLLOW ?? 0
+
 function symlinkPathError(path: string): Error {
   return new Error(`[copilot-delegate] refusing symlink path: ${path}`)
 }
@@ -47,7 +49,7 @@ export async function assertOrphansDirNotSymlink(
 }
 
 export async function readPidFileNoFollow(filePath: string): Promise<string> {
-  const fd = await open(filePath, fsConstants.O_NOFOLLOW | fsConstants.O_RDONLY)
+  const fd = await open(filePath, oNoFollow | fsConstants.O_RDONLY)
   try {
     return await fd.readFile({ encoding: 'utf-8' })
   } finally {
@@ -108,7 +110,7 @@ export async function appendPidEntry(
       tempPath,
       fsConstants.O_EXCL |
         fsConstants.O_CREAT |
-        fsConstants.O_NOFOLLOW |
+        oNoFollow |
         fsConstants.O_WRONLY,
       0o600,
     )
@@ -151,7 +153,7 @@ export async function removePidEntry(
       tempPath,
       fsConstants.O_EXCL |
         fsConstants.O_CREAT |
-        fsConstants.O_NOFOLLOW |
+        oNoFollow |
         fsConstants.O_WRONLY,
       0o600,
     )
@@ -181,10 +183,7 @@ export async function truncatePidFile(filePath: string): Promise<void> {
   await serializeWrite(filePath, async () => {
     try {
       await assertOrphansDirNotSymlink(filePath)
-      const fd = await open(
-        filePath,
-        fsConstants.O_NOFOLLOW | fsConstants.O_WRONLY,
-      )
+      const fd = await open(filePath, oNoFollow | fsConstants.O_WRONLY)
       try {
         await fd.truncate(0)
       } finally {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
   chmodSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -171,5 +174,34 @@ describe('plugin init lifecycle', () => {
     // And tools dispatch is ready
     expect(result.tool).toBeDefined()
     expect(typeof result.tool?.copilot_delegate.execute).toBe('function')
+  })
+
+  it('returns tools without following a symlinked pid state parent into orphans', async () => {
+    const xdgState = mkdtempSync(join(tmpdir(), 'plugin-init-symlink-'))
+    tempPaths.push(xdgState)
+    process.env.XDG_STATE_HOME = xdgState
+
+    const realPluginStateDir = join(xdgState, 'real-plugin-state')
+    const realOrphansDir = join(realPluginStateDir, 'orphans')
+    mkdirSync(realOrphansDir, { recursive: true, mode: 0o700 })
+
+    const linkedPluginStateDir = join(xdgState, 'opencode-copilot-delegate')
+    symlinkSync(realPluginStateDir, linkedPluginStateDir)
+
+    const foreignPidFile = join(realOrphansDir, '4194305.pids')
+    writeFileSync(foreignPidFile, '99999\tcopilot\tTue Apr 28 23:45:30 2026\n')
+
+    const input = makePluginInput(process.cwd())
+    const result = await plugin(input)
+
+    expect(Object.keys(result.tool ?? {}).sort()).toEqual([
+      'copilot_cancel',
+      'copilot_delegate',
+      'copilot_output',
+    ])
+    expect(lstatSync(linkedPluginStateDir).isSymbolicLink()).toBe(true)
+    expect(readFileSync(foreignPidFile, 'utf-8')).toBe(
+      '99999\tcopilot\tTue Apr 28 23:45:30 2026\n',
+    )
   })
 })

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, spyOn } from 'bun:test'
 import {
   appendFileSync,
+  lstatSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -463,6 +466,87 @@ describe('orphan-reaper', () => {
   })
 
   describe('error paths', () => {
+    it('skips a symlinked current-instance pid file without truncating the target', async () => {
+      const dir = makeTempDir()
+      const pidFileDir = join(dir, 'orphans')
+      const currentPath = join(pidFileDir, `${process.pid}.pids`)
+      const targetPath = join(dir, 'target.txt')
+
+      mkdirSync(pidFileDir, { mode: 0o700 })
+      writeFileSync(targetPath, '99999\tcopilot\tt1\n')
+      symlinkSync(targetPath, currentPath)
+
+      const res = await reapOrphans({
+        pidFileDir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidIdentity: async () => null,
+      })
+
+      expect(res).toEqual(result())
+      expect(lstatSync(currentPath).isSymbolicLink()).toBe(true)
+      expect(readFileSync(targetPath, 'utf-8')).toBe('99999\tcopilot\tt1\n')
+    })
+
+    it('skips a symlinked pidFileDir without deleting files in its target', async () => {
+      const dir = makeTempDir()
+      const realDir = join(dir, 'real-orphans')
+      const pidFileDir = join(dir, 'linked-orphans')
+      const currentPath = join(pidFileDir, `${process.pid}.pids`)
+      const foreignPath = join(realDir, '9999.pids')
+
+      mkdirSync(realDir, { mode: 0o700 })
+      writePidFile(foreignPath, [{ pid: 99999, comm: 'copilot', lstart: 't1' }])
+      symlinkSync(realDir, pidFileDir)
+
+      const res = await reapOrphans({
+        pidFileDir,
+        currentInstancePath: currentPath,
+        killProcessTree: async () => {},
+        getPidIdentity: async () => null,
+        isPluginAlive: (pid) => pid !== 9999,
+      })
+
+      expect(res).toEqual(result())
+      expect(lstatSync(pidFileDir).isSymbolicLink()).toBe(true)
+      expect(readFileSync(foreignPath, 'utf-8')).toBe('99999\tcopilot\tt1\n')
+    })
+
+    it('does not enumerate entries through a symlinked pidFileDir', async () => {
+      const dir = makeTempDir()
+      const realDir = join(dir, 'real-orphans')
+      const pidFileDir = join(dir, 'linked-orphans')
+      const currentPath = join(pidFileDir, `${process.pid}.pids`)
+      const foreignPath = join(realDir, 'not-a-pid.pids')
+
+      mkdirSync(realDir, { mode: 0o700 })
+      writePidFile(foreignPath, [{ pid: 99999, comm: 'copilot', lstart: 't1' }])
+      symlinkSync(realDir, pidFileDir)
+
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      let probed = 0
+      try {
+        const res = await reapOrphans({
+          pidFileDir,
+          currentInstancePath: currentPath,
+          killProcessTree: async () => {},
+          getPidIdentity: async () => {
+            probed++
+            return null
+          },
+          isPluginAlive: () => false,
+        })
+
+        expect(res).toEqual(result())
+        expect(probed).toBe(0)
+        expect(warnSpy).not.toHaveBeenCalled()
+        expect(lstatSync(pidFileDir).isSymbolicLink()).toBe(true)
+        expect(readFileSync(foreignPath, 'utf-8')).toBe('99999\tcopilot\tt1\n')
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
     it('should silently skip malformed lines', async () => {
       const dir = makeTempDir()
       const currentPath = join(dir, `${process.pid}.pids`)

--- a/tests/pid-file.test.ts
+++ b/tests/pid-file.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'bun:test'
 import {
   existsSync,
+  constants as fsConstants,
   lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  rmSync,
   statSync,
   symlinkSync,
   writeFileSync,
@@ -14,6 +16,8 @@ import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   appendPidEntry,
+  assertPluginStateDirNotSymlink,
+  readPidFileNoFollow,
   removePidEntry,
   resolveInstancePidFilePath,
   truncatePidFile,
@@ -260,6 +264,72 @@ describe('pid-file', () => {
       const filePath = join(dir, 'missing.pids')
 
       await expect(unlinkPidFile(filePath)).resolves.toBeUndefined()
+    })
+
+    it('removes a symlink without following it', async () => {
+      const dir = makeTempDir()
+      const targetPath = join(dir, 'target.txt')
+      const filePath = join(dir, 'test.pids')
+
+      writeFileSync(targetPath, '12345\tbash\tMon Apr 27 10:00:00 2026\n')
+      symlinkSync(targetPath, filePath)
+
+      await unlinkPidFile(filePath)
+
+      expect(existsSync(filePath)).toBe(false)
+      expect(readFileSync(targetPath, 'utf-8')).toBe(
+        '12345\tbash\tMon Apr 27 10:00:00 2026\n',
+      )
+    })
+  })
+
+  describe('no-follow read', () => {
+    it('reads a regular pid file', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+      writeFileSync(filePath, '12345\tbash\tMon Apr 27 10:00:00 2026\n')
+
+      await expect(readPidFileNoFollow(filePath)).resolves.toBe(
+        '12345\tbash\tMon Apr 27 10:00:00 2026\n',
+      )
+    })
+
+    it('reads a regular pid file when O_NOFOLLOW is unavailable', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'test.pids')
+      const originalNoFollow = fsConstants.O_NOFOLLOW
+      writeFileSync(filePath, '12345\tbash\tMon Apr 27 10:00:00 2026\n')
+
+      try {
+        Reflect.set(fsConstants, 'O_NOFOLLOW', undefined)
+        const modulePath = `../src/runtime/pid-file.ts?no-follow-fallback=${Date.now()}`
+        const pidFile = (await import(
+          modulePath
+        )) as typeof import('../src/runtime/pid-file')
+
+        await expect(pidFile.readPidFileNoFollow(filePath)).resolves.toBe(
+          '12345\tbash\tMon Apr 27 10:00:00 2026\n',
+        )
+      } finally {
+        Reflect.set(fsConstants, 'O_NOFOLLOW', originalNoFollow)
+      }
+    })
+  })
+
+  describe('plugin state directory guard', () => {
+    it('swallows ENOENT before the plugin state directory exists', async () => {
+      const dir = makeTempDir()
+      const filePath = join(dir, 'state', 'orphans', 'test.pids')
+
+      await expect(
+        assertPluginStateDirNotSymlink(filePath),
+      ).resolves.toBeUndefined()
+
+      rmSync(join(dir, 'state'), { force: true, recursive: true })
+
+      await expect(
+        assertPluginStateDirNotSymlink(filePath),
+      ).resolves.toBeUndefined()
     })
   })
 

--- a/tests/pid-file.test.ts
+++ b/tests/pid-file.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'bun:test'
-import { existsSync, mkdtempSync, readFileSync, statSync } from 'node:fs'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -198,7 +207,7 @@ describe('pid-file', () => {
       const lines = content
         .trim()
         .split('\n')
-        .filter((l) => l.length > 0)
+        .filter((l: string) => l.length > 0)
       expect(lines).toHaveLength(10)
 
       const pids = new Set<number>()
@@ -251,6 +260,111 @@ describe('pid-file', () => {
       const filePath = join(dir, 'missing.pids')
 
       await expect(unlinkPidFile(filePath)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('symlink hardening', () => {
+    it('rejects a symlinked pid file in appendPidEntry', async () => {
+      const dir = makeTempDir()
+      const targetPath = join(dir, 'target.txt')
+      const filePath = join(dir, 'test.pids')
+
+      writeFileSync(targetPath, 'secret\n')
+      symlinkSync(targetPath, filePath)
+
+      await expect(
+        appendPidEntry(filePath, 12345, 'copilot', 'Mon Jan 1 00:00:00 2024'),
+      ).rejects.toThrow()
+
+      expect(lstatSync(filePath).isSymbolicLink()).toBe(true)
+      expect(readFileSync(targetPath, 'utf-8')).toBe('secret\n')
+    })
+
+    it('rejects a symlinked parent directory in appendPidEntry', async () => {
+      const dir = makeTempDir()
+      const realDir = join(dir, 'real-orphans')
+      const linkedDir = join(dir, 'linked-orphans')
+      const filePath = join(linkedDir, 'test.pids')
+
+      mkdirSync(realDir, { mode: 0o700 })
+      symlinkSync(realDir, linkedDir)
+
+      await expect(
+        appendPidEntry(filePath, 12345, 'copilot', 'Mon Jan 1 00:00:00 2024'),
+      ).rejects.toThrow(/refusing symlink path/)
+
+      expect(lstatSync(linkedDir).isSymbolicLink()).toBe(true)
+      expect(existsSync(join(realDir, 'test.pids'))).toBe(false)
+    })
+
+    it('rejects a symlinked pid file in removePidEntry', async () => {
+      const dir = makeTempDir()
+      const targetPath = join(dir, 'target.txt')
+      const filePath = join(dir, 'test.pids')
+
+      writeFileSync(targetPath, '12345\tcopilot\tMon Jan 1 00:00:00 2024\n')
+      symlinkSync(targetPath, filePath)
+
+      await expect(removePidEntry(filePath, 12345)).rejects.toThrow()
+
+      expect(lstatSync(filePath).isSymbolicLink()).toBe(true)
+      expect(readFileSync(targetPath, 'utf-8')).toBe(
+        '12345\tcopilot\tMon Jan 1 00:00:00 2024\n',
+      )
+    })
+
+    it('rejects a symlinked parent directory in removePidEntry', async () => {
+      const dir = makeTempDir()
+      const realDir = join(dir, 'real-orphans')
+      const linkedDir = join(dir, 'linked-orphans')
+      const realFilePath = join(realDir, 'test.pids')
+      const filePath = join(linkedDir, 'test.pids')
+
+      mkdirSync(realDir, { mode: 0o700 })
+      writeFileSync(realFilePath, '12345\tcopilot\tMon Jan 1 00:00:00 2024\n')
+      symlinkSync(realDir, linkedDir)
+
+      await expect(removePidEntry(filePath, 12345)).rejects.toThrow(
+        /refusing symlink path/,
+      )
+
+      expect(lstatSync(linkedDir).isSymbolicLink()).toBe(true)
+      expect(readFileSync(realFilePath, 'utf-8')).toBe(
+        '12345\tcopilot\tMon Jan 1 00:00:00 2024\n',
+      )
+    })
+
+    it('rejects a symlinked pid file in truncatePidFile', async () => {
+      const dir = makeTempDir()
+      const targetPath = join(dir, 'target.txt')
+      const filePath = join(dir, 'test.pids')
+
+      writeFileSync(targetPath, 'secret\n')
+      symlinkSync(targetPath, filePath)
+
+      await expect(truncatePidFile(filePath)).rejects.toThrow()
+
+      expect(lstatSync(filePath).isSymbolicLink()).toBe(true)
+      expect(readFileSync(targetPath, 'utf-8')).toBe('secret\n')
+    })
+
+    it('rejects a symlinked parent directory in unlinkPidFile', async () => {
+      const dir = makeTempDir()
+      const realDir = join(dir, 'real-orphans')
+      const linkedDir = join(dir, 'linked-orphans')
+      const realFilePath = join(realDir, 'test.pids')
+      const filePath = join(linkedDir, 'test.pids')
+
+      mkdirSync(realDir, { mode: 0o700 })
+      writeFileSync(realFilePath, '12345\tcopilot\tMon Jan 1 00:00:00 2024\n')
+      symlinkSync(realDir, linkedDir)
+
+      await expect(unlinkPidFile(filePath)).rejects.toThrow(
+        /refusing symlink path/,
+      )
+
+      expect(lstatSync(linkedDir).isSymbolicLink()).toBe(true)
+      expect(existsSync(realFilePath)).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary
- Reject symlinked PID files and orphan-state directories before PID file reads, writes, cleanup, and orphan-reaper scans.
- Use no-follow file opens for PID reads/truncates so symlink targets are not read or modified.
- Add regression coverage for plugin init, PID file operations, and orphan-reaper symlink handling.

## Verification
- `bun test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`

Closes #49