### PR TITLE
feat(runtime): extract attachCompletionPipeline and origin-aware notification headers

### DIFF
--- a/.changeset/origin-aware-completion-pipeline.md
+++ b/.changeset/origin-aware-completion-pipeline.md
@@ -1,0 +1,7 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Extract the post-completion pipeline (`SpawnCopilotResult` → `TaskState` back-patch + completion notification) into a shared `attachCompletionPipeline` helper in `src/runtime/notify.ts`. `copilot_delegate` now delegates its `void task.completionPromise.then(...)` block to this helper; the upcoming `copilot_resume` tool will reuse it without duplicating the load-bearing field sync.
+
+Notification headers are now origin-aware: tasks created with `origin: 'spawn'` (today's only call site) keep the existing `[COPILOT DELEGATION COMPLETED]` header. Tasks with `origin: 'resume'` will surface `[COPILOT RESUME COMPLETED]` so users can distinguish a resumed Copilot session from a fresh delegation. The `connect` header is wired for forward compatibility but no `connect`-origin tasks are constructed in this slice.

--- a/src/runtime/notify.ts
+++ b/src/runtime/notify.ts
@@ -11,6 +11,8 @@
  */
 
 import type { TaskStatus } from './envelope'
+import type { SpawnCopilotResult } from './subprocess'
+import type { TaskOrigin, TaskState } from './task-registry'
 
 /** Minimal client interface for notification injection. */
 export type NotifyClient = {
@@ -47,6 +49,12 @@ export type NotifyTaskInfo = {
   modelName?: string
   startedAt: number
   exitCode?: number
+  /**
+   * Source of the task. Optional for back-compat with callers that
+   * predate the discriminator (S2 Unit 1); existing call sites and
+   * tests omit it and the formatter falls back to the spawn variant.
+   */
+  origin?: TaskOrigin
 }
 
 /** Per-parent-session in-flight task counters. */
@@ -107,14 +115,37 @@ function formatDuration(ms: number): string {
   return `${minutes}m ${remainingSeconds}s`
 }
 
+/**
+ * Section header for the system-reminder text. Defaults to the spawn
+ * header for back-compat with callers that predate the discriminator.
+ *
+ * Per the High-Level Technical Design table in
+ * `docs/plans/2026-05-02-001-feat-copilot-session-continuity-resume-connect-plan.md`:
+ *   spawn   → "COPILOT DELEGATION COMPLETED"
+ *   resume  → "COPILOT RESUME COMPLETED"
+ *   connect → "COPILOT CONNECTOR DISCONNECTED"  (deferred — no connect-origin
+ *             tasks are constructed in this slice; included for forward compat)
+ */
+function notificationHeader(origin: TaskOrigin | undefined): string {
+  switch (origin) {
+    case 'resume':
+      return '[COPILOT RESUME COMPLETED]'
+    case 'connect':
+      return '[COPILOT CONNECTOR DISCONNECTED]'
+    default:
+      return '[COPILOT DELEGATION COMPLETED]'
+  }
+}
+
 /** Build the `<system-reminder>` notification text. */
 function buildNotificationText(task: NotifyTaskInfo): string {
   const agent = task.agentName ?? 'default'
   const model = task.modelName ?? 'default'
   const duration = formatDuration(Date.now() - task.startedAt)
+  const header = notificationHeader(task.origin)
 
   let text = `<system-reminder>
-[COPILOT DELEGATION COMPLETED]
+${header}
 **Task ID:** \`${task.taskId}\`
 **Agent:** ${agent}
 **Model:** ${model}
@@ -194,4 +225,59 @@ export async function notifyCompletion(
   } catch {
     // Toast failure is non-critical
   }
+}
+
+/**
+ * Attach the post-completion pipeline to a task and its underlying spawn
+ * result. Encapsulates the back-patch of late-arriving fields from
+ * `SpawnCopilotResult` to the registry `TaskState`, then dispatches the
+ * completion notification.
+ *
+ * The back-patch is load-bearing: `task` is created up-front from a
+ * snapshot of `spawnFields`, so post-spawn fields populated by the
+ * subprocess wrapper (status, finalMessage, copilotSessionId, etc) live
+ * on `spawnResult` until they are explicitly synced. Any field assigned
+ * after `createTask` returned needs to appear in the assign list —
+ * otherwise it is invisible to `copilot_output` even when present on
+ * `spawnResult`.
+ *
+ * Origin-aware notification text is delegated to `buildNotificationText`
+ * via `task.origin`, so this helper itself is origin-agnostic — the same
+ * pipeline drives spawn-, resume-, and (eventually) connect-origin tasks.
+ */
+export function attachCompletionPipeline(
+  task: TaskState,
+  spawnResult: SpawnCopilotResult,
+  client: NotifyClient,
+): void {
+  void task.completionPromise
+    .then(async () => {
+      Object.assign(task, {
+        status: spawnResult.status,
+        exitCode: spawnResult.exitCode,
+        endedAt: spawnResult.endedAt,
+        stdoutLineBuffer: spawnResult.stdoutLineBuffer,
+        finalMessage: spawnResult.finalMessage,
+        errorText: spawnResult.errorText,
+        copilotSessionId: spawnResult.copilotSessionId,
+      })
+
+      try {
+        await notifyCompletion(client, {
+          taskId: task.taskId,
+          parentSessionID: task.parentSessionID,
+          status: task.status,
+          agentName: task.agentName,
+          modelName: task.modelName,
+          startedAt: task.startedAt,
+          exitCode: task.exitCode,
+          origin: task.origin,
+        })
+      } catch {
+        // Notification failures are non-fatal for the tool call.
+      }
+    })
+    .catch(() => {
+      // completionPromise should resolve, but ignore unexpected rejections
+    })
 }

--- a/src/tools/delegate.ts
+++ b/src/tools/delegate.ts
@@ -2,8 +2,8 @@ import type { PluginInput } from '@opencode-ai/plugin'
 import { tool } from '@opencode-ai/plugin/tool'
 import type { NotifyClient } from '../runtime/notify'
 import {
+  attachCompletionPipeline,
   incrementInFlight,
-  notifyCompletion,
   notifySpawn,
 } from '../runtime/notify'
 import type { SpawnCopilotResult } from '../runtime/subprocess'
@@ -178,41 +178,11 @@ export function createDelegateTool(options: DelegateToolOptions) {
         },
       )
 
-      void task.completionPromise
-        .then(async () => {
-          // The registry's TaskState was created up-front from a snapshot
-          // of `spawnFields`, so post-spawn fields populated by the
-          // subprocess wrapper (status, finalMessage, copilotSessionId, etc)
-          // must be synced back here. Any field assigned after `createTask`
-          // returned needs to appear in this list — otherwise it is invisible
-          // to `copilot_output` even when present on `spawnResult`.
-          Object.assign(task, {
-            status: spawnResult.status,
-            exitCode: spawnResult.exitCode,
-            endedAt: spawnResult.endedAt,
-            stdoutLineBuffer: spawnResult.stdoutLineBuffer,
-            finalMessage: spawnResult.finalMessage,
-            errorText: spawnResult.errorText,
-            copilotSessionId: spawnResult.copilotSessionId,
-          })
-
-          try {
-            await notifyCompletion(options.client as NotifyClient, {
-              taskId: task.taskId,
-              parentSessionID: task.parentSessionID,
-              status: task.status,
-              agentName: task.agentName,
-              modelName: task.modelName,
-              startedAt: task.startedAt,
-              exitCode: task.exitCode,
-            })
-          } catch {
-            // Notification failures are non-fatal for the tool call.
-          }
-        })
-        .catch(() => {
-          // completionPromise should resolve, but ignore unexpected rejections
-        })
+      attachCompletionPipeline(
+        task,
+        spawnResult,
+        options.client as NotifyClient,
+      )
 
       return JSON.stringify({ task_id: task.taskId })
     },

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -339,6 +339,64 @@ describe('notification injection', () => {
     })
   })
 
+  describe('origin-aware notification (S2 Unit 2)', () => {
+    it('uses the spawn header for tasks without an explicit origin (back-compat)', async () => {
+      // Existing call sites (and most existing tests) omit `origin`. The
+      // formatter must keep producing the COPILOT DELEGATION COMPLETED
+      // header for back-compat — origin defaults to spawn.
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      await notifyCompletion(client, makeTaskInfo())
+
+      expect(client.promptCalls[0].text).toContain(
+        '[COPILOT DELEGATION COMPLETED]',
+      )
+    })
+
+    it('uses the spawn header when origin is explicitly spawn', async () => {
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      await notifyCompletion(client, makeTaskInfo({ origin: 'spawn' }))
+
+      expect(client.promptCalls[0].text).toContain(
+        '[COPILOT DELEGATION COMPLETED]',
+      )
+    })
+
+    it('uses the resume header when origin is resume', async () => {
+      // Per the High-Level Technical Design table:
+      // resume → "COPILOT RESUME COMPLETED"
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      await notifyCompletion(client, makeTaskInfo({ origin: 'resume' }))
+
+      expect(client.promptCalls[0].text).toContain('[COPILOT RESUME COMPLETED]')
+      expect(client.promptCalls[0].text).not.toContain(
+        '[COPILOT DELEGATION COMPLETED]',
+      )
+    })
+
+    it('preserves ACTION REQUIRED behavior on failed resume tasks', async () => {
+      // The failed-status branch must still fire regardless of origin —
+      // resume failures need the same operator-attention signal as spawn.
+      const client = mockClient()
+      incrementInFlight('session-A')
+
+      await notifyCompletion(
+        client,
+        makeTaskInfo({ origin: 'resume', status: 'failed', exitCode: 2 }),
+      )
+
+      const text = client.promptCalls[0].text
+      expect(text).toContain('[COPILOT RESUME COMPLETED]')
+      expect(text).toContain('ACTION REQUIRED')
+      expect(text).toContain('2')
+    })
+  })
+
   describe('cancelled status', () => {
     it('should set noReply false for cancelled tasks', async () => {
       const client = mockClient()


### PR DESCRIPTION
## Summary

S2 Unit 2: extract the post-completion pipeline into a shared helper and make notification headers origin-aware so the upcoming `copilot_resume` tool can plug in without duplicating the load-bearing field sync.

- Lift the `void task.completionPromise.then(...)` block out of `delegate.ts` into a new `attachCompletionPipeline(task, spawnResult, client)` exported from `src/runtime/notify.ts`. The helper owns the `Object.assign` back-patch from `SpawnCopilotResult` to the registry `TaskState` (the same load-bearing sync Fro Bot caught on PR #109) and the completion-notification dispatch.
- Branch the system-reminder header on `task.origin`:
  - `spawn` (and undefined for back-compat) → `[COPILOT DELEGATION COMPLETED]`
  - `resume` → `[COPILOT RESUME COMPLETED]`
  - `connect` → `[COPILOT CONNECTOR DISCONNECTED]` (wired but unreachable in this slice — the deferral amendment in `5bb2335` keeps connect out until upstream surfaces a mismatch signal)
- `NotifyTaskInfo` gains an optional `origin?: TaskOrigin` field. Existing call sites omit it and the formatter falls back to the spawn header — every prior test stays green without modification.
- `delegate.ts` shrinks by 32 lines: the completion handler is now a single helper call.

## What changes for users today

Functionally nothing — `copilot_delegate` still produces the exact same `[COPILOT DELEGATION COMPLETED]` notification. The new resume header is reachable only through the `copilot_resume` tool that lands in Unit 3c. The `connect` branch exists for forward compatibility; no `connect`-origin tasks are constructed by any current code path.

## Verification

- 4 new origin-aware tests in `tests/notify.test.ts`: spawn header for back-compat (no origin), spawn header for explicit `'spawn'`, resume header for `'resume'`, and `[ACTION REQUIRED]` still fires on failed resume tasks.
- Step 1 of the implementation is a pure refactor — running `tests/notify.test.ts` + `tests/tools.test.ts` + `tests/envelope.test.ts` against just the helper extraction (before adding any branching) showed all 61 affected tests green.
- Full suite: 258/258 unit tests, typecheck clean, lint clean, build clean.

## Connect-specific work explicitly deferred

Per the S2 plan amendment, the connect-only behaviors that the original Unit 2 spec listed are **not** in this PR:

- No identity gate in `cancel.ts` (deferred — cancel keeps returning `{ cancelled, was_running }`)
- No `disconnected: true` cancel response (deferred)
- No `confirm-card.tsx` connect variant (deferred — Unit 5 surface)
- No `notifySpawn` connect warning toast (deferred)

Those re-open when Copilot CLI surfaces a connect-mismatch signal. The forward-compat hooks (origin discriminator value, header switch case) are in place so the future PR is a small additive landing.
