### PR TITLE
fix(tui): stop /copilot-status escape from freezing

### DIFF
--- a/.changeset/tui-escape-freeze-fix.md
+++ b/.changeset/tui-escape-freeze-fix.md
@@ -1,0 +1,5 @@
+---
+'opencode-copilot-delegate': patch
+---
+
+Fix the `/copilot-status` TUI freeze caused by re-entrant dialog close handling when pressing Escape.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Run `bun run lint` to check, `bun run fix` to auto-fix.
 
 - Format: `feat(scope): description`, `fix(scope): description`, `chore(scope): description`
 - Scopes: `runtime`, `tools`, `discovery`, `ci`, `docs`
-- User-visible changes require a `.changeset/*.md` with `minor` bump (unstable `0.x` series)
+- User-visible feature additions and behavior changes require a `.changeset/*.md` with `minor` bump (unstable `0.x` series). Targeted user-visible bug fixes/hotfixes may use `patch` when they do not add new functionality.
 
 ## Security Constraints
 

--- a/docs/solutions/integration-issues/two-entrypoint-rpc-tui-hardening-2026-05-01.md
+++ b/docs/solutions/integration-issues/two-entrypoint-rpc-tui-hardening-2026-05-01.md
@@ -193,6 +193,7 @@ The fix makes the boundaries explicit:
 ## Related Issues
 
 - Plan: `docs/plans/2026-04-27-001-feat-copilot-status-tui-foundation-plan.md`
+- Follow-up UI lifecycle bug: `docs/solutions/ui-bugs/re-entrant-dialog-close-froze-copilot-status-on-escape-2026-05-02.md`
 - Related runtime lifecycle learning: `docs/solutions/best-practices/centralized-terminal-state-idempotency-task-lifecycle-2026-04-28.md`
 - Related process/session isolation learning: `docs/solutions/best-practices/per-instance-pid-files-spawner-liveness-gating-2026-04-28.md`
 - Related local-state learning: `docs/solutions/best-practices/atomic-file-append-remove-o-excl-temp-file-2026-04-28.md`

--- a/docs/solutions/ui-bugs/re-entrant-dialog-close-froze-copilot-status-on-escape-2026-05-02.md
+++ b/docs/solutions/ui-bugs/re-entrant-dialog-close-froze-copilot-status-on-escape-2026-05-02.md
@@ -1,0 +1,116 @@
+---
+title: Re-entrant dialog close froze /copilot-status on Escape
+date: 2026-05-02
+category: ui-bugs
+module: tui
+problem_type: ui_bug
+component: tooling
+symptoms:
+  - Pressing Escape in `/copilot-status` froze the entire OpenCode TUI instead of closing the modal.
+  - The freeze also affected the modal load-error path while switching to the unavailable alert.
+  - Layout and input rewrites changed the presentation but did not remove the freeze.
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+related_components:
+  - testing_framework
+tags: [tui, copilot-status, dialog-lifecycle, escape-key, modal, re-entrant-close]
+---
+
+# Re-entrant dialog close froze /copilot-status on Escape
+
+## Problem
+
+The custom `/copilot-status` dialog path in the TUI plugin misused the host dialog lifecycle. Pressing `Esc` could freeze the whole OpenCode TUI because the plugin fed host-owned close handling back into `api.ui.dialog.clear()` and re-entered dialog teardown.
+
+## Symptoms
+
+- Opening `/copilot-status` worked, but pressing `Esc` froze the entire TUI instead of closing the modal.
+- The same close-flow hazard existed on RPC load failure, where the modal could try to close itself before the unavailable alert replaced it.
+- The bug survived several UI-level changes, which made layout and keyboard handling look like the cause even though the lifecycle bug remained.
+
+## What Didn't Work
+
+- Removing nested `api.ui.Dialog` wrappers. That fixed a bad render pattern but left the close lifecycle unchanged.
+- Removing forced `height="100%"`. That affected layout only.
+- Removing raw `renderer.keyInput` listeners from the live path. The freeze still happened when the host handled `Esc`.
+- Rewriting the live path onto `DialogSelect`, `DialogConfirm`, and `DialogAlert`. That degraded the UX and still failed to isolate the real bug.
+- Making the custom modal read-only. That removed extra interaction code, but the close path was still re-entrant.
+
+## Solution
+
+Let the host own dialog teardown for the custom status modal, and treat modal load failures as error reporting rather than self-closing.
+
+In `src/tui/index.tsx`, keep `closeDialog` for explicit confirm and alert actions, but do not pass it back into the host `dialog.replace(..., onClose)` path for the custom status dialog:
+
+```tsx
+const closeDialog = () => {
+  api.ui.dialog.clear()
+}
+
+const openList = (initialTaskId?: string) => {
+  api.ui.dialog.setSize('large')
+  api.ui.dialog.replace(() => {
+    return (
+      <ModalList
+        onClose={closeDialog}
+        onLoadError={showUnavailableAlert}
+        initialTaskId={initialTaskId}
+        rpc={rpc}
+      />
+    )
+  })
+}
+```
+
+In `src/tui/components/modal-list.tsx`, report load failure without closing first:
+
+```tsx
+void loadTasks().catch((error) => {
+  if (disposed) {
+    return
+  }
+
+  props.onLoadError?.(error)
+})
+```
+
+Regression coverage pins the lifecycle contract:
+
+- `src/tui/__tests__/index.test.ts` asserts the custom status dialog replacement does not receive a re-entrant host `onClose` callback.
+- `src/tui/__tests__/modal-list.test.tsx` asserts load failures report `error` without a preceding `close`.
+
+Verification for the fix:
+
+- focused RED/GREEN tests for the close-flow bug
+- `bun run test:tui`
+- `bun run lint`
+- `bun run typecheck`
+- `bun run build`
+- live OpenCode restart, then `Esc` closed the modal cleanly instead of freezing the TUI
+
+## Why This Works
+
+`api.ui.dialog.replace(...)` installs content into a host-owned dialog stack. The broken path told the host to call back into plugin code during close so the plugin could call `api.ui.dialog.clear()` again. Pressing `Esc` therefore re-entered dialog teardown while the host was already unwinding that same dialog.
+
+The RPC load-error path had the same structural bug from the other direction: it mixed "close the current dialog" and "replace the current dialog with an unavailable alert" in the same failure path.
+
+The fix restores clean ownership boundaries:
+
+- the host closes the custom modal
+- the modal reports failures upward instead of mutating dialog state first
+- the parent decides whether to replace the dialog with an alert without a pre-emptive `clear()` re-entering the host close flow
+
+## Prevention
+
+- Do not pass `api.ui.dialog.clear()` back into `api.ui.dialog.replace(..., onClose)` for custom dialogs.
+- In async failure paths, do not clear the current dialog before surfacing the replacement error state.
+- Keep regression coverage that proves the custom status dialog does not re-enter the host close callback path.
+- Keep regression coverage that proves load errors are reported before any close-side effects.
+- When debugging TUI freezes, test lifecycle ownership before chasing layout or key-listener theories.
+- Preserve host-integrated verification for TUI fixes: `bun run test:tui`, `bun run lint`, `bun run typecheck`, `bun run build`, then restart OpenCode and exercise the live modal.
+
+## Related Issues
+
+- Related prior hardening in the same area: `docs/solutions/integration-issues/two-entrypoint-rpc-tui-hardening-2026-05-01.md`
+- No direct GitHub issue matched this specific Esc-freeze path during documentation research.

--- a/src/tui/__tests__/confirm-card.test.tsx
+++ b/src/tui/__tests__/confirm-card.test.tsx
@@ -423,6 +423,52 @@ describe('confirm card', () => {
     expect(captureCharFrame()).toContain('Cancel failed: rpc offline')
   })
 
+  it('does not intercept escape while still in the confirm state', async () => {
+    const ConfirmCard = await loadConfirmCard()
+
+    expect(typeof ConfirmCard).toBe('function')
+    if (!ConfirmCard) return
+
+    let confirmed = 0
+    let keptRunning = 0
+    let dismissedAfterError = 0
+
+    const { renderOnce, captureCharFrame, mockInput, renderer } =
+      await testRender(
+        () => (
+          <ConfirmCard
+            task={makeTask('cpl_escape_confirm')}
+            rpc={{
+              tasksCancel: async () => ({ cancelled: true }),
+            }}
+            onConfirm={() => {
+              confirmed += 1
+            }}
+            onCancel={() => {
+              keptRunning += 1
+            }}
+            onDismissAfterError={() => {
+              dismissedAfterError += 1
+            }}
+          />
+        ),
+        { width: 80, height: 20, useThread: false },
+      )
+
+    await renderOnce()
+    await settle(renderOnce, () => renderer.idle())
+
+    mockInput.pressEscape()
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle(renderOnce, () => renderer.idle())
+
+    expect(confirmed).toBe(0)
+    expect(keptRunning).toBe(0)
+    expect(dismissedAfterError).toBe(0)
+    expect(captureCharFrame()).toContain('Cancel Task')
+    expect(captureCharFrame()).toContain('Keep Running')
+  })
+
   it('ignores repeated confirm activations while cancellation is in flight', async () => {
     const ConfirmCard = await loadConfirmCard()
 

--- a/src/tui/__tests__/confirm-card.test.tsx
+++ b/src/tui/__tests__/confirm-card.test.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/solid */
 
 import { describe, expect, it } from 'bun:test'
-import type { TuiDialogProps } from '@opencode-ai/plugin/tui'
 import { type JSX, testRender } from '@opentui/solid'
 import {
   RpcAuthError,
@@ -22,7 +21,6 @@ type TaskRow = {
 }
 
 type ConfirmCardProps = {
-  Dialog: (props: TuiDialogProps) => JSX.Element
   task: TaskRow
   rpc: {
     tasksCancel(taskId: string): Promise<{ cancelled: boolean; error?: string }>
@@ -74,20 +72,6 @@ function createDeferred<T>(): Deferred<T> {
     reject(error: unknown) {
       rejectFn(error)
     },
-  }
-}
-
-function createDialogStub() {
-  let onClose: (() => void) | undefined
-
-  const Dialog = (props: TuiDialogProps) => {
-    onClose = props.onClose
-    return <box flexDirection="column">{props.children}</box>
-  }
-
-  return {
-    Dialog,
-    getOnClose: () => onClose,
   }
 }
 
@@ -143,11 +127,9 @@ describe('confirm card', () => {
     expect(typeof ConfirmCard).toBe('function')
     if (!ConfirmCard) return
 
-    const dialog = createDialogStub()
     const { renderOnce, captureCharFrame, renderer } = await testRender(
       () => (
         <ConfirmCard
-          Dialog={dialog.Dialog}
           task={makeTask('cpl_abc')}
           rpc={{ tasksCancel: async () => ({ cancelled: true }) }}
           onConfirm={() => {}}
@@ -178,7 +160,6 @@ describe('confirm card', () => {
     expect(typeof ConfirmCard).toBe('function')
     if (!ConfirmCard) return
 
-    const dialog = createDialogStub()
     const cancelledTaskIds: string[] = []
     let confirmed = 0
     let keptRunning = 0
@@ -187,7 +168,6 @@ describe('confirm card', () => {
     const { renderOnce, mockInput, renderer } = await testRender(
       () => (
         <ConfirmCard
-          Dialog={dialog.Dialog}
           task={makeTask('cpl_keep_running')}
           rpc={{
             tasksCancel: async (taskId) => {
@@ -229,14 +209,12 @@ describe('confirm card', () => {
     expect(typeof ConfirmCard).toBe('function')
     if (!ConfirmCard) return
 
-    const dialog = createDialogStub()
     const cancelledTaskIds: string[] = []
     let confirmed = 0
 
     const { renderOnce, mockInput, renderer } = await testRender(
       () => (
         <ConfirmCard
-          Dialog={dialog.Dialog}
           task={makeTask('cpl_cancel_success')}
           rpc={{
             tasksCancel: async (taskId) => {
@@ -270,12 +248,10 @@ describe('confirm card', () => {
     expect(typeof ConfirmCard).toBe('function')
     if (!ConfirmCard) return
 
-    const dialog = createDialogStub()
     const { renderOnce, captureCharFrame, mockInput, renderer } =
       await testRender(
         () => (
           <ConfirmCard
-            Dialog={dialog.Dialog}
             task={makeTask('cpl_cancel_error')}
             rpc={{
               tasksCancel: async () => {
@@ -324,14 +300,12 @@ describe('confirm card', () => {
     ]
 
     for (const error of cases) {
-      const dialog = createDialogStub()
       let confirmed = 0
 
       const { renderOnce, captureCharFrame, mockInput, renderer } =
         await testRender(
           () => (
             <ConfirmCard
-              Dialog={dialog.Dialog}
               task={makeTask('cpl_cancel_error')}
               rpc={{
                 tasksCancel: async () => {
@@ -371,7 +345,6 @@ describe('confirm card', () => {
     expect(typeof ConfirmCard).toBe('function')
     if (!ConfirmCard) return
 
-    const dialog = createDialogStub()
     let confirmed = 0
     let keptRunning = 0
 
@@ -379,7 +352,6 @@ describe('confirm card', () => {
       await testRender(
         () => (
           <ConfirmCard
-            Dialog={dialog.Dialog}
             task={makeTask('cpl_finished')}
             rpc={{
               tasksCancel: async () => ({
@@ -410,34 +382,33 @@ describe('confirm card', () => {
     expect(captureCharFrame()).not.toContain('Cancel failed')
   })
 
-  it('dismisses and returns after an inline cancellation error', async () => {
+  it('keeps inline cancellation errors open when escape is pressed', async () => {
     const ConfirmCard = await loadConfirmCard()
 
     expect(typeof ConfirmCard).toBe('function')
     if (!ConfirmCard) return
 
-    const dialog = createDialogStub()
     let dismissedAfterError = 0
 
-    const { renderOnce, mockInput, renderer } = await testRender(
-      () => (
-        <ConfirmCard
-          Dialog={dialog.Dialog}
-          task={makeTask('cpl_dismiss_after_error')}
-          rpc={{
-            tasksCancel: async () => {
-              throw new RpcUnreachableError('rpc offline')
-            },
-          }}
-          onConfirm={() => {}}
-          onCancel={() => {}}
-          onDismissAfterError={() => {
-            dismissedAfterError += 1
-          }}
-        />
-      ),
-      { width: 80, height: 20, useThread: false },
-    )
+    const { renderOnce, captureCharFrame, mockInput, renderer } =
+      await testRender(
+        () => (
+          <ConfirmCard
+            task={makeTask('cpl_dismiss_after_error')}
+            rpc={{
+              tasksCancel: async () => {
+                throw new RpcUnreachableError('rpc offline')
+              },
+            }}
+            onConfirm={() => {}}
+            onCancel={() => {}}
+            onDismissAfterError={() => {
+              dismissedAfterError += 1
+            }}
+          />
+        ),
+        { width: 80, height: 20, useThread: false },
+      )
 
     await renderOnce()
     await settle(renderOnce, () => renderer.idle())
@@ -448,7 +419,8 @@ describe('confirm card', () => {
     await new Promise((resolve) => setTimeout(resolve, 30))
     await settle(renderOnce, () => renderer.idle())
 
-    expect(dismissedAfterError).toBe(1)
+    expect(dismissedAfterError).toBe(0)
+    expect(captureCharFrame()).toContain('Cancel failed: rpc offline')
   })
 
   it('ignores repeated confirm activations while cancellation is in flight', async () => {
@@ -457,7 +429,6 @@ describe('confirm card', () => {
     expect(typeof ConfirmCard).toBe('function')
     if (!ConfirmCard) return
 
-    const dialog = createDialogStub()
     const deferred = createDeferred<{ cancelled: boolean }>()
     const cancelledTaskIds: string[] = []
     let confirmed = 0
@@ -465,7 +436,6 @@ describe('confirm card', () => {
     const { renderOnce, mockInput, renderer } = await testRender(
       () => (
         <ConfirmCard
-          Dialog={dialog.Dialog}
           task={makeTask('cpl_guard')}
           rpc={{
             tasksCancel: async (taskId) => {

--- a/src/tui/__tests__/index.test.ts
+++ b/src/tui/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import type {
   TuiCommand,
   TuiPluginApi,
   TuiPluginMeta,
+  TuiToast,
 } from '@opencode-ai/plugin/tui'
 import { type JSX, testRender } from '@opentui/solid'
 
@@ -25,11 +26,19 @@ type DialogReplacement = {
   onClose?: () => void
 }
 
+type ToastCall = {
+  message: string
+  variant?: string
+  duration?: number
+}
+
 type TestApiControls = {
   api: TuiPluginApi
   commandFactories: Array<() => TuiCommand[]>
   dialogReplacements: DialogReplacement[]
+  dialogSizes: Array<'medium' | 'large' | 'xlarge'>
   disposeHandlers: Array<() => void | Promise<void>>
+  toastCalls: ToastCall[]
   unregisterCalls: number
 }
 
@@ -68,7 +77,9 @@ async function loadTuiPlugin(): Promise<TuiPlugin> {
 function createTestApi(): TestApiControls {
   const commandFactories: Array<() => TuiCommand[]> = []
   const dialogReplacements: DialogReplacement[] = []
+  const dialogSizes: Array<'medium' | 'large' | 'xlarge'> = []
   const disposeHandlers: Array<() => void | Promise<void>> = []
+  const toastCalls: ToastCall[] = []
   let unregisterCalls = 0
 
   const api = {
@@ -91,13 +102,21 @@ function createTestApi(): TestApiControls {
       DialogSelect: (() => null) as TuiPluginApi['ui']['DialogSelect'],
       Slot: (() => null) as TuiPluginApi['ui']['Slot'],
       Prompt: (() => null) as TuiPluginApi['ui']['Prompt'],
-      toast: () => {},
+      toast: (input: TuiToast) => {
+        toastCalls.push({
+          message: input.message,
+          variant: input.variant,
+          duration: input.duration,
+        })
+      },
       dialog: {
         replace: (render: () => JSX.Element, onClose?: () => void) => {
           dialogReplacements.push({ render, onClose })
         },
         clear: () => {},
-        setSize: () => {},
+        setSize: (size: 'medium' | 'large' | 'xlarge') => {
+          dialogSizes.push(size)
+        },
         size: 'medium',
         depth: 0,
         open: false,
@@ -116,7 +135,9 @@ function createTestApi(): TestApiControls {
     api,
     commandFactories,
     dialogReplacements,
+    dialogSizes,
     disposeHandlers,
+    toastCalls,
     get unregisterCalls() {
       return unregisterCalls
     },
@@ -256,6 +277,7 @@ describe('tui entrypoint', () => {
     command.onSelect?.()
 
     expect(controls.dialogReplacements).toHaveLength(1)
+    expect(controls.dialogSizes).toEqual(['large'])
 
     const { renderOnce, captureCharFrame, renderer } = await testRender(
       () => controls.dialogReplacements[0].render(),
@@ -281,11 +303,40 @@ describe('tui entrypoint', () => {
     expect(frame).not.toContain('Unit 6')
   })
 
-  it('opens the confirm card for the selected task when c is pressed in the modal list', async () => {
+  it('does not toast when rpc is unavailable', async () => {
     const plugin = await loadTuiPlugin()
     const controls = createTestApi()
     const cacheHome = makeCacheHome()
-    const sessionDiscriminator = 'tui-index-confirm-card'
+    process.env.XDG_CACHE_HOME = cacheHome
+    process.env.OPENCODE_SESSION_ID = 'tui-index-error'
+
+    await plugin(controls.api, undefined, makePluginMeta())
+
+    const [command] = controls.commandFactories[0]()
+    command.onSelect?.()
+
+    expect(controls.dialogReplacements).toHaveLength(1)
+    expect(controls.dialogSizes).toEqual(['large'])
+
+    const { renderOnce, renderer } = await testRender(
+      () => controls.dialogReplacements[0].render(),
+      { useThread: false },
+    )
+
+    await renderOnce()
+    await renderer.idle()
+    await renderOnce()
+
+    expect(controls.dialogReplacements).toHaveLength(1)
+    expect(controls.dialogSizes).toEqual(['large'])
+    expect(controls.toastCalls).toEqual([])
+  })
+
+  it('keeps /copilot-status on a single read-only dialog replacement', async () => {
+    const plugin = await loadTuiPlugin()
+    const controls = createTestApi()
+    const cacheHome = makeCacheHome()
+    const sessionDiscriminator = 'tui-index-read-only'
 
     process.env.XDG_CACHE_HOME = cacheHome
     process.env.OPENCODE_SESSION_ID = sessionDiscriminator
@@ -293,18 +344,11 @@ describe('tui entrypoint', () => {
     writePortFile(cacheHome, sessionDiscriminator, {
       port: 43124,
       pid: process.pid,
-      token: 'token-index-confirm-card',
+      token: 'token-index-read-only',
     })
 
     const stubFetch = Object.assign(
-      async (_input: string | URL | Request, init?: RequestInit) => {
-        if (typeof init?.body === 'string' && init.body.includes('taskId')) {
-          return new Response(JSON.stringify({ cancelled: true }), {
-            status: 200,
-            headers: { 'content-type': 'application/json' },
-          })
-        }
-
+      async (_input: string | URL | Request) => {
         return new Response(
           JSON.stringify({
             tasks: [
@@ -364,44 +408,10 @@ describe('tui entrypoint', () => {
       includes: '2 running · 0 recent',
     })
     expect(listFrame).toContain('cpl_beta')
-
-    listRender.mockInput.pressKey('j')
-    await waitForFrame({
-      renderOnce: listRender.renderOnce,
-      idle: () => listRender.renderer.idle(),
-      captureCharFrame: listRender.captureCharFrame,
-      includes: 'cpl_beta',
-    })
-    listRender.mockInput.pressKey('c')
-    await waitForFrame({
-      renderOnce: listRender.renderOnce,
-      idle: () => listRender.renderer.idle(),
-      captureCharFrame: listRender.captureCharFrame,
-      includes: 'cpl_beta',
-    })
-
-    expect(controls.dialogReplacements).toHaveLength(2)
-
-    const confirmRender = await testRender(
-      () => controls.dialogReplacements[1].render(),
-      {
-        width: 120,
-        height: 20,
-        useThread: false,
-      },
-    )
-
-    await confirmRender.renderOnce()
-
-    const confirmFrame = await waitForFrame({
-      renderOnce: confirmRender.renderOnce,
-      idle: () => confirmRender.renderer.idle(),
-      captureCharFrame: confirmRender.captureCharFrame,
-      includes: 'Cancel Copilot delegation cpl_beta?',
-    })
-
-    expect(confirmFrame).toContain('Cancel Copilot delegation cpl_beta?')
-    expect(confirmFrame).toContain('Cancel Task')
-    expect(confirmFrame).toContain('Keep Running')
+    expect(listFrame).toContain('Esc close')
+    expect(listFrame).not.toContain('navigate')
+    expect(listFrame).not.toContain('c cancel')
+    expect(controls.dialogReplacements).toHaveLength(1)
+    expect(controls.dialogSizes).toEqual(['large'])
   })
 })

--- a/src/tui/__tests__/index.test.ts
+++ b/src/tui/__tests__/index.test.ts
@@ -37,6 +37,7 @@ type TestApiControls = {
   commandFactories: Array<() => TuiCommand[]>
   dialogReplacements: DialogReplacement[]
   dialogSizes: Array<'medium' | 'large' | 'xlarge'>
+  clearCalls: number
   disposeHandlers: Array<() => void | Promise<void>>
   toastCalls: ToastCall[]
   unregisterCalls: number
@@ -80,6 +81,7 @@ function createTestApi(): TestApiControls {
   const dialogSizes: Array<'medium' | 'large' | 'xlarge'> = []
   const disposeHandlers: Array<() => void | Promise<void>> = []
   const toastCalls: ToastCall[] = []
+  let clearCalls = 0
   let unregisterCalls = 0
 
   const api = {
@@ -113,7 +115,9 @@ function createTestApi(): TestApiControls {
         replace: (render: () => JSX.Element, onClose?: () => void) => {
           dialogReplacements.push({ render, onClose })
         },
-        clear: () => {},
+        clear: () => {
+          clearCalls += 1
+        },
         setSize: (size: 'medium' | 'large' | 'xlarge') => {
           dialogSizes.push(size)
         },
@@ -136,6 +140,9 @@ function createTestApi(): TestApiControls {
     commandFactories,
     dialogReplacements,
     dialogSizes,
+    get clearCalls() {
+      return clearCalls
+    },
     disposeHandlers,
     toastCalls,
     get unregisterCalls() {
@@ -301,6 +308,20 @@ describe('tui entrypoint', () => {
     expect(frame).toContain('0 running · 0 recent')
     expect(frame).toContain('No Copilot delegations are running.')
     expect(frame).not.toContain('Unit 6')
+  })
+
+  it('does not pass a re-entrant host onClose callback to the custom status dialog', async () => {
+    const plugin = await loadTuiPlugin()
+    const controls = createTestApi()
+
+    await plugin(controls.api, undefined, makePluginMeta())
+
+    const [command] = controls.commandFactories[0]()
+    command.onSelect?.()
+
+    expect(controls.dialogReplacements).toHaveLength(1)
+    expect(controls.dialogReplacements[0].onClose).toBeUndefined()
+    expect(controls.clearCalls).toBe(0)
   })
 
   it('does not toast when rpc is unavailable', async () => {

--- a/src/tui/__tests__/modal-list.test.tsx
+++ b/src/tui/__tests__/modal-list.test.tsx
@@ -281,7 +281,7 @@ describe('modal list', () => {
     expect(frame).toContain('Esc close')
   })
 
-  it('closes and reports load errors instead of rendering an inline error state', async () => {
+  it('reports load errors instead of rendering an inline error state', async () => {
     const ModalList = await loadModalList()
     const loadErrors: unknown[] = []
     let closeCalls = 0
@@ -315,10 +315,39 @@ describe('modal list', () => {
     })
     expect(frame).toContain('Loading delegations…')
     expect(frame).toContain('Esc close')
-    expect(closeCalls).toBe(1)
+    expect(closeCalls).toBe(0)
     expect(loadErrors).toHaveLength(1)
     expect(loadErrors[0]).toBeInstanceOf(Error)
     expect((loadErrors[0] as Error).message).toBe('rpc exploded on localhost')
+  })
+
+  it('reports load errors without closing first when an alert handler is present', async () => {
+    const ModalList = await loadModalList()
+    const callOrder: string[] = []
+
+    const { renderOnce, renderer } = await testRender(
+      () => (
+        <ModalList
+          rpc={{
+            tasksList: async () => {
+              throw new Error('rpc exploded on localhost')
+            },
+          }}
+          onClose={() => {
+            callOrder.push('close')
+          }}
+          onLoadError={() => {
+            callOrder.push('error')
+          }}
+        />
+      ),
+      { width: 120, height: 20, useThread: false },
+    )
+
+    await renderOnce()
+    await settle(renderOnce, () => renderer.idle())
+
+    expect(callOrder).toEqual(['error'])
   })
 
   it('renders running rows as a read-only status list', async () => {

--- a/src/tui/__tests__/modal-list.test.tsx
+++ b/src/tui/__tests__/modal-list.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'bun:test'
-import type { TuiDialogProps } from '@opencode-ai/plugin/tui'
 import { type JSX, testRender } from '@opentui/solid'
 
 type TaskStatus = 'running' | 'cancelling' | 'complete' | 'failed' | 'cancelled'
@@ -25,12 +24,11 @@ type ModalListClock = {
 }
 
 type ModalListProps = {
-  Dialog: (props: TuiDialogProps) => JSX.Element
   rpc: {
     tasksList(): Promise<TasksListResponse>
   }
   onClose: () => void
-  onCancelTask?: (task: TaskRow) => void
+  onLoadError?: (error: unknown) => void
   clock?: ModalListClock
 }
 
@@ -159,20 +157,6 @@ function createDeferred<T>(): Deferred<T> {
   }
 }
 
-function createDialogStub() {
-  let onClose: (() => void) | undefined
-
-  const Dialog = (props: TuiDialogProps) => {
-    onClose = props.onClose
-    return <box flexDirection="column">{props.children}</box>
-  }
-
-  return {
-    Dialog,
-    getOnClose: () => onClose,
-  }
-}
-
 function makeTask(taskId: string, overrides: Partial<TaskRow> = {}): TaskRow {
   return {
     taskId,
@@ -243,13 +227,11 @@ describe('modal list', () => {
   it('renders a loading state before tasksList resolves', async () => {
     const ModalList = await loadModalList()
     const deferred = createDeferred<TasksListResponse>()
-    const dialog = createDialogStub()
     let calls = 0
 
     const { renderOnce, captureCharFrame } = await testRender(
       () => (
         <ModalList
-          Dialog={dialog.Dialog}
           rpc={{
             tasksList: () => {
               calls += 1
@@ -272,12 +254,10 @@ describe('modal list', () => {
 
   it('renders an empty state after tasksList returns no tasks', async () => {
     const ModalList = await loadModalList()
-    const dialog = createDialogStub()
 
     const { renderOnce, captureCharFrame, renderer } = await testRender(
       () => (
         <ModalList
-          Dialog={dialog.Dialog}
           rpc={{ tasksList: async () => ({ tasks: [] }) }}
           onClose={() => {}}
         />
@@ -301,20 +281,25 @@ describe('modal list', () => {
     expect(frame).toContain('Esc close')
   })
 
-  it('renders an error state with the rpc rejection message', async () => {
+  it('closes and reports load errors instead of rendering an inline error state', async () => {
     const ModalList = await loadModalList()
-    const dialog = createDialogStub()
+    const loadErrors: unknown[] = []
+    let closeCalls = 0
 
     const { renderOnce, captureCharFrame, renderer } = await testRender(
       () => (
         <ModalList
-          Dialog={dialog.Dialog}
           rpc={{
             tasksList: async () => {
               throw new Error('rpc exploded on localhost')
             },
           }}
-          onClose={() => {}}
+          onClose={() => {
+            closeCalls += 1
+          }}
+          onLoadError={(error: unknown) => {
+            loadErrors.push(error)
+          }}
         />
       ),
       { width: 120, height: 20, useThread: false },
@@ -326,18 +311,19 @@ describe('modal list', () => {
       renderOnce,
       idle: () => renderer.idle(),
       captureCharFrame,
-      includes: 'Status unavailable.',
+      includes: 'Loading delegations…',
     })
-    expect(frame).toContain('Status unavailable.')
-    expect(frame).toContain('rpc exploded on localhost')
+    expect(frame).toContain('Loading delegations…')
     expect(frame).toContain('Esc close')
+    expect(closeCalls).toBe(1)
+    expect(loadErrors).toHaveLength(1)
+    expect(loadErrors[0]).toBeInstanceOf(Error)
+    expect((loadErrors[0] as Error).message).toBe('rpc exploded on localhost')
   })
 
-  it('renders running rows with focused styling, defaults, and key navigation', async () => {
+  it('renders running rows as a read-only status list', async () => {
     const ModalList = await loadModalList()
-    const dialog = createDialogStub()
     const clock = new TestClock(2_000)
-    const cancelled: TaskRow[] = []
     const tasks = [
       makeTask('cpl_alpha', {
         startedAt: 0,
@@ -357,14 +343,12 @@ describe('modal list', () => {
       }),
     ]
 
-    const { renderOnce, captureCharFrame, captureSpans, mockInput, renderer } =
+    const { renderOnce, captureCharFrame, captureSpans, renderer } =
       await testRender(
         () => (
           <ModalList
-            Dialog={dialog.Dialog}
             rpc={{ tasksList: async () => ({ tasks }) }}
             onClose={() => {}}
-            onCancelTask={(task) => cancelled.push(task)}
             clock={clock.adapter()}
           />
         ),
@@ -380,7 +364,9 @@ describe('modal list', () => {
       includes: '3 running · 0 recent',
     })
     expect(frame).toContain('3 running · 0 recent')
-    expect(frame).toContain('↑↓ navigate · c cancel · Esc close')
+    expect(frame).toContain('Esc close')
+    expect(frame).not.toContain('navigate')
+    expect(frame).not.toContain('c cancel')
     expect(frame).toContain('cpl_alpha')
     expect(frame).toContain('cpl_beta')
     expect(frame).toContain('cpl_gamma')
@@ -391,47 +377,18 @@ describe('modal list', () => {
     expect(frame).toContain('5 calls')
     expect(frame).toContain('0s')
 
-    let spans = captureSpans()
+    const spans = captureSpans()
     const firstLine = findLineAttributesContaining(spans, 'cpl_alpha')
     expect(firstLine).toBeDefined()
-    expect(lineHasInverse(firstLine)).toBe(true)
-
-    mockInput.pressKey('j')
-    await settle(renderOnce, () => renderer.idle())
-    expect(captureCharFrame()).toContain('cpl_beta')
-    spans = captureSpans()
-    const secondLine = findLineAttributesContaining(spans, 'cpl_beta')
-    expect(secondLine).toBeDefined()
-    expect(lineHasInverse(secondLine)).toBe(true)
-
-    mockInput.pressArrow('up')
-    await settle(renderOnce, () => renderer.idle())
-    spans = captureSpans()
-    const wrappedLine = findLineAttributesContaining(spans, 'cpl_alpha')
-    expect(wrappedLine).toBeDefined()
-    expect(lineHasInverse(wrappedLine)).toBe(true)
-
-    mockInput.pressKey('k')
-    await settle(renderOnce, () => renderer.idle())
-    spans = captureSpans()
-    const lastLine = findLineAttributesContaining(spans, 'cpl_gamma')
-    expect(lastLine).toBeDefined()
-    expect(lineHasInverse(lastLine)).toBe(true)
-
-    mockInput.pressKey('c')
-    await settle(renderOnce, () => renderer.idle())
-
-    expect(cancelled).toEqual([tasks[2]])
+    expect(lineHasInverse(firstLine)).toBe(false)
   })
 
   it('keeps cancelling tasks visible until runtime removes them', async () => {
     const ModalList = await loadModalList()
-    const dialog = createDialogStub()
 
     const { renderOnce, captureCharFrame, renderer } = await testRender(
       () => (
         <ModalList
-          Dialog={dialog.Dialog}
           rpc={{
             tasksList: async () => ({
               tasks: [makeTask('cpl_cancelling', { status: 'cancelling' })],
@@ -459,13 +416,11 @@ describe('modal list', () => {
 
   it('updates elapsed time from an injected clock without waiting on wall time', async () => {
     const ModalList = await loadModalList()
-    const dialog = createDialogStub()
     const clock = new TestClock(0)
 
     const { renderOnce, captureCharFrame, renderer } = await testRender(
       () => (
         <ModalList
-          Dialog={dialog.Dialog}
           rpc={{
             tasksList: async () => ({
               tasks: [
@@ -499,13 +454,11 @@ describe('modal list', () => {
 
   it('clears its refresh interval on teardown', async () => {
     const ModalList = await loadModalList()
-    const dialog = createDialogStub()
     const clock = new TestClock(0)
 
     const { renderer, renderOnce } = await testRender(
       () => (
         <ModalList
-          Dialog={dialog.Dialog}
           rpc={{
             tasksList: async () => ({
               tasks: [makeTask('cpl_cleanup')],

--- a/src/tui/components/confirm-card.tsx
+++ b/src/tui/components/confirm-card.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @opentui/solid */
 
-import type { TuiPluginApi } from '@opencode-ai/plugin/tui'
 import {
   type KeyEvent,
   TextAttributes,
@@ -12,7 +11,6 @@ import type { RpcClient } from '../rpc-client'
 import type { ModalListTask } from './row'
 
 type ConfirmCardProps = {
-  Dialog: TuiPluginApi['ui']['Dialog']
   task: ModalListTask
   rpc: Pick<RpcClient, 'tasksCancel'>
   onConfirm: () => void
@@ -78,7 +76,6 @@ function updateText(
 }
 
 export function ConfirmCard(props: ConfirmCardProps) {
-  const Dialog = props.Dialog
   const renderer = useRenderer()
   const title = `Cancel Copilot delegation ${props.task.taskId}?`
   const state: { value: ConfirmState } = {
@@ -123,19 +120,6 @@ export function ConfirmCard(props: ConfirmCardProps) {
     updateText(errorText, '')
     updateText(dismissText, '')
     renderer.requestRender()
-  }
-
-  const closeToList = () => {
-    if (state.value.kind === 'error') {
-      props.onDismissAfterError()
-      return
-    }
-
-    if (state.value.busy) {
-      return
-    }
-
-    props.onCancel()
   }
 
   const confirmCancel = async () => {
@@ -202,12 +186,6 @@ export function ConfirmCard(props: ConfirmCardProps) {
   }
 
   const handleKeyPress = (key: KeyEvent) => {
-    if (matchesKey(key, 'escape')) {
-      key.preventDefault()
-      closeToList()
-      return
-    }
-
     if (state.value.kind === 'confirm' && !state.value.busy) {
       if (isLeftKey(key)) {
         key.preventDefault()
@@ -235,41 +213,39 @@ export function ConfirmCard(props: ConfirmCardProps) {
   })
 
   return (
-    <Dialog onClose={closeToList} size="medium">
-      <box flexDirection="column" gap={1} padding={1}>
-        <text>{title}</text>
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI text nodes handle terminal mouse events directly. */}
-        <text
-          ref={confirmText}
-          attributes={TextAttributes.INVERSE}
-          onMouseUp={() => {
-            focusConfirm()
-            void confirmCancel()
-          }}
-        >
-          Cancel Task
-        </text>
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI text nodes handle terminal mouse events directly. */}
-        <text
-          ref={cancelText}
-          onMouseUp={() => {
-            focusCancel()
-            closeToList()
-          }}
-        >
-          Keep Running
-        </text>
-        <text ref={errorText} visible={false} />
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI text nodes handle terminal mouse events directly. */}
-        <text
-          ref={dismissText}
-          visible={false}
-          onMouseUp={() => {
-            props.onDismissAfterError()
-          }}
-        />
-      </box>
-    </Dialog>
+    <box flexDirection="column" gap={1} padding={1} width="100%">
+      <text>{title}</text>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI text nodes handle terminal mouse events directly. */}
+      <text
+        ref={confirmText}
+        attributes={TextAttributes.INVERSE}
+        onMouseUp={() => {
+          focusConfirm()
+          void confirmCancel()
+        }}
+      >
+        Cancel Task
+      </text>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI text nodes handle terminal mouse events directly. */}
+      <text
+        ref={cancelText}
+        onMouseUp={() => {
+          focusCancel()
+          props.onCancel()
+        }}
+      >
+        Keep Running
+      </text>
+      <text ref={errorText} visible={false} />
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI text nodes handle terminal mouse events directly. */}
+      <text
+        ref={dismissText}
+        visible={false}
+        onMouseUp={() => {
+          props.onDismissAfterError()
+        }}
+      />
+    </box>
   )
 }
 

--- a/src/tui/components/modal-list.tsx
+++ b/src/tui/components/modal-list.tsx
@@ -188,7 +188,6 @@ export function ModalList(props: ModalListProps) {
       return
     }
 
-    props.onClose()
     props.onLoadError?.(error)
   })
 

--- a/src/tui/components/modal-list.tsx
+++ b/src/tui/components/modal-list.tsx
@@ -1,9 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 
-import type { TuiPluginApi } from '@opencode-ai/plugin/tui'
 import {
   type BoxRenderable,
-  type KeyEvent,
   TextAttributes,
   type TextRenderable,
 } from '@opentui/core'
@@ -16,10 +14,6 @@ const LOADING_HEADER = 'Loading delegations…'
 const EMPTY_STATE_TITLE = 'No Copilot delegations are running.'
 const EMPTY_STATE_HINT =
   'Start one with the copilot_delegate tool, then reopen /copilot-status.'
-const ERROR_STATE_TITLE = 'The Copilot delegate TUI plugin is not responding.'
-const ERROR_STATE_HINT =
-  'Try reloading the plugin (or run /copilot-status again).'
-
 export type ModalListClock = {
   now(): number
   setInterval(fn: () => void, delayMs: number): unknown
@@ -27,18 +21,14 @@ export type ModalListClock = {
 }
 
 type ModalListProps = {
-  Dialog: TuiPluginApi['ui']['Dialog']
   rpc: Pick<RpcClient, 'tasksList'>
   onClose: () => void
-  onCancelTask?: (task: ModalListTask) => void
+  onLoadError?: (error: unknown) => void
   initialTaskId?: string
   clock?: ModalListClock
 }
 
-type ViewState =
-  | { kind: 'loading' }
-  | { kind: 'ready'; tasks: ModalListTask[] }
-  | { kind: 'error'; message: string }
+type ViewState = { kind: 'loading' } | { kind: 'ready'; tasks: ModalListTask[] }
 
 const defaultClock: ModalListClock = {
   now: () => Date.now(),
@@ -46,14 +36,6 @@ const defaultClock: ModalListClock = {
   clearInterval: (handle) => {
     globalThis.clearInterval(handle as ReturnType<typeof setInterval>)
   },
-}
-
-function errorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message.trim()
-  }
-
-  return 'Unknown RPC error.'
 }
 
 function updateText(
@@ -80,22 +62,12 @@ function updateBoxVisibility(
   node.visible = visible
 }
 
-function matchesKey(key: KeyEvent, expected: string): boolean {
-  return (
-    key.name === expected || key.sequence === expected || key.raw === expected
-  )
-}
-
 type ModalRefs = {
   headerText?: TextRenderable
   footerText?: TextRenderable
   emptyBox?: BoxRenderable
   emptyLineOne?: TextRenderable
   emptyLineTwo?: TextRenderable
-  errorBox?: BoxRenderable
-  errorLineOne?: TextRenderable
-  errorLineTwo?: TextRenderable
-  errorLineThree?: TextRenderable
   rowsBox?: BoxRenderable
   rowTexts: Array<TextRenderable | undefined>
 }
@@ -104,25 +76,12 @@ function renderLoadingState(refs: ModalRefs) {
   updateText(refs.headerText, LOADING_HEADER)
   updateText(refs.footerText, 'Esc close')
   updateBoxVisibility(refs.emptyBox, false)
-  updateBoxVisibility(refs.errorBox, false)
   updateBoxVisibility(refs.rowsBox, false)
-}
-
-function renderErrorState(refs: ModalRefs, message: string) {
-  updateText(refs.headerText, 'Status unavailable.')
-  updateText(refs.footerText, 'Esc close')
-  updateBoxVisibility(refs.emptyBox, false)
-  updateBoxVisibility(refs.errorBox, true)
-  updateBoxVisibility(refs.rowsBox, false)
-  updateText(refs.errorLineOne, ERROR_STATE_TITLE)
-  updateText(refs.errorLineTwo, message)
-  updateText(refs.errorLineThree, ERROR_STATE_HINT)
 }
 
 function renderEmptyView(refs: ModalRefs) {
   updateText(refs.headerText, '0 running · 0 recent')
   updateText(refs.footerText, 'Esc close')
-  updateBoxVisibility(refs.errorBox, false)
   updateBoxVisibility(refs.emptyBox, true)
   updateBoxVisibility(refs.rowsBox, false)
   updateText(refs.emptyLineOne, EMPTY_STATE_TITLE)
@@ -132,12 +91,10 @@ function renderEmptyView(refs: ModalRefs) {
 function renderTaskRows(
   refs: ModalRefs,
   tasks: ModalListTask[],
-  focusedIndex: number,
   nowMs: number,
 ) {
   updateText(refs.headerText, `${tasks.length} running · 0 recent`)
-  updateText(refs.footerText, '↑↓ navigate · c cancel · Esc close')
-  updateBoxVisibility(refs.errorBox, false)
+  updateText(refs.footerText, 'Esc close')
   updateBoxVisibility(refs.emptyBox, false)
   updateBoxVisibility(refs.rowsBox, true)
 
@@ -150,42 +107,15 @@ function renderTaskRows(
 
     rowText.visible = task !== undefined
     rowText.content = task ? formatRowText(task, nowMs) : ''
-    rowText.attributes =
-      task && index === focusedIndex
-        ? TextAttributes.INVERSE
-        : TextAttributes.NONE
+    rowText.attributes = TextAttributes.NONE
   }
 }
 
-function isReadyState(
-  state: ViewState,
-): state is Extract<ViewState, { kind: 'ready' }> {
-  return state.kind === 'ready'
-}
-
-function previousIndex(current: number, total: number): number {
-  return current === 0 ? total - 1 : current - 1
-}
-
-function nextIndex(current: number, total: number): number {
-  return current === total - 1 ? 0 : current + 1
-}
-
-function isUpKey(key: KeyEvent): boolean {
-  return matchesKey(key, 'up') || matchesKey(key, 'k')
-}
-
-function isDownKey(key: KeyEvent): boolean {
-  return matchesKey(key, 'down') || matchesKey(key, 'j')
-}
-
 export function ModalList(props: ModalListProps) {
-  const Dialog = props.Dialog
   const renderer = useRenderer()
   const clock = props.clock ?? defaultClock
   const now = { value: clock.now() }
   const state: { value: ViewState } = { value: { kind: 'loading' } }
-  const focusedIndex = { value: 0 }
   let disposed = false
 
   let headerText: TextRenderable | undefined
@@ -193,10 +123,6 @@ export function ModalList(props: ModalListProps) {
   let emptyBox: BoxRenderable | undefined
   let emptyLineOne: TextRenderable | undefined
   let emptyLineTwo: TextRenderable | undefined
-  let errorBox: BoxRenderable | undefined
-  let errorLineOne: TextRenderable | undefined
-  let errorLineTwo: TextRenderable | undefined
-  let errorLineThree: TextRenderable | undefined
   let rowsBox: BoxRenderable | undefined
   const rowTexts: Array<TextRenderable | undefined> = []
 
@@ -206,10 +132,6 @@ export function ModalList(props: ModalListProps) {
     emptyBox,
     emptyLineOne,
     emptyLineTwo,
-    errorBox,
-    errorLineOne,
-    errorLineTwo,
-    errorLineThree,
     rowsBox,
     rowTexts,
   })
@@ -228,12 +150,6 @@ export function ModalList(props: ModalListProps) {
       return
     }
 
-    if (currentState.kind === 'error') {
-      renderErrorState(currentRefs, currentState.message)
-      renderer.requestRender()
-      return
-    }
-
     const tasks = currentState.tasks
 
     if (tasks.length === 0) {
@@ -242,44 +158,19 @@ export function ModalList(props: ModalListProps) {
       return
     }
 
-    renderTaskRows(currentRefs, tasks, focusedIndex.value, now.value)
+    renderTaskRows(currentRefs, tasks, now.value)
 
     renderer.requestRender()
   }
 
   const loadTasks = async () => {
-    try {
-      const response = await props.rpc.tasksList()
+    const response = await props.rpc.tasksList()
 
-      if (disposed) {
-        return
-      }
-
-      const initialIndex = props.initialTaskId
-        ? response.tasks.findIndex(
-            (task) => task.taskId === props.initialTaskId,
-          )
-        : -1
-
-      if (initialIndex >= 0) {
-        focusedIndex.value = initialIndex
-      } else if (response.tasks.length === 0) {
-        focusedIndex.value = 0
-      } else {
-        focusedIndex.value = Math.min(
-          focusedIndex.value,
-          response.tasks.length - 1,
-        )
-      }
-
-      state.value = { kind: 'ready', tasks: response.tasks }
-    } catch (error) {
-      if (disposed) {
-        return
-      }
-
-      state.value = { kind: 'error', message: errorMessage(error) }
+    if (disposed) {
+      return
     }
+
+    state.value = { kind: 'ready', tasks: response.tasks }
 
     renderView()
   }
@@ -292,97 +183,50 @@ export function ModalList(props: ModalListProps) {
     }
   }, 1_000)
 
-  void loadTasks()
-
-  const handleKeyPress = (key: KeyEvent) => {
-    if (matchesKey(key, 'escape')) {
-      key.preventDefault()
-      props.onClose()
+  void loadTasks().catch((error) => {
+    if (disposed) {
       return
     }
 
-    if (!isReadyState(state.value) || state.value.tasks.length === 0) {
-      return
-    }
-
-    if (isUpKey(key)) {
-      key.preventDefault()
-      focusedIndex.value = previousIndex(
-        focusedIndex.value,
-        state.value.tasks.length,
-      )
-      renderView()
-      return
-    }
-
-    if (isDownKey(key)) {
-      key.preventDefault()
-      focusedIndex.value = nextIndex(
-        focusedIndex.value,
-        state.value.tasks.length,
-      )
-      renderView()
-      return
-    }
-
-    if (matchesKey(key, 'c')) {
-      key.preventDefault()
-      props.onCancelTask?.(state.value.tasks[focusedIndex.value])
-    }
-  }
-
-  renderer.keyInput.on('keypress', handleKeyPress)
+    props.onClose()
+    props.onLoadError?.(error)
+  })
 
   onCleanup(() => {
     disposed = true
-    renderer.keyInput.off('keypress', handleKeyPress)
     clock.clearInterval(intervalHandle)
   })
 
   return (
-    <Dialog onClose={props.onClose} size="medium">
-      <box flexDirection="column" gap={1} padding={1}>
-        <text ref={headerText}>Loading delegations…</text>
+    <box flexDirection="column" gap={1} padding={1} width="100%">
+      <text ref={headerText}>Loading delegations…</text>
 
-        <box
-          ref={emptyBox}
-          flexDirection="column"
-          flexGrow={1}
-          justifyContent="center"
-          visible={false}
-        >
-          <text ref={emptyLineOne} />
-          <text ref={emptyLineTwo} />
-        </box>
-
-        <box
-          ref={errorBox}
-          flexDirection="column"
-          flexGrow={1}
-          justifyContent="center"
-          visible={false}
-        >
-          <text ref={errorLineOne} />
-          <text ref={errorLineTwo} />
-          <text ref={errorLineThree} />
-        </box>
-
-        <box ref={rowsBox} flexDirection="column" flexGrow={1} visible={false}>
-          <text ref={(node) => (rowTexts[0] = node)} />
-          <text ref={(node) => (rowTexts[1] = node)} />
-          <text ref={(node) => (rowTexts[2] = node)} />
-          <text ref={(node) => (rowTexts[3] = node)} />
-          <text ref={(node) => (rowTexts[4] = node)} />
-          <text ref={(node) => (rowTexts[5] = node)} />
-          <text ref={(node) => (rowTexts[6] = node)} />
-          <text ref={(node) => (rowTexts[7] = node)} />
-          <text ref={(node) => (rowTexts[8] = node)} />
-          <text ref={(node) => (rowTexts[9] = node)} />
-        </box>
-
-        <text ref={footerText}>Esc close</text>
+      <box
+        ref={emptyBox}
+        flexDirection="column"
+        flexGrow={1}
+        justifyContent="center"
+        visible={false}
+      >
+        <text ref={emptyLineOne} />
+        <text ref={emptyLineTwo} />
       </box>
-    </Dialog>
+
+      <box ref={rowsBox} flexDirection="column" flexGrow={1} visible={false}>
+        <text ref={(node) => (rowTexts[0] = node)} />
+        <text ref={(node) => (rowTexts[1] = node)} />
+        <text ref={(node) => (rowTexts[2] = node)} />
+        <text ref={(node) => (rowTexts[3] = node)} />
+        <text ref={(node) => (rowTexts[4] = node)} />
+        <text ref={(node) => (rowTexts[5] = node)} />
+        <text ref={(node) => (rowTexts[6] = node)} />
+        <text ref={(node) => (rowTexts[7] = node)} />
+        <text ref={(node) => (rowTexts[8] = node)} />
+        <text ref={(node) => (rowTexts[9] = node)} />
+      </box>
+
+      <text ref={footerText}>Esc close</text>
+    </box>
   )
 }
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -28,7 +28,7 @@ const tui: TuiPlugin = async (api) => {
           onConfirm={closeDialog}
         />
       )
-    }, closeDialog)
+    })
   }
 
   const openList = (initialTaskId?: string) => {
@@ -42,7 +42,7 @@ const tui: TuiPlugin = async (api) => {
           rpc={rpc}
         />
       )
-    }, closeDialog)
+    })
   }
 
   const unregister = api.command.register(() => [

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,10 +1,16 @@
 /** @jsxImportSource @opentui/solid */
 
 import type { TuiPlugin, TuiPluginModule } from '@opencode-ai/plugin/tui'
-import { ConfirmCard } from './components/confirm-card'
 import { ModalList } from './components/modal-list'
-import type { ModalListTask } from './components/row'
 import { createRpcClient } from './rpc-client'
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message.trim()
+  }
+
+  return 'Unknown RPC error.'
+}
 
 const tui: TuiPlugin = async (api) => {
   const rpc = createRpcClient()
@@ -12,30 +18,28 @@ const tui: TuiPlugin = async (api) => {
     api.ui.dialog.clear()
   }
 
-  const openList = (initialTaskId?: string) => {
+  const showUnavailableAlert = (error: unknown) => {
+    api.ui.dialog.setSize('medium')
     api.ui.dialog.replace(() => {
       return (
-        <ModalList
-          Dialog={api.ui.Dialog}
-          onClose={closeDialog}
-          onCancelTask={openConfirmCard}
-          initialTaskId={initialTaskId}
-          rpc={rpc}
+        <api.ui.DialogAlert
+          title="Status unavailable."
+          message={errorMessage(error)}
+          onConfirm={closeDialog}
         />
       )
     }, closeDialog)
   }
 
-  const openConfirmCard = (task: ModalListTask) => {
+  const openList = (initialTaskId?: string) => {
+    api.ui.dialog.setSize('large')
     api.ui.dialog.replace(() => {
       return (
-        <ConfirmCard
-          Dialog={api.ui.Dialog}
-          task={task}
+        <ModalList
+          onClose={closeDialog}
+          onLoadError={showUnavailableAlert}
+          initialTaskId={initialTaskId}
           rpc={rpc}
-          onConfirm={() => openList(task.taskId)}
-          onCancel={() => openList(task.taskId)}
-          onDismissAfterError={() => openList(task.taskId)}
         />
       )
     }, closeDialog)


### PR DESCRIPTION
## Summary
- remove the re-entrant status dialog close path that caused `/copilot-status` to freeze the OpenCode TUI when `Esc` closed the modal
- simplify the live status dialog lifecycle and update the TUI regression tests around close handling and unavailable-state reporting
- add a patch changeset and document the root cause/fix in `docs/solutions/ui-bugs/`

## Verification
- `bun test --preload @opentui/solid/preload src/tui/__tests__/index.test.ts`
- `bun run test:tui`
- `bun run lint`
- `bun run typecheck`
- `bun run build`