### PR TITLE
ci(renovate): remove failing bun post-upgrade tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,14 +18,5 @@
       matchPackageNames: ['@opencode-ai/{/,}**'],
       semanticCommitType: 'build',
     },
-    {
-      description: 'Skip bun artifact updates due to containerbase permission conflict',
-      matchManagers: ['bun'],
-      skipArtifactsUpdate: true,
-    },
   ],
-  postUpgradeTasks: {
-    commands: ['bun install', 'bun run fix', 'bun run build'],
-    executionMode: 'branch',
-  },
 }


### PR DESCRIPTION
- remove Renovate `postUpgradeTasks` that ran `bun install`, `bun run fix`, and `bun run build` on dependency-update branches
- remove the temporary Bun-specific `skipArtifactsUpdate` package rule
- simplify Renovate config to avoid branch-time Bun tool installation failures and unblock normal update PR creation