### PR TITLE
fix(runtime): return empty hooks to duplicate plugin factory invocations

### DIFF
--- a/.changeset/empty-hooks-on-duplicate-plugin-invocation.md
+++ b/.changeset/empty-hooks-on-duplicate-plugin-invocation.md
@@ -1,0 +1,11 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Fix host-side double registration of `copilot_delegate`, `copilot_output`, and `copilot_cancel` when the plugin is listed in both a user-level and project-level `opencode.json`.
+
+Previously, the per-process register-once guard returned the cached real hooks to every duplicate factory invocation in the same PID. The OpenCode host iterates each plugin source's returned hook surface and registers every tool entry it finds, even when two sources return the same JS reference. That meant each tool appeared twice in the LLM-visible tool catalog under dual-source configurations.
+
+The guard now returns empty hooks (`{}`) on duplicate invocations so the host has nothing to register a second time. The first invocation still runs `doInit` once and receives the real hooks; subsequent invocations in the same PID receive `{}` and emit a one-time warning. Heavy initialization (agent discovery, orphan reaping, RPC server startup) still runs at most once per process.
+
+Single-source configurations are unaffected.

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,11 +135,11 @@ async function initializePlugin(input: PluginInputWithTestHooks) {
   }
 }
 
-const CopilotDelegate: Plugin = async (input) =>
-  plugInOnce({
+const CopilotDelegate: Plugin = async (input) => {
+  const result = await plugInOnce({
     doInit: () => initializePlugin(input),
     onDuplicate: (pid) => {
-      const message = `[copilot-delegate] duplicate factory invocation in same process (pid=${pid}); reusing existing hooks. Multiple opencode.json sources may list this plugin.`
+      const message = `[copilot-delegate] duplicate factory invocation in same process (pid=${pid}); returning empty hooks so the host does not double-register tools. Multiple opencode.json sources may list this plugin.`
       console.warn(message)
       // Fire-and-forget so the log call never blocks plugin init.
       input.client.app
@@ -153,5 +153,11 @@ const CopilotDelegate: Plugin = async (input) =>
         .catch(() => {})
     },
   })
+  // Return the envelope's hooks. On the first invocation this is the real
+  // hooks object built by `initializePlugin`. On duplicate invocations
+  // this is `{}` so the host registers nothing for the duplicate source —
+  // see plugin-singleton.ts for the empirical justification.
+  return result.hooks
+}
 
 export default CopilotDelegate

--- a/src/runtime/plugin-singleton.ts
+++ b/src/runtime/plugin-singleton.ts
@@ -1,35 +1,49 @@
 /**
- * Per-process singleton guard for the plugin factory.
+ * Per-process register-once guard for the plugin factory.
  *
  * OpenCode invokes the plugin factory more than once per process when the
  * same plugin is referenced by multiple config sources (for example a
  * user-level `~/.config/opencode/opencode.json` AND a project-level
  * `opencode.json`). Each invocation evaluates the plugin module fresh —
- * module-local variables reset between calls — so the singleton state
- * must live on `globalThis` to persist across module instances within
- * the same process.
+ * module-local variables reset between calls — so the guard state must
+ * live on `globalThis` to persist across module instances within the
+ * same process.
  *
- * On the first invocation the init runs normally and the resulting hooks
- * promise is cached on `globalThis`. On subsequent invocations within
- * the same PID the cached promise is returned and `onDuplicate` is
- * invoked exactly once (subsequent duplicates are silent so logs do not
- * spam). Across PIDs the singleton is treated as absent and init runs
- * fresh — `globalThis` is per-process, but the explicit PID guard adds
- * defensive belt-and-suspenders against any state-leakage edge case.
+ * On the first invocation `doInit` runs and the resulting hooks promise
+ * is cached on `globalThis`; the caller receives `{ isFirst: true, hooks }`.
+ * On every subsequent invocation in the same PID `doInit` is skipped, the
+ * cached promise is awaited (so sticky rejections still propagate),
+ * `onDuplicate` fires exactly once, and the caller receives
+ * `{ isFirst: false, hooks: {} as T }`. Across PIDs the guard is treated
+ * as absent and init runs fresh — `globalThis` is per-process, but the
+ * explicit PID check adds defensive belt-and-suspenders against any
+ * state-leakage edge case.
+ *
+ * **Why empty hooks on duplicate invocations.** A whole-hooks singleton
+ * that returns the same hooks reference to both invocations does not
+ * deduplicate host-side tool registration: OpenCode iterates each plugin
+ * source's returned hook surface and registers every tool entry it finds,
+ * even when two sources return the same JS reference. Returning `{}` from
+ * the duplicate path is the only shape that prevents host-side double
+ * registration of `copilot_delegate`, `copilot_output`, and
+ * `copilot_cancel`. Verified empirically against
+ * `client.tool.list({...})`: under whole-hooks reuse a dual-source config
+ * lists each tool twice; under empty-hooks-on-duplicate it lists each
+ * tool once.
  *
  * The cached value is the init Promise rather than the resolved value so
  * a second invocation that arrives while the first is still awaiting
  * `mkdir` / `reapOrphans` converges on the same init result instead of
  * starting a parallel init.
  *
- * **Known limitation — rejected init is cached.** If `doInit()` rejects,
+ * **Known limitation — rejected init is sticky.** If `doInit()` rejects,
  * the rejected promise is stored on `globalThis` and every subsequent
- * invocation in the same PID returns the same rejection without
+ * invocation in the same PID surfaces the same rejection without
  * retrying init. This is intentional: re-running heavy init on every
- * call would defeat the singleton's purpose. Recovery requires a
- * process restart. OpenCode currently surfaces a failed plugin factory
- * as a startup error rather than retrying within the process, so this
- * matches the upstream contract.
+ * call would defeat the guard's purpose. Recovery requires a process
+ * restart. OpenCode currently surfaces a failed plugin factory as a
+ * startup error rather than retrying within the process, so this matches
+ * the upstream contract.
  */
 
 const SINGLETON_KEY: unique symbol = Symbol.for(
@@ -74,14 +88,32 @@ export interface PlugInOnceOptions<T> {
 }
 
 /**
- * Run `doInit` at most once per process, returning the cached hooks
- * promise on subsequent invocations within the same PID.
+ * Result envelope for `plugInOnce(...)`.
+ *
+ * - `isFirst: true` — caller should return `hooks` (the real hooks from
+ *   `doInit`) to OpenCode.
+ * - `isFirst: false` — caller MUST return `hooks` (which is an empty `{}`)
+ *   so the host loader does not register tools or hooks twice.
+ *
+ * Callers that just `return result.hooks` do the right thing in both
+ * cases without needing to inspect `isFirst` — the empty object is what
+ * the host should register on the duplicate source.
+ */
+export interface PlugInOnceResult<T> {
+  isFirst: boolean
+  hooks: T
+}
+
+/**
+ * Run `doInit` at most once per process; on duplicate invocations resolve
+ * to empty hooks so the OpenCode host does not double-register tools and
+ * hooks under dual-source configurations.
  */
 export async function plugInOnce<T>({
   doInit,
   onDuplicate,
   pid,
-}: PlugInOnceOptions<T>): Promise<T> {
+}: PlugInOnceOptions<T>): Promise<PlugInOnceResult<T>> {
   const currentPid = pid ?? process.pid
   const g = globalThis as unknown as GlobalWithSingleton<T>
   const existing = g[SINGLETON_KEY]
@@ -95,7 +127,12 @@ export async function plugInOnce<T>({
         // onDuplicate must not block plugin init.
       }
     }
-    return existing.hooksPromise
+    // Await the cached init so sticky rejections still propagate to the
+    // duplicate caller. The resolved value is intentionally discarded —
+    // duplicate callers receive empty hooks so the host registers nothing
+    // for this source.
+    await existing.hooksPromise
+    return { isFirst: false, hooks: {} as T }
   }
 
   const hooksPromise = doInit()
@@ -105,7 +142,8 @@ export async function plugInOnce<T>({
     hooksPromise,
     warned: false,
   }
-  return hooksPromise
+  const hooks = await hooksPromise
+  return { isFirst: true, hooks }
 }
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -257,6 +257,50 @@ describe('plugin init lifecycle', () => {
     expect(typeof result.tool?.copilot_delegate.execute).toBe('function')
   })
 
+  it('returns empty hooks on duplicate factory invocations in the same process', async () => {
+    // Regression for the dual-source registration bug: when OpenCode
+    // invokes the plugin factory twice in the same PID (because the same
+    // plugin is listed in BOTH a user-level and a project-level
+    // opencode.json), the host iterates each invocation's returned hook
+    // surface and registers every tool entry it finds — even when both
+    // calls return the same JS reference. Returning the cached real hooks
+    // on the duplicate path causes copilot_delegate / copilot_output /
+    // copilot_cancel to appear twice in the LLM-visible tool catalog.
+    //
+    // The fix: the duplicate caller receives `{}` from `plugInOnce`, the
+    // factory unwraps `result.hooks`, and the host registers nothing for
+    // the duplicate source. This test asserts that exact contract at the
+    // factory boundary so a future refactor cannot silently regress to
+    // whole-hooks reuse.
+    const xdgState = mkdtempSync(join(tmpdir(), 'plugin-init-dup-'))
+    tempPaths.push(xdgState)
+    process.env.XDG_STATE_HOME = xdgState
+
+    const input = makePluginInput(process.cwd())
+    const first = await plugin(input)
+    const second = await plugin(input)
+    const third = await plugin(input)
+
+    // First invocation gets the real hooks with all three tools.
+    expect(Object.keys(first.tool ?? {}).sort()).toEqual([
+      'copilot_cancel',
+      'copilot_delegate',
+      'copilot_output',
+    ])
+
+    // Duplicate invocations get an empty hooks object — `tool` is absent
+    // entirely, not just empty. The host has nothing to register.
+    expect(second).toEqual({})
+    expect(second.tool).toBeUndefined()
+    expect(third).toEqual({})
+    expect(third.tool).toBeUndefined()
+
+    // The first hooks reference is NOT shared with the duplicates: the
+    // real hooks object stays attached to its first registration only.
+    expect(second).not.toBe(first)
+    expect(third).not.toBe(first)
+  })
+
   it('returns tools without following a symlinked pid state parent into orphans', async () => {
     const xdgState = mkdtempSync(join(tmpdir(), 'plugin-init-symlink-'))
     tempPaths.push(xdgState)

--- a/tests/plugin-singleton.test.ts
+++ b/tests/plugin-singleton.test.ts
@@ -9,30 +9,47 @@ describe('plugInOnce', () => {
     _resetPluginSingleton()
   })
 
-  it('runs doInit once and returns its result on first invocation', async () => {
+  it('returns isFirst:true with real hooks on first invocation', async () => {
     let calls = 0
+    const realHooks = { tool: { example: 'tool' } }
     const doInit = async () => {
       calls += 1
-      return { tool: 'one' }
+      return realHooks
     }
     const result = await plugInOnce({ doInit, pid: 1 })
-    expect(result).toEqual({ tool: 'one' })
+    expect(result.isFirst).toBe(true)
+    expect(result.hooks).toBe(realHooks)
     expect(calls).toBe(1)
   })
 
-  it('returns the same hooks reference on subsequent calls in the same PID', async () => {
+  it('returns isFirst:false with empty hooks on duplicate invocations in the same PID', async () => {
+    // The empty-hooks contract is the entire point of Option-2: the OpenCode
+    // host iterates each plugin source's returned hook surface and registers
+    // every tool entry it finds, even when two sources return the same JS
+    // reference. Returning the cached real hooks from the duplicate path
+    // would cause the host to register tools twice. Returning {} is the only
+    // shape that prevents host-side double registration.
     let calls = 0
-    const hooks = { tool: 'cached' }
+    const realHooks = { tool: { example: 'tool' } }
     const doInit = async () => {
       calls += 1
-      return hooks
+      return realHooks
     }
     const r1 = await plugInOnce({ doInit, pid: 1 })
     const r2 = await plugInOnce({ doInit, pid: 1 })
     const r3 = await plugInOnce({ doInit, pid: 1 })
-    expect(r1).toBe(hooks)
-    expect(r2).toBe(hooks)
-    expect(r3).toBe(hooks)
+
+    expect(r1.isFirst).toBe(true)
+    expect(r1.hooks).toBe(realHooks)
+
+    expect(r2.isFirst).toBe(false)
+    expect(r2.hooks).not.toBe(realHooks)
+    expect(Object.keys(r2.hooks)).toEqual([])
+
+    expect(r3.isFirst).toBe(false)
+    expect(r3.hooks).not.toBe(realHooks)
+    expect(Object.keys(r3.hooks)).toEqual([])
+
     expect(calls).toBe(1)
   })
 
@@ -45,8 +62,10 @@ describe('plugInOnce', () => {
     const r1 = await plugInOnce({ doInit, pid: 1 })
     _resetPluginSingleton() // simulate "new process" globalThis fresh
     const r2 = await plugInOnce({ doInit, pid: 2 })
-    expect(r1.call).toBe(1)
-    expect(r2.call).toBe(2)
+    expect(r1.isFirst).toBe(true)
+    expect(r1.hooks.call).toBe(1)
+    expect(r2.isFirst).toBe(true)
+    expect(r2.hooks.call).toBe(2)
     expect(calls).toBe(2)
   })
 
@@ -64,8 +83,10 @@ describe('plugInOnce', () => {
     }
     const r1 = await plugInOnce({ doInit, pid: 1 })
     const r2 = await plugInOnce({ doInit, pid: 2 })
-    expect(r1.call).toBe(1)
-    expect(r2.call).toBe(2)
+    expect(r1.isFirst).toBe(true)
+    expect(r1.hooks.call).toBe(1)
+    expect(r2.isFirst).toBe(true)
+    expect(r2.hooks.call).toBe(2)
     expect(calls).toBe(2)
   })
 
@@ -109,11 +130,13 @@ describe('plugInOnce', () => {
     expect(receivedPid).toBe(9001)
   })
 
-  it('caches a rejected doInit promise on subsequent calls', async () => {
+  it('propagates a rejected doInit to first and duplicate callers', async () => {
     // Documents the known limitation in the JSDoc as test-form: when
     // `doInit()` rejects, the rejected promise is cached and every
-    // subsequent invocation in the same PID returns the same rejection
-    // without retrying init. Recovery requires a process restart.
+    // subsequent invocation in the same PID surfaces the same rejection
+    // without retrying init. Recovery requires a process restart. The
+    // duplicate path awaits the cached promise so sticky rejections
+    // propagate to all callers, not just the first.
     const error = new Error('init failed')
     let calls = 0
     const doInit = async () => {
@@ -126,8 +149,9 @@ describe('plugInOnce', () => {
     expect(calls).toBe(1)
   })
 
-  it('converges concurrent invocations on the same hooks promise', async () => {
+  it('runs doInit exactly once across concurrent invocations', async () => {
     let started = 0
+    const realHooks = { tool: 'concurrent' }
     const doInit = async () => {
       started += 1
       // The 20ms delay is intentionally larger than the time it takes for
@@ -139,33 +163,53 @@ describe('plugInOnce', () => {
       // microtask preemption between awaits, this test would need to
       // pivot to an explicit deferred-resolve fixture.
       await new Promise((r) => setTimeout(r, 20))
-      return { tool: 'concurrent' }
+      return realHooks
     }
     const [r1, r2, r3] = await Promise.all([
       plugInOnce({ doInit, pid: 1 }),
       plugInOnce({ doInit, pid: 1 }),
       plugInOnce({ doInit, pid: 1 }),
     ])
-    expect(r1).toBe(r2)
-    expect(r2).toBe(r3)
+    // Only one call ran init.
     expect(started).toBe(1)
+
+    // The first call to claim the singleton slot resolves with isFirst:true
+    // and the real hooks. Promise.all preserves array order matching the
+    // input array, so r1 is the call that arrived first.
+    expect(r1.isFirst).toBe(true)
+    expect(r1.hooks).toBe(realHooks)
+
+    // Subsequent concurrent callers resolve with isFirst:false and {} so
+    // the host does not double-register tools.
+    expect(r2.isFirst).toBe(false)
+    expect(Object.keys(r2.hooks)).toEqual([])
+    expect(r3.isFirst).toBe(false)
+    expect(Object.keys(r3.hooks)).toEqual([])
   })
 
-  it('swallows onDuplicate exceptions', async () => {
+  it('swallows onDuplicate exceptions without affecting init result', async () => {
     let initCalls = 0
     let duplicateCalls = 0
+    const realHooks = { ok: true }
     const doInit = async () => {
       initCalls += 1
-      return { ok: true }
+      return realHooks
     }
     const onDuplicate = () => {
       duplicateCalls += 1
       throw new Error('boom')
     }
-    await plugInOnce({ doInit, onDuplicate, pid: 1 })
-    // The throwing onDuplicate must not propagate to plugin init.
-    const result = await plugInOnce({ doInit, onDuplicate, pid: 1 })
-    expect(result).toEqual({ ok: true })
+    const r1 = await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    // The throwing onDuplicate must not propagate into the duplicate
+    // result; the duplicate call still resolves with empty hooks.
+    const r2 = await plugInOnce({ doInit, onDuplicate, pid: 1 })
+
+    expect(r1.isFirst).toBe(true)
+    expect(r1.hooks).toBe(realHooks)
+
+    expect(r2.isFirst).toBe(false)
+    expect(Object.keys(r2.hooks)).toEqual([])
+
     expect(duplicateCalls).toBe(1)
     expect(initCalls).toBe(1)
   })


### PR DESCRIPTION
## The bug

When this plugin is listed in BOTH a user-level (`~/.config/opencode/opencode.json`) AND a project-level (`<repo>/opencode.json`) config, OpenCode invokes the plugin factory twice in the same PID. The OpenCode host iterates each invocation's returned hook surface and registers every tool entry it finds — even when both calls return the same JavaScript reference. The visible symptom under dual-source configurations is that `copilot_delegate`, `copilot_output`, and `copilot_cancel` each appear twice in the LLM-visible tool catalog returned by `client.tool.list({ provider, model })`.

The previous whole-hooks reuse path inside `plugInOnce` returned the cached real hooks object to every duplicate caller. The intuition that "same reference both times → host dedupes" turns out to be wrong: reference equality is not part of the host's registration logic.

## The fix

`plugInOnce` now resolves to a `{ isFirst, hooks }` envelope:

- **First invocation** in a PID — runs `doInit`, caches the in-flight promise, returns `{ isFirst: true, hooks: <real hooks> }`. The factory unwraps `result.hooks` and OpenCode registers `copilot_delegate` / `copilot_output` / `copilot_cancel` exactly once.
- **Subsequent invocations** in the same PID — await the cached promise so sticky rejections still propagate, fire `onDuplicate` once, then return `{ isFirst: false, hooks: {} as T }`. The factory unwraps `result.hooks` and OpenCode has nothing to register for the duplicate source.

Heavy initialization (agent discovery, `mkdir`, orphan reaping, RPC server startup) still runs at most once per process. Single-source configurations are unaffected.

## Empirical verification

Reproduced with a dual-source config:

- User-level `~/.config/opencode/opencode.json` → `/absolute/path/to/dist/index.js`
- Project-level `<repo>/opencode.json` → `./src/index.ts`

Doctor probe via the SDK endpoint `client.tool.list({ provider, model })`:

```
mise run opencode:doctor --only tools --full --format json \
  --tools-provider opencode --tools-model big-pickle \
  | jq '.[] | select(.label == "Tools").data | map(.id) | map(select(. == "copilot_delegate")) | length'
```

Result before this fix: **2**.
Result after this fix: **1** (and the same for `copilot_output` and `copilot_cancel`).

The host log confirms the duplicate path fires:

```
WARN service=copilot-delegate [copilot-delegate] duplicate factory invocation in same process (pid=<pid>); returning empty hooks so the host does not double-register tools. Multiple opencode.json sources may list this plugin.
```

## Tests

- `tests/plugin-singleton.test.ts` rewritten to assert the envelope contract: 11 tests covering first-invocation real hooks, duplicate empty hooks, PID-mismatch reinit, sticky rejection propagation to first AND duplicate callers, concurrent invocation convergence, `onDuplicate` exactly-once and exception-swallowing semantics.
- New factory-level regression test in `tests/index.test.ts` exercising three sequential `await plugin(input)` calls in the same process: the first returns the full tool surface; the second and third resolve to `{}` with no `tool` key.

Full unit suite: 241/241 pass. Typecheck, lint, build all clean.

## API impact

The exported plugin factory signature is unchanged — OpenCode still receives a hooks object from `await plugin(input)`. The internal `plugInOnce` helper signature changed from `Promise<T>` to `Promise<{ isFirst: boolean, hooks: T }>`. The only caller (`src/index.ts`) is updated to unwrap `result.hooks`.

## Reference

Reference implementation and empirical proof: [marcusrbrown/systematic#335](https://github.com/marcusrbrown/systematic/pull/335).
