### PR TITLE
test(subprocess): stabilize cancel-process-tree assertion against CI runner load

### DIFF
--- a/.changeset/cancel-flake-poll-with-retry.md
+++ b/.changeset/cancel-flake-poll-with-retry.md
@@ -1,0 +1,5 @@
+---
+'opencode-copilot-delegate': patch
+---
+
+Stabilize the cancel-process-tree test against CI runner load by polling `process.kill(pid, 0)` with a 2s deadline instead of asserting synchronously. Test-only change; no plugin behavior or consumer surface affected.

--- a/tests/subprocess.test.ts
+++ b/tests/subprocess.test.ts
@@ -135,7 +135,31 @@ async function waitForFile(filePath: string): Promise<void> {
   throw new Error(`Timed out waiting for file: ${filePath}`)
 }
 
-function expectProcessToBeGone(pid: number): void {
+// Polls `process.kill(pid, 0)` (signal 0 probes liveness without delivery)
+// until it throws ESRCH/EPERM (process gone) or the deadline expires. Use
+// instead of a synchronous assertion when the test cancels a process tree
+// and immediately checks for liveness — the kernel may not have fully reaped
+// the grandchild by the time the assertion runs on a loaded CI runner.
+async function expectProcessToBeGone(
+  pid: number,
+  {
+    timeoutMs = 2000,
+    intervalMs = 50,
+  }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0)
+    } catch {
+      return
+    }
+
+    await delay(intervalMs)
+  }
+
+  // Final attempt — let the assertion failure surface the live PID for diagnosis.
   expect(() => process.kill(pid, 0)).toThrow()
 }
 
@@ -308,7 +332,7 @@ describe('subprocess runtime', () => {
       // Then the process tree is gone and the task is marked cancelled
       expect(task.status).toBe('cancelled')
       expect(Date.now() - startedAt).toBeLessThan(3000)
-      expectProcessToBeGone(grandchildPid)
+      await expectProcessToBeGone(grandchildPid)
     })
 
     it('does not append events after cancellation (cancel-race guard)', async () => {


### PR DESCRIPTION
## Summary

Stabilize `tests/subprocess.test.ts` against CI runner load by replacing the synchronous `expectProcessToBeGone(pid)` helper with an async poll-with-retry that probes `process.kill(pid, 0)` every 50ms until the target throws ESRCH/EPERM or a 2s deadline expires.

## Problem

`tests/subprocess.test.ts > spawnCopilot > "cancels the subprocess tree through the abort controller"` was intermittently failing with `process.kill(pid, 0) === true` instead of throwing — six observed failures in a week (one PR CI run, five consecutive Renovate runs) on otherwise-green main.

The synchronous assertion lost the race against the kernel reap on loaded runners after `killProcessTree(-pid)` had already signalled the process group. Locally the test always passed because the M-series host has spare cycles.

## Fix

`expectProcessToBeGone(pid, { timeoutMs = 2000, intervalMs = 50 })` now polls liveness with a deadline. If the process is still alive after the deadline, the final attempt surfaces the live PID for diagnosis. Mirrors the `waitUntil` pattern already used in `tests/task-registry.test.ts`.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test:unit` — 240/240 pass (1022 expect calls, 11.45s)
- `bun run build` — clean
- 5 consecutive iterations of the previously-flaky test in isolation — 5/5 stable

## Scope

Test-only. No plugin behavior or consumer surface changes.