### PR TITLE
docs(copilot): direct Copilot to refresh memories on load-bearing changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,21 @@ bun run build     # Bundle + declaration emit
 | `src/discovery/` | Agent file discovery, description builder | Depend on runtime or tools |
 | `src/index.ts` | Plugin entrypoint, wiring | Contain business logic |
 
+## Persisting Architectural Memory
+
+This repo has [Copilot Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory) enabled (Preview). When you modify load-bearing invariants, call `store_memory` to refresh the corresponding entry so future Copilot sessions inherit the current architecture rather than rediscover it. Memories auto-expire after 28 days unless re-derived from current code.
+
+Trigger files (non-exhaustive):
+
+- `src/lib/normalize-tool-arg-schemas.ts` and `src/runtime/plugin-singleton.ts` — the DUAL pattern (cross-instance Zod metadata + duplicate factory invocation)
+- `src/runtime/task-status.ts`, `src/runtime/task-registry.ts`, `src/runtime/subprocess.ts` — task lifecycle (`setStatus` contract, terminal-state idempotency)
+- `src/runtime/orphan-reaper.ts`, `src/runtime/pid-file.ts`, `src/runtime/kill-tree.ts` — orphan reaper (per-instance PID files, spawner-liveness + identity gates)
+- `src/index.ts` — plugin wiring; any change to factory invocation or singleton key
+
+API shape (`{subject, fact <200 chars, citations, reason}`), recommended subjects, citation format, and the full seeding pattern: see `docs/research/copilot-memory-experiment-2026-05-03.md`.
+
+Verify a memory before storing: re-read the cited code in this session and only commit facts that hold. The system rechecks citations on use; memories with stale citations are silently dropped.
+
 ## Changeset Policy
 
 This package uses `0.x` unstable versioning. User-visible changes require a `.changeset/*.md` entry with a `minor` bump (not `patch`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,8 +51,10 @@ Trigger files (non-exhaustive):
 
 - `src/lib/normalize-tool-arg-schemas.ts` and `src/runtime/plugin-singleton.ts` — the DUAL pattern (cross-instance Zod metadata + duplicate factory invocation)
 - `src/runtime/task-status.ts`, `src/runtime/task-registry.ts`, `src/runtime/subprocess.ts` — task lifecycle (`setStatus` contract, terminal-state idempotency)
-- `src/runtime/orphan-reaper.ts`, `src/runtime/pid-file.ts`, `src/runtime/kill-tree.ts` — orphan reaper (per-instance PID files, spawner-liveness + identity gates)
+- `src/runtime/orphan-reaper.ts`, `src/runtime/pid-file.ts`, `src/lib/kill-tree.ts` — orphan reaper (per-instance PID files, spawner-liveness + identity gates)
 - `src/index.ts` — plugin wiring; any change to factory invocation or singleton key
+
+For files outside this list, "load-bearing" means any change that could alter subprocess lifecycle, tool schema shape, or plugin initialization order.
 
 API shape (`{subject, fact <200 chars, citations, reason}`), recommended subjects, citation format, and the full seeding pattern: see `docs/research/copilot-memory-experiment-2026-05-03.md`.
 


### PR DESCRIPTION
Closes the operational loop on the [Copilot Memory experiment](https://github.com/marcusrbrown/opencode-copilot-delegate/pull/95): `store_memory` is callable in `copilot -p`, but delegated runs do not author memories spontaneously — the parent session has to direct it. This PR makes that direction part of the persistent repo instructions, so any Copilot session that lands in this repo (CLI, cloud agent, code review) knows to refresh the relevant memory when it modifies load-bearing code.

## What landed

A new "Persisting Architectural Memory" section in `.github/copilot-instructions.md`:

- Links to the [Copilot Memory upstream docs](https://docs.github.com/en/copilot/concepts/agents/copilot-memory) and notes the 28-day auto-expiration.
- Enumerates the trigger files explicitly so there's no ambiguity about which invariants warrant a memory refresh:
  - DUAL pattern: `src/lib/normalize-tool-arg-schemas.ts`, `src/runtime/plugin-singleton.ts`
  - Task lifecycle: `src/runtime/task-status.ts`, `src/runtime/task-registry.ts`, `src/runtime/subprocess.ts`
  - Orphan reaper: `src/runtime/orphan-reaper.ts`, `src/runtime/pid-file.ts`, `src/runtime/kill-tree.ts`
  - Plugin wiring: `src/index.ts`
- References `docs/research/copilot-memory-experiment-2026-05-03.md` for the API surface, recommended subjects, citation format, and the seeding pattern.
- Calls out the verification discipline: re-read the cited code in the current session before storing — the system silently drops memories whose citations no longer match.

## Why this shape

- **Copilot-instructions, not AGENTS.md.** The `store_memory` tool only exists in Copilot CLI; other agents (Claude, GPT, etc.) have their own memory mechanisms. Keeping the directive Copilot-specific avoids cross-agent confusion.
- **Trigger files enumerated, not heuristically described.** "Load-bearing" is too soft. The list of files maps 1:1 to the three currently-stored memories, so refresh signals are unambiguous.
- **No code change, no changeset.** The PR mutates only contributor-facing instruction text; npm consumers see no behavior change.

## Verification

- `bun run lint` clean.
- One file modified, +15 lines.
- Section ordering preserved (Module Boundaries → new section → Changeset Policy).