### PR TITLE
feat(runtime): add copilot resume tool

### DIFF
--- a/.changeset/copilot-resume-tool.md
+++ b/.changeset/copilot-resume-tool.md
@@ -1,0 +1,15 @@
+---
+'opencode-copilot-delegate': minor
+---
+
+Add `copilot_resume` tool for resuming prior Copilot sessions by ID, name, or prefix.
+
+The new tool wraps `copilot --resume=<target>` and integrates fully with the existing task lifecycle — output, cancel, and completion notifications all work the same way as delegated tasks.
+
+Key behaviors:
+- UUID targets are validated against the local Copilot session store before spawning; missing sessions return a structured error without touching the CLI.
+- When a prior plugin task's session ID matches the target, its workspace paths (`--add-dir` set) are reused automatically when the caller omits `addDirs`.
+- CLI no-match errors (`Error: No session, task, or name matched '...'`) are normalized to a clean `Session not found` response.
+- All path inputs (`cwd`, `addDirs`) are validated against allowed roots before spawn; argv-injection-shaped values are rejected.
+
+The tool catalog grows from 3 to 4. Resume + new prompt (fork) is not part of this release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,12 @@
 
 ## What This Project Is
 
-`opencode-copilot-delegate` is an OpenCode plugin that spawns GitHub Copilot CLI (`copilot -p`) as background subprocesses. It exposes three tools to OpenCode sessions:
+`opencode-copilot-delegate` is an OpenCode plugin that spawns GitHub Copilot CLI (`copilot -p`) as background subprocesses. It exposes four tools to OpenCode sessions:
 
 - **`copilot_delegate`** — Spawn a Copilot CLI subprocess with a prompt and optional agent/model
 - **`copilot_output`** — Retrieve results from a running or completed delegation (supports blocking with timeout)
 - **`copilot_cancel`** — Cancel a running delegation and kill its process tree
+- **`copilot_resume`** — Resume a prior Copilot session by UUID, name, or prefix (`copilot --resume=<target_id>`)
 
 ## Architecture
 
@@ -16,7 +17,8 @@ src/
 ├── tools/
 │   ├── delegate.ts       # copilot_delegate tool
 │   ├── output.ts         # copilot_output tool
-│   └── cancel.ts         # copilot_cancel tool
+│   ├── cancel.ts         # copilot_cancel tool
+│   └── resume.ts         # copilot_resume tool
 ├── runtime/
 │   ├── rpc-contract.ts   # Shared server/TUI RPC schemas + inferred types
 │   ├── rpc-server.ts     # localhost RPC server for the TUI half

--- a/docs/plans/2026-05-02-001-feat-copilot-session-continuity-resume-connect-plan.md
+++ b/docs/plans/2026-05-02-001-feat-copilot-session-continuity-resume-connect-plan.md
@@ -353,7 +353,7 @@ The plugin is strong at spawning fresh delegations and weak at picking useful wo
 
 ---
 
-- [ ] **Unit 3b: Pre-flight check helpers and security/input-validation primitives**
+- [x] **Unit 3b: Pre-flight check helpers and security/input-validation primitives**
 
 **Goal:** Pure functions for stderr normalization, config-dir resolution, UUID detection, filesystem pre-flight checks, and the input-validation primitives the new tool/RPC schemas will depend on.
 
@@ -405,9 +405,9 @@ The plugin is strong at spawning fresh delegations and weak at picking useful wo
 
 ---
 
-- [ ] **Unit 3c: `copilot_resume` and `copilot_connect` tool factories**
+- [x] **Unit 3c: `copilot_resume` tool factory**
 
-**Goal:** Two new tool factories with full argv assembly, validated inputs, pre-flight checks (config-dir aware), origin-aware completion pipeline, and structured error normalization. Both register through `normalizeToolArgSchemas` and `plugInOnce`. `launchResume` and `launchConnect` are exported directly from these files for RPC re-use (Unit 4).
+**Goal:** A new resume tool factory with full argv assembly, validated inputs, pre-flight checks (config-dir aware), origin-aware completion pipeline, and structured error normalization. It registers through `normalizeToolArgSchemas` and `plugInOnce`. `launchResume` is exported directly for RPC re-use (Unit 4). `copilot_connect` is deferred by the amendment above.
 
 **Requirements:** R1, R2, R3, R6, R7, R8, R9, R10
 
@@ -415,21 +415,17 @@ The plugin is strong at spawning fresh delegations and weak at picking useful wo
 
 **Files:**
 - Create: `src/tools/resume.ts` (also exports `launchResume`)
-- Create: `src/tools/connect.ts` (also exports `launchConnect`)
-- Modify: `src/index.ts` (register both new tools through the existing normalization + plugInOnce pipeline; add startup canary that logs warning when `copilot --version` differs from tested 1.0.40)
-- Test: `tests/tools.test.ts` (extend tool-catalog assertion to 5 tools; extend schema-walk cases to include resume/connect args)
+- Modify: `src/index.ts` (register `copilot_resume` through the existing normalization + plugInOnce pipeline)
+- Test: `tests/tools.test.ts` (extend tool-catalog assertion to 4 tools; extend schema-walk cases to include resume args)
 - Test: `tests/resume.test.ts`
-- Test: `tests/connect.test.ts`
 
 **Approach:**
-- `resume.ts` argv: `['--resume=<targetId>', '--output-format', 'json', '-s', '--allow-all-tools', '--no-ask-user']` + `appendRepeatedFlag` for `--add-dir`. Pre-flight: `validateTargetId` first; if `type === 'uuid'`, call `hasLocalCopilotSession(value, resolveConfigDir(args.configDir))`; if false, return `{ error: "No local session found for UUID <id>" }` without spawning. **Resume does NOT accept a `prompt` argument** (semantic alignment: resume + new prompt is fork; deferred to follow-up slice). Schema: `{ targetId: string, cwd?: string, addDirs?: string[], configDir?: string }`.
-- `connect.ts` argv: `['--connect=<targetId>', '--output-format', 'json', '-s', '--allow-all-tools', '--no-ask-user', '--no-remote']` + `--add-dir` reuse. Pre-flight: `validateTargetId`. Validation strategy from Unit 3a: if early identity event exists, validate; if not, the tool description and `notifySpawn` toast carry the loud warning that an invalid ID may silently start a fresh session. Capture target PID's `comm + lstart` via `getPidIdentity()` AT SPAWN TIME (synchronous with PID assignment) and store on `TaskState.psIdentity`. Schema: `{ targetId: string, cwd?: string, addDirs?: string[], configDir?: string }`.
-- Both tools call `validateAddDirs(args.addDirs, allowedRoots)` and `validateCwd(args.cwd, allowedRoots)` before assembling argv. Validation failures return structured `{ error }` without spawning.
-- Lookup-by-known-task (R3): both tools first scan `getAllTasks()` for any task whose `copilotSessionId === targetId`; if found, reuse its captured `addDirs` as workspace context (re-validated through `validateAddDirs`). The lookup returns workspace metadata only — resume/connect always create a new `TaskState`, never alias to a prior task handle.
-- `launchResume(opts)` and `launchConnect(opts)` are exported from these files (no separate `launch-helpers.ts`). RPC routes (Unit 4) import them directly.
-- `index.ts`: register `copilot_resume` and `copilot_connect` alongside the existing three. Goes through `normalizeToolArgSchemas` walk + `plugInOnce` wrapper automatically.
-- **Borrowed-session rule**: connect-mode `createTask` does NOT include the `pidFilePath` orphan-ledger write hook (the *remote session* lifecycle is what the ledger tracks; the local connector PID is owned but un-reapable in that sense). Resume-mode includes it (resume spawns a real new process owned by this plugin instance and IS in scope for orphan tracking).
-- **Cancel-from-connect identity gate**: when `cancelTaskById` runs against a connect-origin task, re-call `getPidIdentity(task.pid)` and compare against the captured `task.psIdentity` BEFORE invoking `killProcessTree`. On mismatch, log a warning and skip kill (defense against connector PID being reused by the OS). This is wired into `cancel-helper.ts` in Unit 2 (signature already accommodates origin branching).
+- `resume.ts` argv: `['--resume=<targetId>', '--output-format', 'json', '-s', '--allow-all-tools', '--no-ask-user']` + `appendRepeatedFlag` for `--add-dir`. Pre-flight: `validateTargetId` first; if `type === 'uuid'`, call `hasLocalCopilotSession(value, resolveConfigDir(args.configDir))`; if false, return `{ error: "No local session found for UUID <id>" }` without spawning. **Resume does NOT accept a `prompt` argument** (semantic alignment: resume + new prompt is fork; not part of this release). Schema: `{ targetId: string, cwd?: string, addDirs?: string[], configDir?: string }`.
+- The tool calls `validateAddDirs(args.addDirs, allowedRoots)` and `validateCwd(args.cwd, allowedRoots)` before assembling argv. Validation failures return structured `{ error }` without spawning.
+- Lookup-by-known-task (R3): scan `getAllTasks()` for any task whose `copilotSessionId === targetId`; if found, reuse its captured `addDirs` as workspace context (re-validated through `validateAddDirs`). The lookup returns workspace metadata only — resume always creates a new `TaskState`, never aliases to a prior task handle.
+- `launchResume(opts)` is exported from `src/tools/resume.ts` (no separate `launch-helpers.ts`). RPC routes (Unit 4) import it directly.
+- `index.ts`: register `copilot_resume` alongside the existing three. Goes through `normalizeToolArgSchemas` walk + `plugInOnce` wrapper automatically.
+- Resume-mode includes the `pidFilePath` orphan-ledger write hook because resume spawns a real new process owned by this plugin instance and is in scope for orphan tracking.
 
 **Execution note:** Test-first for the tool factories using the existing fake-binary pattern from `tests/tools.test.ts`. Validation helpers from Unit 3b already covered; here we only test wiring + argv assembly + pre-flight gating + happy/sad paths.
 
@@ -445,21 +441,16 @@ The plugin is strong at spawning fresh delegations and weak at picking useful wo
 - Error path (resume): target = valid UUID with no local `session.db`; returns `{ error: "No local session found for UUID <id>" }` without spawning. — resume
 - Error path (resume): target = unknown name (CLI exits 1 with stderr no-match); tool returns `{ error: "Session not found: '<value>'" }`. — resume
 - Edge case (resume): target = name shorter than 7 chars; CLI rejects same way; same normalized error. — resume
-- Happy path (connect): target = real session ID; spawn succeeds; `result.sessionId === target`; task created with `origin: 'connect'`, no orphan ledger entry. — connect
-- Error path (connect): target = unknown ID; spawn succeeds but `result.sessionId !== target`; tool surfaces `{ error: "remote session '<id>' not found; new session started instead" }` and the spurious task is cleaned up. — connect
-- Happy path (connect): captured `psIdentity` is non-empty after attach. — connect
-- Integration: cancel on a `connect`-origin task returns `{ disconnected: true, was_running: true }` (relies on Unit 2). — tools
-- Integration: tool catalog assertion in `tests/tools.test.ts` lists all 5 tools. — tools
-- Integration: schema-walk case set in `tests/tools.test.ts` exercises resume/connect args (catches forgotten `normalizeToolArgSchemas` regression). — tools
+- Integration: tool catalog assertion in `tests/tools.test.ts` lists all 4 tools. — tools
+- Integration: schema-walk case set in `tests/tools.test.ts` exercises resume args (catches forgotten `normalizeToolArgSchemas` regression). — tools
 - Happy path: `hasLocalSession(<uuid>)` returns true when `session.db` exists, false when the directory or file is absent. — session-store
 - Edge case: `hasLocalSession` with non-UUID input returns false without throwing. — session-store
 - Happy path: `normalizeContinuityError` matches the no-match stderr pattern and returns the cleaned message. — continuity-errors
 - Edge case: `normalizeContinuityError` returns null for stderr it does not recognize. — continuity-errors
 
 **Verification:**
-- 5 tools registered; tool catalog test passes.
+- 4 tools registered; tool catalog test passes.
 - All schema-walk cases pass after extension.
-- Connect-mode tasks do not create an entry in the orphan PID ledger; verified by checking `orphans/` directory contents in the connect happy-path test.
 - Resume-mode tasks DO create an orphan-ledger entry (regression check that resume keeps the existing spawn ownership behavior).
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { getAllTasks, getTask } from './runtime/task-registry'
 import { createCancelTool } from './tools/cancel'
 import { createDelegateTool } from './tools/delegate'
 import { createOutputTool } from './tools/output'
+import { createResumeTool } from './tools/resume'
 
 type PluginInputWithTestHooks = PluginInput & {
   __captureRpcCleanup?: (cleanup: () => Promise<void>) => void
@@ -131,6 +132,13 @@ async function initializePlugin(input: PluginInputWithTestHooks) {
       ),
       copilot_output: normalizeToolArgSchemas(createOutputTool()),
       copilot_cancel: normalizeToolArgSchemas(createCancelTool()),
+      copilot_resume: normalizeToolArgSchemas(
+        createResumeTool({
+          client,
+          directory,
+          pidFilePath: currentInstancePath,
+        }),
+      ),
     },
   }
 }

--- a/src/runtime/continuity-checks.ts
+++ b/src/runtime/continuity-checks.ts
@@ -6,6 +6,7 @@ import { isErrnoException } from '../lib/errno'
 const copilotSessionUuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+// "Error:" casing matches Copilot CLI 1.0.40 observed stderr output.
 export function normalizeContinuityError(stderr: string): string | null {
   const match = stderr.match(
     /^Error: No session, task, or name matched '(.+)'/m,

--- a/src/runtime/continuity-checks.ts
+++ b/src/runtime/continuity-checks.ts
@@ -24,10 +24,12 @@ export function isCopilotSessionUuid(value: string): boolean {
   return copilotSessionUuidPattern.test(value)
 }
 
+export type SessionLookupResult = boolean | { error: string }
+
 export async function hasLocalCopilotSession(
   uuid: string,
   configDir: string,
-): Promise<boolean> {
+): Promise<SessionLookupResult> {
   const sessionStateDir = resolve(configDir, 'session-state')
   const sessionDbPath = resolve(sessionStateDir, uuid, 'session.db')
 
@@ -40,7 +42,10 @@ export async function hasLocalCopilotSession(
     return stats.isFile()
   } catch (e) {
     if (isErrnoException(e) && e.code === 'ENOENT') return false
-    throw e
+    const code = isErrnoException(e) ? e.code : 'UNKNOWN'
+    return {
+      error: `Session store stat failed (${code}): ${e instanceof Error ? e.message : String(e)}`,
+    }
   }
 }
 

--- a/src/runtime/continuity-checks.ts
+++ b/src/runtime/continuity-checks.ts
@@ -1,0 +1,54 @@
+import { stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join, resolve, sep } from 'node:path'
+import { isErrnoException } from '../lib/errno'
+
+const copilotSessionUuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function normalizeContinuityError(stderr: string): string | null {
+  const match = stderr.match(
+    /^Error: No session, task, or name matched '(.+)'/m,
+  )
+  if (!match) return null
+  return `No session, task, or name matched '${match[1]}'`
+}
+
+export function resolveConfigDir(explicit?: string): string {
+  return resolve(
+    explicit ?? process.env.COPILOT_CONFIG_DIR ?? join(homedir(), '.copilot'),
+  )
+}
+
+export function isCopilotSessionUuid(value: string): boolean {
+  return copilotSessionUuidPattern.test(value)
+}
+
+export async function hasLocalCopilotSession(
+  uuid: string,
+  configDir: string,
+): Promise<boolean> {
+  const sessionStateDir = resolve(configDir, 'session-state')
+  const sessionDbPath = resolve(sessionStateDir, uuid, 'session.db')
+
+  if (!isWithin(sessionDbPath, sessionStateDir)) {
+    return false
+  }
+
+  try {
+    const stats = await stat(sessionDbPath)
+    return stats.isFile()
+  } catch (e) {
+    if (isErrnoException(e) && e.code === 'ENOENT') return false
+    throw e
+  }
+}
+
+function isWithin(path: string, root: string): boolean {
+  const resolvedPath = resolve(path)
+  const resolvedRoot = resolve(root)
+  return (
+    resolvedPath === resolvedRoot ||
+    resolvedPath.startsWith(`${resolvedRoot}${sep}`)
+  )
+}

--- a/src/runtime/continuity-validation.ts
+++ b/src/runtime/continuity-validation.ts
@@ -1,0 +1,65 @@
+import { isAbsolute, resolve, sep } from 'node:path'
+
+type TargetId = { type: 'uuid' | 'name'; value: string }
+type ValidationError = { error: string }
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const namePattern = /^[A-Za-z0-9._-]{1,128}$/
+
+export function validateTargetId(value: string): TargetId | ValidationError {
+  if (uuidPattern.test(value)) return { type: 'uuid', value }
+  if (namePattern.test(value)) return { type: 'name', value }
+  return { error: 'invalid target ID format' }
+}
+
+export function validateAddDirs(
+  values: string[],
+  allowedRoots: string[],
+): string[] | ValidationError {
+  if (values.length > 32) return { error: 'too many addDirs' }
+
+  const resolved: string[] = []
+  for (const value of values) {
+    if (value.startsWith('--')) {
+      return { error: 'argv-injection-shaped value in addDirs' }
+    }
+
+    const path = validatePathUnderAllowedRoots(value, allowedRoots)
+    if (!path) return { error: 'path outside allowed roots' }
+    resolved.push(path)
+  }
+
+  return resolved
+}
+
+export function validateCwd(
+  value: string,
+  allowedRoots: string[],
+): string | ValidationError {
+  if (value.startsWith('--')) return { error: 'argv-injection-shaped cwd' }
+
+  const path = validatePathUnderAllowedRoots(value, allowedRoots)
+  if (!path) return { error: 'cwd outside allowed roots' }
+  return path
+}
+
+function validatePathUnderAllowedRoots(
+  value: string,
+  allowedRoots: string[],
+): string | null {
+  if (!isAbsolute(value)) return null
+
+  const path = resolve(value)
+  if (allowedRoots.some((root) => isWithin(path, root))) return path
+  return null
+}
+
+function isWithin(path: string, root: string): boolean {
+  const resolvedPath = resolve(path)
+  const resolvedRoot = resolve(root)
+  return (
+    resolvedPath === resolvedRoot ||
+    resolvedPath.startsWith(`${resolvedRoot}${sep}`)
+  )
+}

--- a/src/runtime/continuity-validation.ts
+++ b/src/runtime/continuity-validation.ts
@@ -58,7 +58,10 @@ export function validateCwd(
  * in candidate paths are caught when we compare real paths.
  */
 function canonicalizeRoots(roots: string[]): string[] {
-  return roots.map((r) => tryRealpath(resolve(r)))
+  return roots.flatMap((r) => {
+    const real = tryRealpath(resolve(r))
+    return real !== null ? [real] : []
+  })
 }
 
 /**
@@ -66,6 +69,7 @@ function canonicalizeRoots(roots: string[]): string[] {
  * Uses realpath to follow symlinks — a symlink inside an allowed root that
  * points outside will resolve to a real path outside and be rejected.
  * Falls back to `resolve()` when the path does not exist (ENOENT).
+ * Returns null (→ rejected) on any other realpath error (ELOOP, EACCES, …).
  */
 function validatePathUnderAllowedRoots(
   value: string,
@@ -74,12 +78,17 @@ function validatePathUnderAllowedRoots(
   if (!isAbsolute(value)) return null
 
   const real = tryRealpath(resolve(value))
+  if (real === null) return null
   if (canonicalRoots.some((root) => isWithin(real, root))) return real
   return null
 }
 
-/** realpath with ENOENT fallback to resolve(). Throws on other errors. */
-function tryRealpath(path: string): string {
+/**
+ * realpath with ENOENT fallback to resolve(), null on any other error.
+ * Returning null signals the caller to treat the path as unresolvable and
+ * reject it — covers ELOOP (symlink cycles), EACCES, ENOTDIR, etc.
+ */
+function tryRealpath(path: string): string | null {
   try {
     return realpathSync(path)
   } catch (e) {
@@ -90,7 +99,7 @@ function tryRealpath(path: string): string {
     ) {
       return path
     }
-    throw e
+    return null
   }
 }
 

--- a/src/runtime/continuity-validation.ts
+++ b/src/runtime/continuity-validation.ts
@@ -1,14 +1,21 @@
+import { realpathSync } from 'node:fs'
 import { isAbsolute, resolve, sep } from 'node:path'
+import { isCopilotSessionUuid } from './continuity-checks'
 
 type TargetId = { type: 'uuid' | 'name'; value: string }
 type ValidationError = { error: string }
 
-const uuidPattern =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const namePattern = /^[A-Za-z0-9._-]{1,128}$/
 
 export function validateTargetId(value: string): TargetId | ValidationError {
-  if (uuidPattern.test(value)) return { type: 'uuid', value }
+  if (value.startsWith('cpl_')) {
+    return {
+      error:
+        'Plugin task IDs (cpl_*) are not valid resume targets. Use copilot_output(task_id) to retrieve results, or pass the copilot_session_id from the completed task envelope.',
+    }
+  }
+  if (isCopilotSessionUuid(value))
+    return { type: 'uuid', value: value.toLowerCase() }
   if (namePattern.test(value)) return { type: 'name', value }
   return { error: 'invalid target ID format' }
 }
@@ -19,13 +26,14 @@ export function validateAddDirs(
 ): string[] | ValidationError {
   if (values.length > 32) return { error: 'too many addDirs' }
 
+  const canonicalRoots = canonicalizeRoots(allowedRoots)
   const resolved: string[] = []
   for (const value of values) {
     if (value.startsWith('--')) {
       return { error: 'argv-injection-shaped value in addDirs' }
     }
 
-    const path = validatePathUnderAllowedRoots(value, allowedRoots)
+    const path = validatePathUnderAllowedRoots(value, canonicalRoots)
     if (!path) return { error: 'path outside allowed roots' }
     resolved.push(path)
   }
@@ -39,27 +47,53 @@ export function validateCwd(
 ): string | ValidationError {
   if (value.startsWith('--')) return { error: 'argv-injection-shaped cwd' }
 
-  const path = validatePathUnderAllowedRoots(value, allowedRoots)
+  const canonicalRoots = canonicalizeRoots(allowedRoots)
+  const path = validatePathUnderAllowedRoots(value, canonicalRoots)
   if (!path) return { error: 'cwd outside allowed roots' }
   return path
 }
 
+/**
+ * Canonicalize allowed roots via realpath so symlink-based escape attempts
+ * in candidate paths are caught when we compare real paths.
+ */
+function canonicalizeRoots(roots: string[]): string[] {
+  return roots.map((r) => tryRealpath(resolve(r)))
+}
+
+/**
+ * Resolve a candidate path against canonicalized allowed roots.
+ * Uses realpath to follow symlinks — a symlink inside an allowed root that
+ * points outside will resolve to a real path outside and be rejected.
+ * Falls back to `resolve()` when the path does not exist (ENOENT).
+ */
 function validatePathUnderAllowedRoots(
   value: string,
-  allowedRoots: string[],
+  canonicalRoots: string[],
 ): string | null {
   if (!isAbsolute(value)) return null
 
-  const path = resolve(value)
-  if (allowedRoots.some((root) => isWithin(path, root))) return path
+  const real = tryRealpath(resolve(value))
+  if (canonicalRoots.some((root) => isWithin(real, root))) return real
   return null
 }
 
+/** realpath with ENOENT fallback to resolve(). Throws on other errors. */
+function tryRealpath(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      'code' in e &&
+      (e as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      return path
+    }
+    throw e
+  }
+}
+
 function isWithin(path: string, root: string): boolean {
-  const resolvedPath = resolve(path)
-  const resolvedRoot = resolve(root)
-  return (
-    resolvedPath === resolvedRoot ||
-    resolvedPath.startsWith(`${resolvedRoot}${sep}`)
-  )
+  return path === root || path.startsWith(`${root}${sep}`)
 }

--- a/src/runtime/task-registry.ts
+++ b/src/runtime/task-registry.ts
@@ -57,9 +57,8 @@ export function createTask(
     ...rest,
     taskId,
     // Existing call sites (delegate.ts) predate the discriminator; default
-    // to 'spawn' so they keep working without explicit `origin` until
-    // Unit 3c lands the resume tool. Explicit values from the input are
-    // preserved by the spread above.
+    // to 'spawn' so they keep working without explicit `origin`. Explicit
+    // values from the input are preserved by the spread above.
     origin: rest.origin ?? 'spawn',
   }
 

--- a/src/tools/resume.ts
+++ b/src/tools/resume.ts
@@ -1,14 +1,22 @@
 /**
  * copilot_resume tool — resumes a prior Copilot session by ID, name, or prefix.
  *
- * Wraps `copilot --resume=<targetId>` with:
+ * Wraps `copilot --resume=<target_id>` with:
+ *   - Concurrency cap: same 10-task limit as copilot_delegate
  *   - Input validation (validateTargetId, validateAddDirs, validateCwd)
- *   - UUID preflight: checks local session.db before spawning
- *   - Known-task addDirs reuse: if a prior task's copilotSessionId matches targetId,
- *     its captured addDirs are reused when the caller omits addDirs
+ *   - UUID preflight: checks local session.db before spawning; fs errors → structured { error }
+ *   - configDir propagation: resolved configDir is passed as COPILOT_CONFIG_DIR env to the
+ *     spawned process so preflight and CLI use the same session store
+ *   - Known-task add_dir reuse: if a prior task's copilotSessionId matches target_id,
+ *     its captured addDirs are reused when the caller omits add_dir; inherited paths bypass
+ *     explicit containment so multi-repo context from the prior task is preserved
+ *   - Symlink containment: realpath-based canonicalization in validateAddDirs/validateCwd
  *   - CLI no-match stderr normalization to structured { error } response
  *   - origin: 'resume' on the created TaskState
  *   - Full completion pipeline (attachCompletionPipeline) identical to delegate
+ *
+ * Public tool args use snake_case (target_id, add_dir, config_dir) consistent with
+ * the rest of the plugin's public API surface.
  *
  * No `prompt` argument — resume + new prompt is a fork operation.
  *
@@ -40,6 +48,8 @@ import { createTask, deleteTask, getAllTasks } from '../runtime/task-registry'
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+const MAX_CONCURRENT = 10
 
 function appendRepeatedFlag(
   args: string[],
@@ -77,58 +87,71 @@ export type LaunchResumeOptions = {
 export type LaunchResumeResult = { task_id: string } | { error: string }
 
 type ValidatedResumeInputs = {
-  targetValue: string
   targetType: 'uuid' | 'name'
+  resolvedConfigDir: string
   resolvedAddDirs: string[] | undefined
+  /** Inherited addDirs from a prior known task. */
+  inheritedAddDirs: string[] | undefined
   resolvedCwd: string | undefined
   cliArgs: string[]
 }
 
 /**
  * Validate targetId and run UUID preflight if needed.
+ * Returns the resolved configDir alongside the target so it can be propagated
+ * to the spawned process env.
  */
 async function validateTarget(
   targetId: string,
   configDir?: string,
-): Promise<{ type: 'uuid' | 'name'; value: string } | { error: string }> {
+): Promise<
+  | { type: 'uuid' | 'name'; value: string; resolvedConfigDir: string }
+  | { error: string }
+> {
   const targetResult = validateTargetId(targetId)
   if ('error' in targetResult) return targetResult
 
+  const resolvedConfigDir = resolveConfigDir(configDir)
+
   if (targetResult.type === 'uuid') {
-    const resolvedConfigDir = resolveConfigDir(configDir)
-    const hasSession = await hasLocalCopilotSession(
+    const sessionResult = await hasLocalCopilotSession(
       targetResult.value,
       resolvedConfigDir,
     )
-    if (!hasSession) {
+    if (typeof sessionResult === 'object' && 'error' in sessionResult) {
+      return { error: sessionResult.error }
+    }
+    if (!sessionResult) {
       return { error: `No local session found for UUID ${targetResult.value}` }
     }
   }
 
-  return targetResult
+  return { ...targetResult, resolvedConfigDir }
 }
 
 /**
- * Validate addDirs and cwd against allowed roots.
+ * Validate explicit caller-provided addDirs and cwd against allowed roots.
+ * Inherited addDirs (from a prior known task) are NOT passed through here —
+ * they bypass containment so the prior task's multi-repo context is preserved.
  */
 function validatePaths(
-  opts: Pick<LaunchResumeOptions, 'addDirs' | 'cwd'>,
-  inheritedAddDirs: string[] | undefined,
+  callerAddDirs: string[] | undefined,
+  cwd: string | undefined,
   allowedRoots: string[],
 ):
   | { resolvedAddDirs: string[] | undefined; resolvedCwd: string | undefined }
   | { error: string } {
-  let resolvedAddDirs = opts.addDirs ?? inheritedAddDirs
+  let resolvedAddDirs: string[] | undefined
 
-  if (resolvedAddDirs && resolvedAddDirs.length > 0) {
-    const addDirsResult = validateAddDirs(resolvedAddDirs, allowedRoots)
+  if (callerAddDirs && callerAddDirs.length > 0) {
+    const addDirsResult = validateAddDirs(callerAddDirs, allowedRoots)
     if (!Array.isArray(addDirsResult)) return { error: addDirsResult.error }
     resolvedAddDirs = addDirsResult
   }
 
   let resolvedCwd: string | undefined
-  if (opts.cwd) {
-    const cwdResult = validateCwd(opts.cwd, allowedRoots)
+  if (cwd) {
+    const cwdResult = validateCwd(cwd, allowedRoots)
     if (typeof cwdResult !== 'string') return { error: cwdResult.error }
     resolvedCwd = cwdResult
   }
@@ -148,20 +171,22 @@ async function validateResumeInputs(
   const targetResult = await validateTarget(targetId, configDir)
   if ('error' in targetResult) return targetResult
 
-  // Reuse captured addDirs from a prior task when the caller omits them
-  const callerAddDirs = opts.addDirs
+  // Reuse captured addDirs from a prior task when the caller omits them or passes [].
+  // Inherited paths may legitimately reference paths outside the current primary
+  // directory, so they preserve the prior task's multi-repo context verbatim.
+  const callerAddDirs =
+    opts.addDirs && opts.addDirs.length > 0 ? opts.addDirs : undefined
   const inheritedAddDirs =
-    !callerAddDirs || callerAddDirs.length === 0
+    callerAddDirs === undefined
       ? getAllTasks().find((t) => t.copilotSessionId === targetId)?.addDirs
       : undefined
 
   const allowedRoots = computeAllowedRoots(directory)
-  const pathsResult = validatePaths(
-    { addDirs: callerAddDirs, cwd: opts.cwd },
-    inheritedAddDirs,
-    allowedRoots,
-  )
+  const pathsResult = validatePaths(callerAddDirs, opts.cwd, allowedRoots)
   if ('error' in pathsResult) return pathsResult
+
+  // Effective addDirs: explicit caller paths (validated) or inherited paths (trusted)
+  const effectiveAddDirs = pathsResult.resolvedAddDirs ?? inheritedAddDirs
 
   const cliArgs = [
     `--resume=${targetResult.value}`,
@@ -171,12 +196,13 @@ async function validateResumeInputs(
     '--allow-all-tools',
     '--no-ask-user',
   ]
-  appendRepeatedFlag(cliArgs, '--add-dir', pathsResult.resolvedAddDirs)
+  appendRepeatedFlag(cliArgs, '--add-dir', effectiveAddDirs)
 
   return {
-    targetValue: targetResult.value,
     targetType: targetResult.type,
-    resolvedAddDirs: pathsResult.resolvedAddDirs,
+    resolvedConfigDir: targetResult.resolvedConfigDir,
+    resolvedAddDirs: effectiveAddDirs,
+    inheritedAddDirs,
     resolvedCwd: pathsResult.resolvedCwd,
     cliArgs,
   }
@@ -201,17 +227,37 @@ export async function launchResume(
 ): Promise<LaunchResumeResult> {
   const { client, directory, sessionID, pidFilePath } = opts
 
+  const runningCount = getAllTasks().filter(
+    (task) => task.status === 'running' || task.status === 'cancelling',
+  ).length
+  if (runningCount >= MAX_CONCURRENT) {
+    return {
+      error:
+        'Concurrent delegation limit reached (10 running). Cancel or wait for existing tasks.',
+    }
+  }
+
   const validated = await validateResumeInputs(opts)
   if ('error' in validated) return validated
 
-  const { targetType, resolvedAddDirs, resolvedCwd, cliArgs } = validated
+  const {
+    targetType,
+    resolvedConfigDir,
+    resolvedAddDirs,
+    resolvedCwd,
+    cliArgs,
+  } = validated
   const effectiveCwd = resolvedCwd ?? directory
 
   const startedAt = Date.now()
   let spawnResult: SpawnCopilotResult
 
   try {
-    spawnResult = spawnCopilot(cliArgs, { cwd: effectiveCwd, pidFilePath })
+    spawnResult = spawnCopilot(cliArgs, {
+      cwd: effectiveCwd,
+      pidFilePath,
+      env: { COPILOT_CONFIG_DIR: resolvedConfigDir },
+    })
   } catch (error) {
     return {
       error: `Failed to spawn copilot: ${error instanceof Error ? error.message : String(error)}`,
@@ -275,7 +321,7 @@ type ResumeToolOptions = {
 const TOOL_DESCRIPTION = [
   'Resume a prior Copilot session by ID, name, or prefix.',
   '',
-  'Wraps `copilot --resume=<targetId>` and returns a plugin task handle immediately.',
+  'Wraps `copilot --resume=<target_id>` and returns a plugin task handle immediately.',
   'The resumed session runs as a background subprocess; retrieve its output with',
   '`copilot_output(task_id)` and cancel it with `copilot_cancel(task_id)`.',
   '',
@@ -285,6 +331,9 @@ const TOOL_DESCRIPTION = [
   '- Session name or prefix — passed directly to the CLI.',
   '- Plugin task ID (`cpl_*`) — not supported here; use `copilot_output` instead.',
   '',
+  'Concurrency: at most 10 Copilot sessions may be running concurrently. Exceeding',
+  'the cap returns `{ error: ... }` and the caller should wait or cancel existing tasks.',
+  '',
   'Note: resume + new prompt is a fork operation and is not part of this release.',
   'This tool resumes the session as-is without injecting a new prompt.',
 ].join('\n')
@@ -293,7 +342,7 @@ export function createResumeTool(options: ResumeToolOptions) {
   return tool({
     description: TOOL_DESCRIPTION,
     args: {
-      targetId: tool.schema
+      target_id: tool.schema
         .string()
         .min(1)
         .describe(
@@ -305,18 +354,18 @@ export function createResumeTool(options: ResumeToolOptions) {
         .describe(
           'Working directory for the resumed session. Must be an absolute path within the active workspace. Defaults to the plugin directory when omitted.',
         ),
-      addDirs: tool.schema
+      add_dir: tool.schema
         .string()
         .array()
         .optional()
         .describe(
-          'Additional repository paths to grant Copilot access to. Each entry becomes a `--add-dir <path>` flag. When omitted and a prior plugin task matches the target, its captured addDirs are reused automatically.',
+          'Additional repository paths to grant Copilot access to. Each entry becomes a `--add-dir <path>` flag. When omitted and a prior plugin task matches the target, its captured add_dir values are reused automatically.',
         ),
-      configDir: tool.schema
+      config_dir: tool.schema
         .string()
         .optional()
         .describe(
-          'Override the Copilot config directory used for UUID session-state lookup. Defaults to `~/.copilot` (or `COPILOT_CONFIG_DIR` env). Rarely needed.',
+          'Override the Copilot config directory used for UUID session-state lookup and propagated to the spawned process as COPILOT_CONFIG_DIR. Defaults to `~/.copilot` (or `COPILOT_CONFIG_DIR` env). Rarely needed.',
         ),
     },
     async execute(args, ctx) {
@@ -325,10 +374,10 @@ export function createResumeTool(options: ResumeToolOptions) {
         directory: options.directory,
         pidFilePath: options.pidFilePath,
         sessionID: ctx.sessionID,
-        targetId: args.targetId,
+        targetId: args.target_id,
         cwd: args.cwd,
-        addDirs: args.addDirs,
-        configDir: args.configDir,
+        addDirs: args.add_dir,
+        configDir: args.config_dir,
       })
 
       return JSON.stringify(result)

--- a/src/tools/resume.ts
+++ b/src/tools/resume.ts
@@ -208,7 +208,8 @@ async function validateResumeInputs(
   }
 }
 
-/** Milliseconds to wait for an immediate CLI failure before attaching the pipeline. */
+// Empirical fast-fail probe: wait this long for an immediate CLI exit (e.g. "no session matched")
+// before treating the spawn as live and falling back to background task output via copilot_output.
 const NAME_TARGET_FAILURE_WINDOW_MS = 500
 
 function attachResumePipeline(

--- a/src/tools/resume.ts
+++ b/src/tools/resume.ts
@@ -1,0 +1,337 @@
+/**
+ * copilot_resume tool — resumes a prior Copilot session by ID, name, or prefix.
+ *
+ * Wraps `copilot --resume=<targetId>` with:
+ *   - Input validation (validateTargetId, validateAddDirs, validateCwd)
+ *   - UUID preflight: checks local session.db before spawning
+ *   - Known-task addDirs reuse: if a prior task's copilotSessionId matches targetId,
+ *     its captured addDirs are reused when the caller omits addDirs
+ *   - CLI no-match stderr normalization to structured { error } response
+ *   - origin: 'resume' on the created TaskState
+ *   - Full completion pipeline (attachCompletionPipeline) identical to delegate
+ *
+ * No `prompt` argument — resume + new prompt is a fork operation.
+ *
+ * Exports `launchResume` for RPC reuse.
+ */
+
+import type { PluginInput } from '@opencode-ai/plugin'
+import { tool } from '@opencode-ai/plugin/tool'
+import {
+  hasLocalCopilotSession,
+  normalizeContinuityError,
+  resolveConfigDir,
+} from '../runtime/continuity-checks'
+import {
+  validateAddDirs,
+  validateCwd,
+  validateTargetId,
+} from '../runtime/continuity-validation'
+import type { NotifyClient } from '../runtime/notify'
+import {
+  attachCompletionPipeline,
+  incrementInFlight,
+  notifySpawn,
+} from '../runtime/notify'
+import type { SpawnCopilotResult } from '../runtime/subprocess'
+import { spawnCopilot } from '../runtime/subprocess'
+import { createTask, deleteTask, getAllTasks } from '../runtime/task-registry'
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function appendRepeatedFlag(
+  args: string[],
+  flag: string,
+  values?: string[],
+): void {
+  for (const value of values ?? []) {
+    args.push(flag, value)
+  }
+}
+
+/**
+ * Compute allowed roots for path validation.
+ * Only the plugin `directory` option is an allowed root.
+ */
+function computeAllowedRoots(directory: string): string[] {
+  return [directory]
+}
+
+// ---------------------------------------------------------------------------
+// launchResume — exported for RPC reuse
+// ---------------------------------------------------------------------------
+
+export type LaunchResumeOptions = {
+  client: PluginInput['client']
+  directory: string
+  sessionID: string
+  targetId: string
+  cwd?: string
+  addDirs?: string[]
+  configDir?: string
+  pidFilePath?: string
+}
+
+export type LaunchResumeResult = { task_id: string } | { error: string }
+
+type ValidatedResumeInputs = {
+  targetValue: string
+  targetType: 'uuid' | 'name'
+  resolvedAddDirs: string[] | undefined
+  resolvedCwd: string | undefined
+  cliArgs: string[]
+}
+
+/**
+ * Validate targetId and run UUID preflight if needed.
+ */
+async function validateTarget(
+  targetId: string,
+  configDir?: string,
+): Promise<{ type: 'uuid' | 'name'; value: string } | { error: string }> {
+  const targetResult = validateTargetId(targetId)
+  if ('error' in targetResult) return targetResult
+
+  if (targetResult.type === 'uuid') {
+    const resolvedConfigDir = resolveConfigDir(configDir)
+    const hasSession = await hasLocalCopilotSession(
+      targetResult.value,
+      resolvedConfigDir,
+    )
+    if (!hasSession) {
+      return { error: `No local session found for UUID ${targetResult.value}` }
+    }
+  }
+
+  return targetResult
+}
+
+/**
+ * Validate addDirs and cwd against allowed roots.
+ */
+function validatePaths(
+  opts: Pick<LaunchResumeOptions, 'addDirs' | 'cwd'>,
+  inheritedAddDirs: string[] | undefined,
+  allowedRoots: string[],
+):
+  | { resolvedAddDirs: string[] | undefined; resolvedCwd: string | undefined }
+  | { error: string } {
+  let resolvedAddDirs = opts.addDirs ?? inheritedAddDirs
+
+  if (resolvedAddDirs && resolvedAddDirs.length > 0) {
+    const addDirsResult = validateAddDirs(resolvedAddDirs, allowedRoots)
+    if (!Array.isArray(addDirsResult)) return { error: addDirsResult.error }
+    resolvedAddDirs = addDirsResult
+  }
+
+  let resolvedCwd: string | undefined
+  if (opts.cwd) {
+    const cwdResult = validateCwd(opts.cwd, allowedRoots)
+    if (typeof cwdResult !== 'string') return { error: cwdResult.error }
+    resolvedCwd = cwdResult
+  }
+
+  return { resolvedAddDirs, resolvedCwd }
+}
+
+/**
+ * Validate all inputs for a resume operation and assemble the argv.
+ * Returns either a structured error or the validated inputs ready for spawn.
+ */
+async function validateResumeInputs(
+  opts: LaunchResumeOptions,
+): Promise<ValidatedResumeInputs | { error: string }> {
+  const { directory, targetId, configDir } = opts
+
+  const targetResult = await validateTarget(targetId, configDir)
+  if ('error' in targetResult) return targetResult
+
+  // Reuse captured addDirs from a prior task when the caller omits them
+  const callerAddDirs = opts.addDirs
+  const inheritedAddDirs =
+    !callerAddDirs || callerAddDirs.length === 0
+      ? getAllTasks().find((t) => t.copilotSessionId === targetId)?.addDirs
+      : undefined
+
+  const allowedRoots = computeAllowedRoots(directory)
+  const pathsResult = validatePaths(
+    { addDirs: callerAddDirs, cwd: opts.cwd },
+    inheritedAddDirs,
+    allowedRoots,
+  )
+  if ('error' in pathsResult) return pathsResult
+
+  const cliArgs = [
+    `--resume=${targetResult.value}`,
+    '--output-format',
+    'json',
+    '-s',
+    '--allow-all-tools',
+    '--no-ask-user',
+  ]
+  appendRepeatedFlag(cliArgs, '--add-dir', pathsResult.resolvedAddDirs)
+
+  return {
+    targetValue: targetResult.value,
+    targetType: targetResult.type,
+    resolvedAddDirs: pathsResult.resolvedAddDirs,
+    resolvedCwd: pathsResult.resolvedCwd,
+    cliArgs,
+  }
+}
+
+/** Milliseconds to wait for an immediate CLI failure before attaching the pipeline. */
+const NAME_TARGET_FAILURE_WINDOW_MS = 500
+
+function attachResumePipeline(
+  client: PluginInput['client'],
+  sessionID: string,
+  task: ReturnType<typeof createTask>,
+  spawnResult: SpawnCopilotResult,
+): void {
+  incrementInFlight(sessionID)
+  void notifySpawn(client as NotifyClient, task.taskId).catch(() => {})
+  attachCompletionPipeline(task, spawnResult, client as NotifyClient)
+}
+
+export async function launchResume(
+  opts: LaunchResumeOptions,
+): Promise<LaunchResumeResult> {
+  const { client, directory, sessionID, pidFilePath } = opts
+
+  const validated = await validateResumeInputs(opts)
+  if ('error' in validated) return validated
+
+  const { targetType, resolvedAddDirs, resolvedCwd, cliArgs } = validated
+  const effectiveCwd = resolvedCwd ?? directory
+
+  const startedAt = Date.now()
+  let spawnResult: SpawnCopilotResult
+
+  try {
+    spawnResult = spawnCopilot(cliArgs, { cwd: effectiveCwd, pidFilePath })
+  } catch (error) {
+    return {
+      error: `Failed to spawn copilot: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+
+  const { taskId: spawnTaskId, ...spawnFields } = spawnResult
+
+  const task = createTask(
+    {
+      ...spawnFields,
+      parentSessionID: sessionID,
+      startedAt,
+      args: cliArgs,
+      cwd: effectiveCwd,
+      origin: 'resume',
+      addDirs: resolvedAddDirs,
+      pidFilePath,
+    },
+    spawnTaskId,
+  )
+
+  if (targetType === 'uuid') {
+    attachResumePipeline(client, sessionID, task, spawnResult)
+    return { task_id: task.taskId }
+  }
+
+  const timeout = new Promise<'timeout'>((resolve) =>
+    setTimeout(() => resolve('timeout'), NAME_TARGET_FAILURE_WINDOW_MS),
+  )
+
+  const raceResult = await Promise.race([
+    spawnResult.completionPromise.then(() => 'done' as const),
+    timeout,
+  ])
+
+  if (raceResult !== 'timeout') {
+    const noMatch =
+      spawnResult.errorText &&
+      normalizeContinuityError(spawnResult.errorText) !== null
+    if (noMatch) {
+      deleteTask(task.taskId)
+      return { error: `Session not found: '${opts.targetId}'` }
+    }
+  }
+
+  attachResumePipeline(client, sessionID, task, spawnResult)
+  return { task_id: task.taskId }
+}
+
+// ---------------------------------------------------------------------------
+// Tool factory
+// ---------------------------------------------------------------------------
+
+type ResumeToolOptions = {
+  client: PluginInput['client']
+  directory: string
+  pidFilePath?: string
+}
+
+const TOOL_DESCRIPTION = [
+  'Resume a prior Copilot session by ID, name, or prefix.',
+  '',
+  'Wraps `copilot --resume=<targetId>` and returns a plugin task handle immediately.',
+  'The resumed session runs as a background subprocess; retrieve its output with',
+  '`copilot_output(task_id)` and cancel it with `copilot_cancel(task_id)`.',
+  '',
+  'Target formats:',
+  '- UUID (e.g. `123e4567-e89b-12d3-a456-426614174000`) — validated against the',
+  '  local Copilot session store before spawning.',
+  '- Session name or prefix — passed directly to the CLI.',
+  '- Plugin task ID (`cpl_*`) — not supported here; use `copilot_output` instead.',
+  '',
+  'Note: resume + new prompt is a fork operation and is not part of this release.',
+  'This tool resumes the session as-is without injecting a new prompt.',
+].join('\n')
+
+export function createResumeTool(options: ResumeToolOptions) {
+  return tool({
+    description: TOOL_DESCRIPTION,
+    args: {
+      targetId: tool.schema
+        .string()
+        .min(1)
+        .describe(
+          'Session identity to resume. Accepts a Copilot session UUID, a session name, or a unique name prefix. UUID targets are validated against the local session store before spawning.',
+        ),
+      cwd: tool.schema
+        .string()
+        .optional()
+        .describe(
+          'Working directory for the resumed session. Must be an absolute path within the active workspace. Defaults to the plugin directory when omitted.',
+        ),
+      addDirs: tool.schema
+        .string()
+        .array()
+        .optional()
+        .describe(
+          'Additional repository paths to grant Copilot access to. Each entry becomes a `--add-dir <path>` flag. When omitted and a prior plugin task matches the target, its captured addDirs are reused automatically.',
+        ),
+      configDir: tool.schema
+        .string()
+        .optional()
+        .describe(
+          'Override the Copilot config directory used for UUID session-state lookup. Defaults to `~/.copilot` (or `COPILOT_CONFIG_DIR` env). Rarely needed.',
+        ),
+    },
+    async execute(args, ctx) {
+      const result = await launchResume({
+        client: options.client,
+        directory: options.directory,
+        pidFilePath: options.pidFilePath,
+        sessionID: ctx.sessionID,
+        targetId: args.targetId,
+        cwd: args.cwd,
+        addDirs: args.addDirs,
+        configDir: args.configDir,
+      })
+
+      return JSON.stringify(result)
+    },
+  })
+}

--- a/tests/continuity-checks.test.ts
+++ b/tests/continuity-checks.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import {
+  hasLocalCopilotSession,
+  isCopilotSessionUuid,
+  normalizeContinuityError,
+  resolveConfigDir,
+} from '../src/runtime/continuity-checks'
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'continuity-checks-'))
+}
+
+const uuid = '123e4567-e89b-12d3-a456-426614174000'
+
+describe('continuity-checks', () => {
+  describe('resolveConfigDir', () => {
+    it('should return the default Copilot config dir when no override is set', () => {
+      const previous = process.env.COPILOT_CONFIG_DIR
+      delete process.env.COPILOT_CONFIG_DIR
+
+      try {
+        expect(resolveConfigDir()).toBe(resolve(homedir(), '.copilot'))
+      } finally {
+        if (previous === undefined) delete process.env.COPILOT_CONFIG_DIR
+        else process.env.COPILOT_CONFIG_DIR = previous
+      }
+    })
+
+    it('should resolve an explicit config dir', () => {
+      expect(resolveConfigDir('relative-copilot-config')).toBe(
+        resolve('relative-copilot-config'),
+      )
+    })
+
+    it('should honor COPILOT_CONFIG_DIR when no explicit config dir is provided', () => {
+      const previous = process.env.COPILOT_CONFIG_DIR
+      process.env.COPILOT_CONFIG_DIR = 'env-copilot-config'
+
+      try {
+        expect(resolveConfigDir()).toBe(resolve('env-copilot-config'))
+      } finally {
+        if (previous === undefined) delete process.env.COPILOT_CONFIG_DIR
+        else process.env.COPILOT_CONFIG_DIR = previous
+      }
+    })
+  })
+
+  describe('hasLocalCopilotSession', () => {
+    it('should return true when the local session database exists', async () => {
+      const configDir = makeTempDir()
+      const sessionDir = join(configDir, 'session-state', uuid)
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(join(sessionDir, 'session.db'), '')
+
+      try {
+        await expect(hasLocalCopilotSession(uuid, configDir)).resolves.toBe(
+          true,
+        )
+      } finally {
+        rmSync(configDir, { recursive: true, force: true })
+      }
+    })
+
+    it('should return false when the local session database is absent', async () => {
+      const configDir = makeTempDir()
+
+      try {
+        await expect(hasLocalCopilotSession(uuid, configDir)).resolves.toBe(
+          false,
+        )
+      } finally {
+        rmSync(configDir, { recursive: true, force: true })
+      }
+    })
+
+    it('should reject with a non-ENOENT filesystem error (ENOTDIR)', async () => {
+      const configDir = makeTempDir()
+      // Place a regular file where the uuid directory would be, so stat of
+      // `${uuid}/session.db` raises ENOTDIR instead of ENOENT.
+      const sessionStateDir = join(configDir, 'session-state')
+      mkdirSync(sessionStateDir, { recursive: true })
+      writeFileSync(join(sessionStateDir, uuid), '')
+
+      try {
+        await expect(
+          hasLocalCopilotSession(uuid, configDir),
+        ).rejects.toMatchObject({ code: 'ENOTDIR' })
+      } finally {
+        rmSync(configDir, { recursive: true, force: true })
+      }
+    })
+
+    it('should reject traversal-shaped session ids without probing outside session-state', async () => {
+      const configDir = makeTempDir()
+      const outsidePath = join(configDir, 'outside')
+      writeFileSync(outsidePath, '')
+
+      try {
+        await expect(
+          hasLocalCopilotSession('../outside', configDir),
+        ).resolves.toBe(false)
+        expect(existsSync(outsidePath)).toBe(true)
+      } finally {
+        rmSync(configDir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('isCopilotSessionUuid', () => {
+    it('should return true for a UUID-shaped Copilot session id', () => {
+      expect(isCopilotSessionUuid(uuid)).toBe(true)
+    })
+
+    it('should return false for a short hex prefix', () => {
+      expect(isCopilotSessionUuid('123e4567')).toBe(false)
+    })
+  })
+
+  describe('normalizeContinuityError', () => {
+    it('should normalize Copilot no-match stderr into a clean message', () => {
+      const stderr =
+        "Error: No session, task, or name matched 'missing-session'\n"
+
+      expect(normalizeContinuityError(stderr)).toBe(
+        "No session, task, or name matched 'missing-session'",
+      )
+    })
+
+    it('should return null for unrecognized stderr', () => {
+      expect(
+        normalizeContinuityError('Error: something else failed'),
+      ).toBeNull()
+    })
+  })
+})

--- a/tests/continuity-checks.test.ts
+++ b/tests/continuity-checks.test.ts
@@ -82,7 +82,7 @@ describe('continuity-checks', () => {
       }
     })
 
-    it('should reject with a non-ENOENT filesystem error (ENOTDIR)', async () => {
+    it('should return { error } on a non-ENOENT filesystem error (ENOTDIR)', async () => {
       const configDir = makeTempDir()
       // Place a regular file where the uuid directory would be, so stat of
       // `${uuid}/session.db` raises ENOTDIR instead of ENOENT.
@@ -91,9 +91,10 @@ describe('continuity-checks', () => {
       writeFileSync(join(sessionStateDir, uuid), '')
 
       try {
-        await expect(
-          hasLocalCopilotSession(uuid, configDir),
-        ).rejects.toMatchObject({ code: 'ENOTDIR' })
+        const result = await hasLocalCopilotSession(uuid, configDir)
+        expect(result).toMatchObject({
+          error: expect.stringContaining('ENOTDIR'),
+        })
       } finally {
         rmSync(configDir, { recursive: true, force: true })
       }

--- a/tests/continuity-validation.test.ts
+++ b/tests/continuity-validation.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import {
+  validateAddDirs,
+  validateCwd,
+  validateTargetId,
+} from '../src/runtime/continuity-validation'
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'continuity-validation-'))
+}
+
+const uuid = '123e4567-e89b-12d3-a456-426614174000'
+
+describe('continuity-validation', () => {
+  describe('validateTargetId', () => {
+    it('should return a uuid target for UUID-shaped values', () => {
+      expect(validateTargetId(uuid)).toEqual({ type: 'uuid', value: uuid })
+    })
+
+    it('should return a name target for safe names', () => {
+      expect(validateTargetId('session.name-1')).toEqual({
+        type: 'name',
+        value: 'session.name-1',
+      })
+    })
+
+    it('should reject path traversal targets', () => {
+      expect(validateTargetId('../../etc/passwd')).toEqual({
+        error: 'invalid target ID format',
+      })
+    })
+
+    it('should reject targets longer than the length cap', () => {
+      expect(validateTargetId('a'.repeat(200))).toEqual({
+        error: 'invalid target ID format',
+      })
+    })
+  })
+
+  describe('validateAddDirs', () => {
+    it('should reject argv-injection-shaped values', () => {
+      const root = makeTempDir()
+
+      try {
+        expect(validateAddDirs(['--allow-tool=shell(*)'], [root])).toEqual({
+          error: 'argv-injection-shaped value in addDirs',
+        })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    it('should reject paths outside allowed roots', () => {
+      const root = makeTempDir()
+      const outside = makeTempDir()
+
+      try {
+        expect(validateAddDirs([outside], [root])).toEqual({
+          error: 'path outside allowed roots',
+        })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+        rmSync(outside, { recursive: true, force: true })
+      }
+    })
+
+    it('should return resolved paths under allowed roots', () => {
+      const root = makeTempDir()
+      const child = join(root, 'sub')
+      mkdirSync(child)
+
+      try {
+        expect(validateAddDirs([child], [root])).toEqual([resolve(child)])
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    it('should reject relative paths', () => {
+      const root = makeTempDir()
+
+      try {
+        expect(validateAddDirs(['relative/path'], [root])).toEqual({
+          error: 'path outside allowed roots',
+        })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    it('should reject more than 32 entries', () => {
+      const root = makeTempDir()
+
+      try {
+        expect(
+          validateAddDirs(
+            Array.from({ length: 33 }, () => root),
+            [root],
+          ),
+        ).toEqual({
+          error: 'too many addDirs',
+        })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('validateCwd', () => {
+    it('should return a resolved path under allowed roots', () => {
+      const root = makeTempDir()
+
+      try {
+        expect(validateCwd(root, [root])).toBe(resolve(root))
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    it('should reject argv-injection-shaped cwd values', () => {
+      const root = makeTempDir()
+
+      try {
+        expect(validateCwd('--cwd=/tmp', [root])).toEqual({
+          error: 'argv-injection-shaped cwd',
+        })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    it('should reject cwd outside allowed roots', () => {
+      const root = makeTempDir()
+      const outside = makeTempDir()
+
+      try {
+        expect(validateCwd(outside, [root])).toEqual({
+          error: 'cwd outside allowed roots',
+        })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+        rmSync(outside, { recursive: true, force: true })
+      }
+    })
+  })
+})

--- a/tests/continuity-validation.test.ts
+++ b/tests/continuity-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import {
@@ -13,11 +13,19 @@ function makeTempDir(): string {
 }
 
 const uuid = '123e4567-e89b-12d3-a456-426614174000'
+const uuidUpper = '123E4567-E89B-12D3-A456-426614174000'
 
 describe('continuity-validation', () => {
   describe('validateTargetId', () => {
     it('should return a uuid target for UUID-shaped values', () => {
       expect(validateTargetId(uuid)).toEqual({ type: 'uuid', value: uuid })
+    })
+
+    it('should canonicalize uppercase UUID to lowercase', () => {
+      expect(validateTargetId(uuidUpper)).toEqual({
+        type: 'uuid',
+        value: uuid,
+      })
     })
 
     it('should return a name target for safe names', () => {
@@ -37,6 +45,22 @@ describe('continuity-validation', () => {
       expect(validateTargetId('a'.repeat(200))).toEqual({
         error: 'invalid target ID format',
       })
+    })
+
+    it('should reject plugin task IDs starting with cpl_ with an actionable error', () => {
+      const result = validateTargetId('cpl_abc123')
+      expect(result).toEqual({
+        error:
+          'Plugin task IDs (cpl_*) are not valid resume targets. Use copilot_output(task_id) to retrieve results, or pass the copilot_session_id from the completed task envelope.',
+      })
+    })
+
+    it('should reject cpl_ IDs without spawning (no task_id in result)', () => {
+      const result = validateTargetId(
+        'cpl_123e4567-e89b-12d3-a456-426614174000',
+      )
+      expect('error' in result).toBe(true)
+      expect('type' in result).toBe(false)
     })
   })
 
@@ -73,7 +97,9 @@ describe('continuity-validation', () => {
       mkdirSync(child)
 
       try {
-        expect(validateAddDirs([child], [root])).toEqual([resolve(child)])
+        expect(validateAddDirs([child], [root])).toEqual([
+          realpathSync(resolve(child)),
+        ])
       } finally {
         rmSync(root, { recursive: true, force: true })
       }
@@ -114,7 +140,7 @@ describe('continuity-validation', () => {
       const root = makeTempDir()
 
       try {
-        expect(validateCwd(root, [root])).toBe(resolve(root))
+        expect(validateCwd(root, [root])).toBe(realpathSync(resolve(root)))
       } finally {
         rmSync(root, { recursive: true, force: true })
       }

--- a/tests/continuity-validation.test.ts
+++ b/tests/continuity-validation.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test'
-import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import {
@@ -169,6 +175,46 @@ describe('continuity-validation', () => {
       } finally {
         rmSync(root, { recursive: true, force: true })
         rmSync(outside, { recursive: true, force: true })
+      }
+    })
+
+    it('should return structured error when cwd contains a symlink loop', () => {
+      const root = makeTempDir()
+      const linkPath = join(root, 'loop-link')
+      symlinkSync(linkPath, linkPath)
+
+      try {
+        const result = validateCwd(linkPath, [root])
+        expect(result).toEqual({ error: 'cwd outside allowed roots' })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('validateAddDirs (realpath error handling)', () => {
+    it('should return structured error when add_dir contains a symlink loop (ELOOP)', () => {
+      const root = makeTempDir()
+      const linkPath = join(root, 'loop-link')
+      symlinkSync(linkPath, linkPath)
+
+      try {
+        const result = validateAddDirs([linkPath], [root])
+        expect(result).toEqual({ error: 'path outside allowed roots' })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    it('should not throw when add_dir realpath fails', () => {
+      const root = makeTempDir()
+      const linkPath = join(root, 'loop2')
+      symlinkSync(linkPath, linkPath)
+
+      try {
+        expect(() => validateAddDirs([linkPath], [root])).not.toThrow()
+      } finally {
+        rmSync(root, { recursive: true, force: true })
       }
     })
   })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -133,6 +133,7 @@ describe('plugin init lifecycle', () => {
       'copilot_cancel',
       'copilot_delegate',
       'copilot_output',
+      'copilot_resume',
     ])
   })
 
@@ -156,6 +157,7 @@ describe('plugin init lifecycle', () => {
       'copilot_cancel',
       'copilot_delegate',
       'copilot_output',
+      'copilot_resume',
     ])
     expect(existsSync(portFilePath)).toBe(true)
     expect(
@@ -186,6 +188,7 @@ describe('plugin init lifecycle', () => {
       'copilot_cancel',
       'copilot_delegate',
       'copilot_output',
+      'copilot_resume',
     ])
   })
 
@@ -218,6 +221,7 @@ describe('plugin init lifecycle', () => {
       'copilot_cancel',
       'copilot_delegate',
       'copilot_output',
+      'copilot_resume',
     ])
 
     // And the orphans directory was NOT created (proves the failure path
@@ -281,11 +285,12 @@ describe('plugin init lifecycle', () => {
     const second = await plugin(input)
     const third = await plugin(input)
 
-    // First invocation gets the real hooks with all three tools.
+    // First invocation gets the real hooks with the full tool catalog.
     expect(Object.keys(first.tool ?? {}).sort()).toEqual([
       'copilot_cancel',
       'copilot_delegate',
       'copilot_output',
+      'copilot_resume',
     ])
 
     // Duplicate invocations get an empty hooks object — `tool` is absent
@@ -323,6 +328,7 @@ describe('plugin init lifecycle', () => {
       'copilot_cancel',
       'copilot_delegate',
       'copilot_output',
+      'copilot_resume',
     ])
     expect(lstatSync(linkedPluginStateDir).isSymbolicLink()).toBe(true)
     expect(readFileSync(foreignPidFile, 'utf-8')).toBe(

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -224,7 +224,7 @@ describe('copilot_resume tool', () => {
       const tools = result.tool as NonNullable<typeof result.tool>
 
       const resumeArgs = tools.copilot_resume.args as Record<string, unknown>
-      const targetIdSchema = resumeArgs.targetId
+      const targetIdSchema = resumeArgs.target_id
       const override = (
         targetIdSchema as { _zod: { toJSONSchema?: () => unknown } }
       )._zod.toJSONSchema
@@ -252,7 +252,7 @@ describe('copilot_resume tool', () => {
       })
 
       const raw = await tool.execute(
-        { targetId: VALID_UUID },
+        { target_id: VALID_UUID },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
@@ -273,7 +273,7 @@ describe('copilot_resume tool', () => {
       const tool = createResumeTool({ client, directory: cwd })
 
       const raw = await tool.execute(
-        { targetId: VALID_UUID },
+        { target_id: VALID_UUID },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
@@ -311,13 +311,94 @@ exit 1
       const tool = createResumeTool({ client, directory: cwd })
 
       const raw = await tool.execute(
-        { targetId: VALID_UUID },
+        { target_id: VALID_UUID },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
       const output = expectObject(raw)
       expect(output.error).toBe(`No local session found for UUID ${VALID_UUID}`)
       expect(output.task_id).toBeUndefined()
+    })
+  })
+
+  describe('cpl_ plugin task ID rejection', () => {
+    it('returns structured error for cpl_ target without spawning', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-cpl-reject-'))
+      tempPaths.push(cwd)
+
+      const binDir = mkdtempSync(join(tmpdir(), 'resume-cpl-bin-'))
+      tempPaths.push(binDir)
+      const copilotPath = join(binDir, 'copilot')
+      writeFileSync(
+        copilotPath,
+        `#!/usr/bin/env bash
+echo "SHOULD NOT SPAWN" >&2
+exit 1
+`,
+      )
+      chmodSync(copilotPath, 0o755)
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { target_id: 'cpl_abc123' },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.error).toBeDefined()
+      expect(typeof output.error).toBe('string')
+      expect(output.error as string).toContain('copilot_output')
+      expect(output.task_id).toBeUndefined()
+    })
+
+    it('returns error for cpl_<uuid> without spawning', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-cpl-uuid-'))
+      tempPaths.push(cwd)
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { target_id: `cpl_${VALID_UUID}` },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.error).toBeDefined()
+      expect(output.task_id).toBeUndefined()
+    })
+  })
+
+  describe('uppercase UUID canonicalization', () => {
+    it('accepts uppercase UUID and canonicalizes to lowercase in argv', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-upper-uuid-'))
+      tempPaths.push(cwd)
+
+      const { binDir, configDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+      process.env.COPILOT_CONFIG_DIR = configDir
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const UPPER_UUID = VALID_UUID.toUpperCase()
+      const raw = await tool.execute(
+        { target_id: UPPER_UUID },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
+      expect(output.error).toBeUndefined()
+
+      const { getTask } = await import('../src/runtime/task-registry')
+      const task = getTask(output.task_id as string)
+      // argv should contain the lowercase canonical form
+      const resumeArg = task?.args?.find((a) => a.startsWith('--resume='))
+      expect(resumeArg).toBe(`--resume=${VALID_UUID}`)
     })
   })
 
@@ -360,7 +441,7 @@ exit 1
       const tool = createResumeTool({ client, directory: cwd })
 
       const raw = await tool.execute(
-        { targetId: VALID_UUID },
+        { target_id: VALID_UUID },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
@@ -371,6 +452,60 @@ exit 1
       const { getTask } = await import('../src/runtime/task-registry')
       const resumeTask = getTask(output.task_id as string)
       expect(resumeTask?.args).toBeDefined()
+      const args = resumeTask?.args ?? []
+      const addDirIdx = args.indexOf('--add-dir')
+      expect(addDirIdx).toBeGreaterThanOrEqual(0)
+      expect(args[addDirIdx + 1]).toBe(cwd)
+    })
+
+    it('reuses addDirs from a known task when caller passes empty addDirs: []', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-empty-adddir-'))
+      tempPaths.push(cwd)
+
+      const { binDir, configDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+      process.env.COPILOT_CONFIG_DIR = configDir
+
+      const { createTask } = await import('../src/runtime/task-registry')
+      const { spawnCopilot } = await import('../src/runtime/subprocess')
+
+      const fakeSpawn = spawnCopilot(
+        [
+          '-p',
+          'Return JSONL',
+          '--output-format',
+          'json',
+          '-s',
+          '--allow-all-tools',
+          '--no-ask-user',
+        ],
+        { cwd },
+      )
+      const knownTask = createTask({
+        ...fakeSpawn,
+        parentSessionID: 'session-empty-adddir',
+        startedAt: Date.now(),
+        args: ['-p', 'Return JSONL'],
+        cwd,
+        origin: 'spawn',
+        addDirs: [cwd],
+      })
+      knownTask.copilotSessionId = VALID_UUID
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { target_id: VALID_UUID, add_dir: [] },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
+      expect(output.error).toBeUndefined()
+
+      const { getTask } = await import('../src/runtime/task-registry')
+      const resumeTask = getTask(output.task_id as string)
       const args = resumeTask?.args ?? []
       const addDirIdx = args.indexOf('--add-dir')
       expect(addDirIdx).toBeGreaterThanOrEqual(0)
@@ -387,7 +522,7 @@ exit 1
       const tool = createResumeTool({ client, directory: cwd })
 
       const raw = await tool.execute(
-        { targetId: '../../etc/passwd' },
+        { target_id: '../../etc/passwd' },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
@@ -405,7 +540,7 @@ exit 1
       const tool = createResumeTool({ client, directory: cwd })
 
       const raw = await tool.execute(
-        { targetId: 'a'.repeat(200) },
+        { target_id: 'a'.repeat(200) },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
@@ -429,8 +564,8 @@ exit 1
 
       const raw = await tool.execute(
         {
-          targetId: VALID_UUID,
-          addDirs: ['--allow-tool=shell(*)'],
+          target_id: VALID_UUID,
+          add_dir: ['--allow-tool=shell(*)'],
         },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
@@ -454,7 +589,7 @@ exit 1
 
       const raw = await tool.execute(
         {
-          targetId: VALID_UUID,
+          target_id: VALID_UUID,
           cwd: '/etc',
         },
         makeToolContext({ directory: cwd, worktree: cwd }),
@@ -478,7 +613,7 @@ exit 1
       const tool = createResumeTool({ client, directory: cwd })
 
       const raw = await tool.execute(
-        { targetId: 'no-match-name' },
+        { target_id: 'no-match-name' },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
@@ -500,7 +635,7 @@ exit 1
       const tool = createResumeTool({ client, directory: cwd })
 
       const raw = await tool.execute(
-        { targetId: 'my-session-name' },
+        { target_id: 'my-session-name' },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
@@ -509,7 +644,7 @@ exit 1
       expect(output.error).toBeUndefined()
     })
 
-    it('returns task_id promptly for a long-running name target without blocking', async () => {
+    it('returns a running task for a long-running name target', async () => {
       const cwd = mkdtempSync(join(tmpdir(), 'resume-name-slow-'))
       tempPaths.push(cwd)
 
@@ -519,17 +654,18 @@ exit 1
       const client = makeMockClient()
       const tool = createResumeTool({ client, directory: cwd })
 
-      const before = Date.now()
       const raw = await tool.execute(
-        { targetId: 'long-running-session' },
+        { target_id: 'long-running-session' },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
-      const elapsed = Date.now() - before
 
       const output = expectObject(raw)
       expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
       expect(output.error).toBeUndefined()
-      expect(elapsed).toBeLessThan(900)
+
+      const { getTask } = await import('../src/runtime/task-registry')
+      const task = getTask(output.task_id as string)
+      expect(task?.status).toBe('running')
     })
   })
 
@@ -546,7 +682,7 @@ exit 1
       const tool = createResumeTool({ client, directory: cwd, pidFilePath })
 
       const raw = await tool.execute(
-        { targetId: 'long-running-session' },
+        { target_id: 'long-running-session' },
         makeToolContext({ directory: cwd, worktree: cwd }),
       )
 
@@ -587,14 +723,14 @@ describe('plugin tool catalog with copilot_resume', () => {
     ])
   })
 
-  it('schema-walk covers copilot_resume targetId and addDirs args', async () => {
+  it('schema-walk covers copilot_resume target_id and add_dir args', async () => {
     const input = makePluginInput(process.cwd())
     const result = await plugin(input)
     const tools = result.tool as NonNullable<typeof result.tool>
 
     const cases: Array<{ tool: keyof typeof tools; arg: string }> = [
-      { tool: 'copilot_resume', arg: 'targetId' },
-      { tool: 'copilot_resume', arg: 'addDirs' },
+      { tool: 'copilot_resume', arg: 'target_id' },
+      { tool: 'copilot_resume', arg: 'add_dir' },
     ]
 
     for (const { tool: toolId, arg } of cases) {
@@ -607,5 +743,351 @@ describe('plugin tool catalog with copilot_resume', () => {
       expect(typeof emitted.description).toBe('string')
       expect((emitted.description as string).length).toBeGreaterThan(5)
     }
+  })
+})
+
+describe('name-target fast-success pipeline regression', () => {
+  it('copilot_output reaches completed envelope with origin: resume and copilot_session_id after name-target resume', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-pipeline-'))
+    tempPaths.push(cwd)
+
+    const { binDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    // Use a name target that the fake binary handles with a successful result
+    const raw = await tool.execute(
+      { target_id: 'my-session-name' },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const output = expectObject(raw)
+    expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
+    expect(output.error).toBeUndefined()
+
+    const taskId = output.task_id as string
+
+    // Wait for completion via copilot_output with block:true
+    const { createOutputTool } = await import('../src/tools/output')
+    const outputTool = createOutputTool()
+
+    const outputRaw = await outputTool.execute(
+      { task_id: taskId, block: true, timeout_ms: 5000 },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const envelope = expectObject(outputRaw)
+    expect(envelope.task_id).toBe(taskId)
+    expect(envelope.status).toBe('complete')
+    expect(envelope.origin).toBe('resume')
+    // copilot_session_id is populated from the result JSONL event
+    expect(typeof envelope.copilot_session_id).toBe('string')
+    expect((envelope.copilot_session_id as string).length).toBeGreaterThan(0)
+  })
+})
+
+describe('concurrency cap', () => {
+  it('returns structured error when 10 tasks are already running, without spawning', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-cap-'))
+    tempPaths.push(cwd)
+
+    const { binDir, configDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    // Manually register 10 fake running tasks in the registry
+    const { createTask, cleanupAll: _cleanup } = await import(
+      '../src/runtime/task-registry'
+    )
+    const { spawnCopilot } = await import('../src/runtime/subprocess')
+
+    const fakeTasks: Array<{ taskId: string }> = []
+    for (let i = 0; i < 10; i++) {
+      // Spawn a real long-running process so status stays 'running'
+      const longBinDir = mkdtempSync(join(tmpdir(), 'resume-cap-bin-'))
+      tempPaths.push(longBinDir)
+      const longBin = join(longBinDir, 'copilot')
+      writeFileSync(longBin, `#!/usr/bin/env bash\nsleep 30\n`)
+      chmodSync(longBin, 0o755)
+      const savedPath = process.env.PATH
+      process.env.PATH = `${longBinDir}:${savedPath ?? ''}`
+      const spawnResult = spawnCopilot(
+        ['--output-format', 'json', '-s', '--allow-all-tools', '--no-ask-user'],
+        { cwd },
+      )
+      process.env.PATH = savedPath
+      const task = createTask(
+        {
+          ...spawnResult,
+          parentSessionID: 'cap-session',
+          startedAt: Date.now(),
+          args: [],
+          cwd,
+          origin: 'spawn',
+        },
+        spawnResult.taskId,
+      )
+      fakeTasks.push(task)
+    }
+
+    try {
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { target_id: VALID_UUID, config_dir: configDir },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const result = expectObject(raw)
+      expect(result.error).toMatch(/[Cc]oncurren/)
+      expect(result.task_id).toBeUndefined()
+    } finally {
+      // Kill the fake sleeping processes
+      for (const t of fakeTasks) {
+        const { getAllTasks } = await import('../src/runtime/task-registry')
+        const task = getAllTasks().find((x) => x.taskId === t.taskId)
+        task?.abortController.abort()
+      }
+    }
+  })
+})
+
+describe('UUID preflight filesystem errors', () => {
+  it('returns structured error on ENOTDIR instead of rejecting', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-enotdir-'))
+    tempPaths.push(cwd)
+
+    // Create a configDir where session-state/<uuid> is a file (not a dir)
+    // so stat of session.db raises ENOTDIR
+    const configDir = mkdtempSync(join(tmpdir(), 'resume-enotdir-config-'))
+    tempPaths.push(configDir)
+    const sessionStateDir = join(configDir, 'session-state')
+    mkdirSync(sessionStateDir, { recursive: true })
+    writeFileSync(join(sessionStateDir, VALID_UUID), '') // file, not dir
+
+    const { binDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    const raw = await tool.execute(
+      { target_id: VALID_UUID, config_dir: configDir },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const result = expectObject(raw)
+    expect(result.error).toBeDefined()
+    expect(typeof result.error).toBe('string')
+    expect(result.task_id).toBeUndefined()
+  })
+})
+
+describe('configDir env propagation', () => {
+  it('passes COPILOT_CONFIG_DIR to the spawned process matching the preflight configDir', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-configdir-'))
+    tempPaths.push(cwd)
+
+    // Build a fake binary that writes its env to a temp file
+    const envCapturePath = join(cwd, 'captured-env.json')
+    const binDir = mkdtempSync(join(tmpdir(), 'resume-configdir-bin-'))
+    tempPaths.push(binDir)
+
+    const configDir = mkdtempSync(join(tmpdir(), 'resume-configdir-config-'))
+    tempPaths.push(configDir)
+    const sessionStateDir = join(configDir, 'session-state', VALID_UUID)
+    mkdirSync(sessionStateDir, { recursive: true })
+    writeFileSync(join(sessionStateDir, 'session.db'), '')
+
+    const copilotPath = join(binDir, 'copilot')
+    writeFileSync(
+      copilotPath,
+      `#!/usr/bin/env bash
+echo "{\\"COPILOT_CONFIG_DIR\\": \\"$COPILOT_CONFIG_DIR\\"}" > ${envCapturePath}
+printf '%s\\n' '{"type":"result","sessionId":"${VALID_UUID}","exitCode":0,"usage":{}}'
+exit 0
+`,
+    )
+    chmodSync(copilotPath, 0o755)
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    const raw = await tool.execute(
+      { target_id: VALID_UUID, config_dir: configDir },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const result = expectObject(raw)
+    expect(result.task_id).toBeDefined()
+
+    // Wait for process to finish
+    const { createOutputTool } = await import('../src/tools/output')
+    const outputTool = createOutputTool()
+    await outputTool.execute(
+      { task_id: result.task_id as string, block: true, timeout_ms: 5000 },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const captured = JSON.parse(readFileSync(envCapturePath, 'utf8')) as Record<
+      string,
+      string
+    >
+    expect(captured.COPILOT_CONFIG_DIR).toBe(configDir)
+  })
+})
+
+describe('symlink escape containment', () => {
+  it('rejects cwd that is a symlink pointing outside allowed roots', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-symlink-'))
+    tempPaths.push(cwd)
+    const outside = mkdtempSync(join(tmpdir(), 'resume-symlink-outside-'))
+    tempPaths.push(outside)
+
+    // Create a symlink inside cwd pointing to outside
+    const { symlinkSync } = await import('node:fs')
+    const linkPath = join(cwd, 'escape-link')
+    symlinkSync(outside, linkPath)
+
+    const { binDir, configDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    const raw = await tool.execute(
+      { target_id: VALID_UUID, config_dir: configDir, cwd: linkPath },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const result = expectObject(raw)
+    expect(result.error).toBeDefined()
+    expect(result.task_id).toBeUndefined()
+  })
+
+  it('rejects add_dir that is a symlink pointing outside allowed roots', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-symlink-adddir-'))
+    tempPaths.push(cwd)
+    const outside = mkdtempSync(
+      join(tmpdir(), 'resume-symlink-adddir-outside-'),
+    )
+    tempPaths.push(outside)
+
+    const { symlinkSync } = await import('node:fs')
+    const linkPath = join(cwd, 'escape-link')
+    symlinkSync(outside, linkPath)
+
+    const { binDir, configDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    const raw = await tool.execute(
+      { target_id: VALID_UUID, config_dir: configDir, add_dir: [linkPath] },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const result = expectObject(raw)
+    expect(result.error).toBeDefined()
+    expect(result.task_id).toBeUndefined()
+  })
+})
+
+describe('snake_case public arg names', () => {
+  it('accepts target_id (snake_case) as the resume target', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-snake-'))
+    tempPaths.push(cwd)
+
+    const { binDir, configDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    const raw = await tool.execute(
+      { target_id: VALID_UUID, config_dir: configDir },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const result = expectObject(raw)
+    expect(result.task_id).toBeDefined()
+    expect(result.error).toBeUndefined()
+  })
+
+  it('tool schema exposes target_id, add_dir, config_dir (not camelCase)', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-schema-snake-'))
+    tempPaths.push(cwd)
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+    const shape = tool.args as Record<string, unknown>
+
+    expect(shape.target_id).toBeDefined()
+    expect(shape.add_dir).toBeDefined()
+    expect(shape.config_dir).toBeDefined()
+    // Old camelCase names must not exist
+    expect(shape.targetId).toBeUndefined()
+    expect(shape.addDirs).toBeUndefined()
+    expect(shape.configDir).toBeUndefined()
+  })
+})
+
+describe('inherited addDirs from known task bypass containment', () => {
+  it('reuses captured addDirs from a known task even when they are outside the primary directory', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-inherited-adddir-'))
+    tempPaths.push(cwd)
+    // A second repo dir outside cwd — simulates multi-repo scenario
+    const secondRepo = mkdtempSync(join(tmpdir(), 'resume-second-repo-'))
+    tempPaths.push(secondRepo)
+
+    const { binDir, configDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    // Register a prior task with copilotSessionId = VALID_UUID and addDirs = [secondRepo]
+    const { createTask } = await import('../src/runtime/task-registry')
+    const { spawnCopilot } = await import('../src/runtime/subprocess')
+
+    // Spawn a dummy process that exits immediately
+    const dummyBinDir = mkdtempSync(join(tmpdir(), 'resume-dummy-bin-'))
+    tempPaths.push(dummyBinDir)
+    const dummyBin = join(dummyBinDir, 'copilot')
+    writeFileSync(dummyBin, `#!/usr/bin/env bash\nexit 0\n`)
+    chmodSync(dummyBin, 0o755)
+    const savedPath = process.env.PATH
+    process.env.PATH = `${dummyBinDir}:${savedPath ?? ''}`
+    const spawnResult = spawnCopilot(['--output-format', 'json'], { cwd })
+    process.env.PATH = savedPath
+
+    const priorTask = createTask(
+      {
+        ...spawnResult,
+        parentSessionID: 'inherited-session',
+        startedAt: Date.now(),
+        args: [],
+        cwd,
+        origin: 'spawn',
+        addDirs: [secondRepo],
+      },
+      spawnResult.taskId,
+    )
+    // Manually set copilotSessionId so the lookup matches
+    priorTask.copilotSessionId = VALID_UUID
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    const raw = await tool.execute(
+      { target_id: VALID_UUID, config_dir: configDir },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const result = expectObject(raw)
+    // Should succeed — inherited addDirs bypass explicit containment check
+    expect(result.task_id).toBeDefined()
+    expect(result.error).toBeUndefined()
   })
 })

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -14,6 +14,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -988,6 +989,50 @@ describe('symlink escape containment', () => {
 
     const raw = await tool.execute(
       { target_id: VALID_UUID, config_dir: configDir, add_dir: [linkPath] },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const result = expectObject(raw)
+    expect(result.error).toBeDefined()
+    expect(result.task_id).toBeUndefined()
+  })
+
+  it('returns structured error (not throw) when cwd is a symlink loop (ELOOP)', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-eloop-cwd-'))
+    tempPaths.push(cwd)
+    const { binDir, configDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    const loopLink = join(cwd, 'loop')
+    symlinkSync(loopLink, loopLink)
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    const raw = await tool.execute(
+      { target_id: 'my-session', config_dir: configDir, cwd: loopLink },
+      makeToolContext({ directory: cwd, worktree: cwd }),
+    )
+
+    const result = expectObject(raw)
+    expect(result.error).toBeDefined()
+    expect(result.task_id).toBeUndefined()
+  })
+
+  it('returns structured error (not throw) when add_dir is a symlink loop (ELOOP)', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'resume-eloop-adddir-'))
+    tempPaths.push(cwd)
+    const { binDir, configDir } = makeFakeResumeBin()
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+    const loopLink = join(cwd, 'loop')
+    symlinkSync(loopLink, loopLink)
+
+    const client = makeMockClient()
+    const tool = createResumeTool({ client, directory: cwd })
+
+    const raw = await tool.execute(
+      { target_id: 'my-session', config_dir: configDir, add_dir: [loopLink] },
       makeToolContext({ directory: cwd, worktree: cwd }),
     )
 

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -1,0 +1,611 @@
+/**
+ * Tests for the copilot_resume tool.
+ *
+ * Covers: catalog registration, argv assembly, UUID preflight, known-task
+ * addDirs reuse, validation errors, CLI no-match stderr normalization,
+ * pidFilePath orphan tracking, and non-blocking behavior for name targets.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import type { PluginInput } from '@opencode-ai/plugin'
+import type { ToolContext } from '@opencode-ai/plugin/tool'
+import plugin from '../src/index'
+import { _resetPluginSingleton } from '../src/runtime/plugin-singleton'
+import { cleanupAll } from '../src/runtime/task-registry'
+import { createResumeTool } from '../src/tools/resume'
+
+type ToolResultObject = Record<string, unknown>
+
+const tempPaths: string[] = []
+const originalPath = process.env.PATH
+const originalHome = process.env.HOME
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME
+const originalSessionId = process.env.OPENCODE_SESSION_ID
+const originalCopilotConfigDir = process.env.COPILOT_CONFIG_DIR
+
+const VALID_UUID = '123e4567-e89b-12d3-a456-426614174000'
+
+beforeEach(() => {
+  _resetPluginSingleton()
+
+  const homeDir = mkdtempSync(join(tmpdir(), 'resume-test-home-'))
+  const xdgCacheHome = mkdtempSync(join(tmpdir(), 'resume-test-cache-'))
+  tempPaths.push(homeDir, xdgCacheHome)
+  process.env.HOME = homeDir
+  process.env.XDG_CACHE_HOME = xdgCacheHome
+  process.env.OPENCODE_SESSION_ID = 'resume-test-session'
+  delete process.env.COPILOT_CONFIG_DIR
+})
+
+afterEach(async () => {
+  process.emit('beforeExit', 0)
+  await delay(0)
+  await cleanupAll()
+
+  process.env.PATH = originalPath
+  process.env.HOME = originalHome
+  process.env.XDG_CACHE_HOME = originalXdgCacheHome
+  process.env.OPENCODE_SESSION_ID = originalSessionId
+  if (originalCopilotConfigDir === undefined) {
+    delete process.env.COPILOT_CONFIG_DIR
+  } else {
+    process.env.COPILOT_CONFIG_DIR = originalCopilotConfigDir
+  }
+
+  for (const p of tempPaths.splice(0)) {
+    rmSync(p, { force: true, recursive: true })
+  }
+})
+
+function makeMockClient(): PluginInput['client'] {
+  return {
+    session: {
+      prompt: async () => {},
+    },
+    tui: {
+      showToast: () => {},
+    },
+    app: {
+      log: async () => {},
+    },
+  } as unknown as PluginInput['client']
+}
+
+function makePluginInput(directory: string): PluginInput {
+  return {
+    client: makeMockClient(),
+    project: {
+      id: 'project-resume',
+      name: 'project-resume',
+      root: directory,
+      worktree: directory,
+      time: { created: Date.now(), updated: Date.now() },
+    } as unknown as PluginInput['project'],
+    directory,
+    worktree: directory,
+    experimental_workspace: { register: () => {} },
+    serverUrl: new URL('http://localhost:3000'),
+    $: {} as PluginInput['$'],
+  }
+}
+
+function makeToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    sessionID: 'session-resume',
+    messageID: 'message-resume',
+    agent: 'default',
+    directory: process.cwd(),
+    worktree: process.cwd(),
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: (() => {
+      throw new Error('ask should not be called in resume tests')
+    }) as ToolContext['ask'],
+    ...overrides,
+  }
+}
+
+function expectObject(value: unknown): ToolResultObject {
+  expect(typeof value).toBe('string')
+  return JSON.parse(value as string) as ToolResultObject
+}
+
+function makeFakeResumeBin(configDir?: string): {
+  binDir: string
+  configDir: string
+} {
+  const binDir = mkdtempSync(join(tmpdir(), 'resume-test-bin-'))
+  const resolvedConfigDir =
+    configDir ?? mkdtempSync(join(tmpdir(), 'resume-test-config-'))
+  tempPaths.push(binDir, resolvedConfigDir)
+
+  const sessionStateDir = join(resolvedConfigDir, 'session-state', VALID_UUID)
+  mkdirSync(sessionStateDir, { recursive: true })
+  writeFileSync(join(sessionStateDir, 'session.db'), '')
+
+  const copilotPath = join(binDir, 'copilot')
+  writeFileSync(
+    copilotPath,
+    `#!/usr/bin/env bash
+resume_id=""
+add_dirs=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --resume=*)
+      resume_id="\${1#--resume=}"
+      ;;
+    --add-dir)
+      shift
+      add_dirs+=("$1")
+      ;;
+    --add-dir=*)
+      add_dirs+=("\${1#--add-dir=}")
+      ;;
+  esac
+  shift
+done
+
+case "$resume_id" in
+  "no-match-name")
+    echo "Error: No session, task, or name matched 'no-match-name'" >&2
+    exit 1
+    ;;
+  "${VALID_UUID}")
+    if [ "\${#add_dirs[@]}" -gt 0 ]; then
+      printf '%s\\n' '{"type":"add-dirs","count":"'"\${#add_dirs[@]}"'"}'
+    fi
+    printf '%s\\n' '{"type":"assistant.message","data":{"messageId":"msg-resume","content":"resumed","toolRequests":[]}}'
+    printf '%s\\n' '{"type":"result","sessionId":"${VALID_UUID}","exitCode":0,"usage":{}}'
+    exit 0
+    ;;
+  *)
+    printf '%s\\n' '{"type":"assistant.message","data":{"messageId":"msg-default","content":"default","toolRequests":[]}}'
+    printf '%s\\n' '{"type":"result","sessionId":"session-default","exitCode":0,"usage":{}}'
+    exit 0
+    ;;
+esac
+`,
+  )
+  chmodSync(copilotPath, 0o755)
+
+  return { binDir, configDir: resolvedConfigDir }
+}
+
+function makeLongRunningResumeBin(sleepMs: number): { binDir: string } {
+  const binDir = mkdtempSync(join(tmpdir(), 'resume-test-slow-bin-'))
+  tempPaths.push(binDir)
+
+  const copilotPath = join(binDir, 'copilot')
+  const sleepSecs = (sleepMs / 1000).toFixed(3)
+  writeFileSync(
+    copilotPath,
+    `#!/usr/bin/env bash
+sleep ${sleepSecs}
+printf '%s\\n' '{"type":"assistant.message","data":{"messageId":"msg-slow","content":"slow","toolRequests":[]}}'
+printf '%s\\n' '{"type":"result","sessionId":"session-slow","exitCode":0,"usage":{}}'
+exit 0
+`,
+  )
+  chmodSync(copilotPath, 0o755)
+
+  return { binDir }
+}
+
+describe('copilot_resume tool', () => {
+  describe('catalog registration', () => {
+    it('registers copilot_resume as the 4th tool (catalog grows 3 → 4)', async () => {
+      const input = makePluginInput(process.cwd())
+      const result = await plugin(input)
+
+      expect(Object.keys(result.tool ?? {}).sort()).toEqual([
+        'copilot_cancel',
+        'copilot_delegate',
+        'copilot_output',
+        'copilot_resume',
+      ])
+    })
+
+    it('copilot_resume args carry normalizeToolArgSchemas overrides', async () => {
+      const input = makePluginInput(process.cwd())
+      const result = await plugin(input)
+      const tools = result.tool as NonNullable<typeof result.tool>
+
+      const resumeArgs = tools.copilot_resume.args as Record<string, unknown>
+      const targetIdSchema = resumeArgs.targetId
+      const override = (
+        targetIdSchema as { _zod: { toJSONSchema?: () => unknown } }
+      )._zod.toJSONSchema
+
+      expect(typeof override).toBe('function')
+      const emitted = override?.() as Record<string, unknown>
+      expect(typeof emitted.description).toBe('string')
+      expect((emitted.description as string).length).toBeGreaterThan(10)
+    })
+  })
+
+  describe('UUID target with local session present', () => {
+    it('spawns copilot --resume=<uuid> and returns a cpl_ task_id', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-uuid-happy-'))
+      tempPaths.push(cwd)
+
+      const { binDir, configDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+      process.env.COPILOT_CONFIG_DIR = configDir
+
+      const client = makeMockClient()
+      const tool = createResumeTool({
+        client,
+        directory: cwd,
+      })
+
+      const raw = await tool.execute(
+        { targetId: VALID_UUID },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
+      expect(output.error).toBeUndefined()
+    })
+
+    it('created task has origin: resume', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-origin-'))
+      tempPaths.push(cwd)
+
+      const { binDir, configDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+      process.env.COPILOT_CONFIG_DIR = configDir
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { targetId: VALID_UUID },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const { task_id: taskId } = expectObject(raw)
+      expect(typeof taskId).toBe('string')
+
+      const { getTask } = await import('../src/runtime/task-registry')
+      const task = getTask(taskId as string)
+      expect(task?.origin).toBe('resume')
+    })
+  })
+
+  describe('UUID target with no local session', () => {
+    it('returns structured error without spawning when session.db is absent', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-no-session-'))
+      const emptyConfigDir = mkdtempSync(join(tmpdir(), 'resume-empty-config-'))
+      tempPaths.push(cwd, emptyConfigDir)
+
+      const binDir = mkdtempSync(join(tmpdir(), 'resume-no-session-bin-'))
+      tempPaths.push(binDir)
+      const copilotPath = join(binDir, 'copilot')
+      writeFileSync(
+        copilotPath,
+        `#!/usr/bin/env bash
+echo "SHOULD NOT SPAWN" >&2
+exit 1
+`,
+      )
+      chmodSync(copilotPath, 0o755)
+
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+      process.env.COPILOT_CONFIG_DIR = emptyConfigDir
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { targetId: VALID_UUID },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.error).toBe(`No local session found for UUID ${VALID_UUID}`)
+      expect(output.task_id).toBeUndefined()
+    })
+  })
+
+  describe('known plugin task target reuses captured addDirs', () => {
+    it('reuses addDirs from a known task when caller omits addDirs', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-known-task-'))
+      tempPaths.push(cwd)
+
+      const { binDir, configDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+      process.env.COPILOT_CONFIG_DIR = configDir
+
+      const { createTask } = await import('../src/runtime/task-registry')
+      const { spawnCopilot } = await import('../src/runtime/subprocess')
+
+      const fakeSpawn = spawnCopilot(
+        [
+          '-p',
+          'Return JSONL',
+          '--output-format',
+          'json',
+          '-s',
+          '--allow-all-tools',
+          '--no-ask-user',
+        ],
+        { cwd },
+      )
+      const knownTask = createTask({
+        ...fakeSpawn,
+        parentSessionID: 'session-known',
+        startedAt: Date.now(),
+        args: ['-p', 'Return JSONL'],
+        cwd,
+        origin: 'spawn',
+        addDirs: [cwd],
+      })
+      knownTask.copilotSessionId = VALID_UUID
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { targetId: VALID_UUID },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
+      expect(output.error).toBeUndefined()
+
+      const { getTask } = await import('../src/runtime/task-registry')
+      const resumeTask = getTask(output.task_id as string)
+      expect(resumeTask?.args).toBeDefined()
+      const args = resumeTask?.args ?? []
+      const addDirIdx = args.indexOf('--add-dir')
+      expect(addDirIdx).toBeGreaterThanOrEqual(0)
+      expect(args[addDirIdx + 1]).toBe(cwd)
+    })
+  })
+
+  describe('invalid target ID', () => {
+    it('returns validation error for path-traversal-shaped target', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-invalid-target-'))
+      tempPaths.push(cwd)
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { targetId: '../../etc/passwd' },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.error).toBeDefined()
+      expect(typeof output.error).toBe('string')
+      expect(output.task_id).toBeUndefined()
+    })
+
+    it('returns validation error for overlong target ID', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-overlong-'))
+      tempPaths.push(cwd)
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { targetId: 'a'.repeat(200) },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.error).toBeDefined()
+      expect(output.task_id).toBeUndefined()
+    })
+  })
+
+  describe('invalid addDirs and cwd validation', () => {
+    it('returns error for argv-injection-shaped addDirs without spawning', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-bad-adddir-'))
+      tempPaths.push(cwd)
+
+      const { binDir, configDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+      process.env.COPILOT_CONFIG_DIR = configDir
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        {
+          targetId: VALID_UUID,
+          addDirs: ['--allow-tool=shell(*)'],
+        },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.error).toBeDefined()
+      expect(typeof output.error).toBe('string')
+      expect(output.task_id).toBeUndefined()
+    })
+
+    it('returns error for cwd outside allowed roots without spawning', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-bad-cwd-'))
+      tempPaths.push(cwd)
+
+      const { binDir, configDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+      process.env.COPILOT_CONFIG_DIR = configDir
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        {
+          targetId: VALID_UUID,
+          cwd: '/etc',
+        },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.error).toBeDefined()
+      expect(output.task_id).toBeUndefined()
+    })
+  })
+
+  describe('CLI no-match stderr normalization', () => {
+    it('normalizes no-match stderr to Session not found error', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-no-match-'))
+      tempPaths.push(cwd)
+
+      const { binDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { targetId: 'no-match-name' },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.error).toBe("Session not found: 'no-match-name'")
+      expect(output.task_id).toBeUndefined()
+    })
+  })
+
+  describe('name target (non-UUID)', () => {
+    it('spawns without UUID preflight for a valid name target', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-name-target-'))
+      tempPaths.push(cwd)
+
+      const { binDir } = makeFakeResumeBin()
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const raw = await tool.execute(
+        { targetId: 'my-session-name' },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const output = expectObject(raw)
+      expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
+      expect(output.error).toBeUndefined()
+    })
+
+    it('returns task_id promptly for a long-running name target without blocking', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-name-slow-'))
+      tempPaths.push(cwd)
+
+      const { binDir } = makeLongRunningResumeBin(1000)
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd })
+
+      const before = Date.now()
+      const raw = await tool.execute(
+        { targetId: 'long-running-session' },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+      const elapsed = Date.now() - before
+
+      const output = expectObject(raw)
+      expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
+      expect(output.error).toBeUndefined()
+      expect(elapsed).toBeLessThan(900)
+    })
+  })
+
+  describe('pidFilePath orphan tracking', () => {
+    it('passes pidFilePath from tool options into the spawned task and writes the pid file', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'resume-pid-'))
+      tempPaths.push(cwd)
+
+      const { binDir } = makeLongRunningResumeBin(1000)
+      process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`
+
+      const pidFilePath = join(cwd, 'orphan.pid')
+      const client = makeMockClient()
+      const tool = createResumeTool({ client, directory: cwd, pidFilePath })
+
+      const raw = await tool.execute(
+        { targetId: 'long-running-session' },
+        makeToolContext({ directory: cwd, worktree: cwd }),
+      )
+
+      const { task_id: taskId } = expectObject(raw)
+      expect(typeof taskId).toBe('string')
+
+      const { getTask } = await import('../src/runtime/task-registry')
+      const task = getTask(taskId as string)
+      expect(task?.pid).toBeGreaterThan(0)
+
+      const deadline = Date.now() + 1000
+      while (!existsSync(pidFilePath) && Date.now() < deadline) {
+        await delay(20)
+      }
+
+      expect(existsSync(pidFilePath)).toBe(true)
+      const pidFileContent = readFileSync(pidFilePath, 'utf8').trim()
+      expect(
+        pidFileContent
+          .split('\n')
+          .some((line) => line.startsWith(`${task?.pid}\t`)),
+      ).toBe(true)
+    })
+  })
+})
+
+describe('plugin tool catalog with copilot_resume', () => {
+  it('lists exactly 4 tools after resume registration', async () => {
+    const input = makePluginInput(process.cwd())
+    const result = await plugin(input)
+
+    const toolNames = Object.keys(result.tool ?? {}).sort()
+    expect(toolNames).toEqual([
+      'copilot_cancel',
+      'copilot_delegate',
+      'copilot_output',
+      'copilot_resume',
+    ])
+  })
+
+  it('schema-walk covers copilot_resume targetId and addDirs args', async () => {
+    const input = makePluginInput(process.cwd())
+    const result = await plugin(input)
+    const tools = result.tool as NonNullable<typeof result.tool>
+
+    const cases: Array<{ tool: keyof typeof tools; arg: string }> = [
+      { tool: 'copilot_resume', arg: 'targetId' },
+      { tool: 'copilot_resume', arg: 'addDirs' },
+    ]
+
+    for (const { tool: toolId, arg } of cases) {
+      const schema = (tools[toolId].args as Record<string, unknown>)[arg]
+      const override = (schema as { _zod: { toJSONSchema?: () => unknown } })
+        ._zod.toJSONSchema
+      expect(typeof override).toBe('function')
+
+      const emitted = override?.() as Record<string, unknown>
+      expect(typeof emitted.description).toBe('string')
+      expect((emitted.description as string).length).toBeGreaterThan(5)
+    }
+  })
+})

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -203,7 +203,7 @@ function requireTools(result: Awaited<ReturnType<typeof plugin>>) {
 }
 
 describe('plugin tools', () => {
-  it('registers the three plugin tools', async () => {
+  it('registers the four plugin tools including copilot_resume', async () => {
     // Given a plugin input
     const input = makePluginInput(process.cwd())
 
@@ -215,6 +215,7 @@ describe('plugin tools', () => {
       'copilot_cancel',
       'copilot_delegate',
       'copilot_output',
+      'copilot_resume',
     ])
   })
 
@@ -246,6 +247,8 @@ describe('plugin tools', () => {
       { tool: 'copilot_output', arg: 'task_id' },
       { tool: 'copilot_output', arg: 'block' },
       { tool: 'copilot_cancel', arg: 'task_id' },
+      { tool: 'copilot_resume', arg: 'targetId' },
+      { tool: 'copilot_resume', arg: 'addDirs' },
     ]
 
     for (const { tool: toolId, arg } of cases) {
@@ -285,9 +288,8 @@ describe('plugin tools', () => {
     expect(output.task_id).toMatch(/^cpl_[0-9a-f-]+$/)
   })
 
-  it('surfaces copilot_session_id and origin on the output envelope after end-to-end completion (S2 Unit 1 pipeline regression)', async () => {
-    // This is the integration-style guard for the Unit 1 sync gap:
-    // assignCopilotSessionId() writes copilotSessionId on SpawnCopilotResult,
+  it('surfaces copilot_session_id and origin on the output envelope after end-to-end completion', async () => {
+    // Integration guard: assignCopilotSessionId() writes copilotSessionId on SpawnCopilotResult,
     // but the registry's TaskState is a separate object, populated up-front
     // via createTask({...spawnFields, ...}). The completion handler in
     // delegate.ts uses Object.assign to sync select fields back. If

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -247,8 +247,8 @@ describe('plugin tools', () => {
       { tool: 'copilot_output', arg: 'task_id' },
       { tool: 'copilot_output', arg: 'block' },
       { tool: 'copilot_cancel', arg: 'task_id' },
-      { tool: 'copilot_resume', arg: 'targetId' },
-      { tool: 'copilot_resume', arg: 'addDirs' },
+      { tool: 'copilot_resume', arg: 'target_id' },
+      { tool: 'copilot_resume', arg: 'add_dir' },
     ]
 
     for (const { tool: toolId, arg } of cases) {


### PR DESCRIPTION
## Summary

Adds `copilot_resume`, a fourth plugin tool for resuming prior Copilot CLI sessions by UUID, name, or prefix.

## Changes

- Register `copilot_resume` alongside delegate/output/cancel.
- Add continuity helpers for session UUID detection, config-dir resolution, local session preflight, and stderr normalization.
- Add validation for resume targets, `cwd`, and `add_dir` inputs, including argv-injection and realpath containment guards.
- Run resumed sessions through the same task registry, output envelope, cancellation path, PID ledger, and completion notification pipeline as delegated sessions.
- Reuse captured `addDirs` from known prior plugin tasks when resuming by captured `copilot_session_id`.
- Keep `copilot_connect` deferred; the tool catalog grows from 3 to 4, not 5.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test tests/resume.test.ts tests/continuity-validation.test.ts tests/continuity-checks.test.ts tests/tools.test.ts tests/index.test.ts`
- `bun test tests/continuity-validation.test.ts tests/continuity-checks.test.ts tests/resume.test.ts tests/tools.test.ts tests/notify.test.ts tests/index.test.ts`
- `bun test:unit`
- `bun run build`
