### PR TITLE
fix(runtime): skip stale pid registration

### DIFF
--- a/.changeset/quiet-plants-train.md
+++ b/.changeset/quiet-plants-train.md
@@ -1,0 +1,5 @@
+---
+"opencode-copilot-delegate": patch
+---
+
+Skip delayed orphan PID registration after a Copilot task has already reached a terminal state.

--- a/src/runtime/task-registry.ts
+++ b/src/runtime/task-registry.ts
@@ -47,6 +47,11 @@ export type CreateTaskInput = Omit<SpawnCopilotResult, 'taskId'> & {
 }
 
 const tasks = new Map<string, TaskState>()
+const TERMINAL_STATUSES = new Set<TaskState['status']>([
+  'complete',
+  'failed',
+  'cancelled',
+])
 
 export function createTask(
   input: CreateTaskInput,
@@ -65,6 +70,10 @@ export function createTask(
   if (task.pid > 0 && pidFilePath) {
     getPidIdentity(task.pid)
       .then((identity) => {
+        if (TERMINAL_STATUSES.has(task.status)) {
+          return
+        }
+
         if (identity) {
           appendPidEntry(
             pidFilePath,

--- a/tests/task-registry.test.ts
+++ b/tests/task-registry.test.ts
@@ -227,6 +227,45 @@ describe('task registry PID-file hooks', () => {
     expect(() => readFileSync(pidFilePath, 'utf-8')).toThrow()
   })
 
+  it('does not append to the PID file after a terminal transition wins the spawn race', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'task-registry-'))
+    tempPaths.push(dir)
+    const pidFilePath = join(dir, 'orphans.pids')
+
+    const child = Bun.spawn({ cmd: ['sleep', '30'] })
+    childHandles.push(child)
+    const abortController = new AbortController()
+
+    const task = createTask(
+      {
+        parentSessionID: 'session-fast-terminal',
+        pid: child.pid,
+        startedAt: Date.now(),
+        status: 'running',
+        args: ['-c', 'sleep 30'],
+        cwd: process.cwd(),
+        stdoutLineBuffer: '',
+        events: [],
+        child,
+        completionPromise: child.exited.then(() => undefined),
+        abortController,
+        pidFilePath,
+      },
+      undefined,
+    )
+
+    setStatus(task, 'complete', { pidFilePath })
+
+    const staleEntryAppeared = await waitUntil(
+      () =>
+        existsSync(pidFilePath) &&
+        readFileSync(pidFilePath, 'utf-8').includes(`${child.pid}\t`),
+      { timeoutMs: 300, intervalMs: 25 },
+    )
+
+    expect(staleEntryAppeared).toBe(false)
+  })
+
   it('skips PID-file work when pid <= 0', async () => {
     // Given a task with pid === 0 (sentinel for "no subprocess yet").
     // The createTask guard `task.pid > 0 && pidFilePath` must short-circuit


### PR DESCRIPTION
## Summary

- skip delayed orphan PID registration once a task has already reached a terminal state
- add a regression test for the race where `setStatus(..., 'complete')` wins before the async `getPidIdentity(...).then(...)` append runs
- add a patch changeset

## Why

`createTask()` records orphan-reaper PID entries after an async process identity lookup. A very fast Copilot subprocess can become terminal before that lookup resolves. In that ordering, `setStatus(...terminal...)` has already removed the PID entry, but the delayed append can write the completed task back into the orphan PID file.

That leaves stale orphan-reaper state for a task that is no longer running. Checking the current task status immediately before append keeps the existing running/cancelling behavior while avoiding terminal-task resurrection in the pid file.

## Validation

- `bun test tests/task-registry.test.ts tests/pid-file.test.ts`
- `bun run test:unit`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `npm pack --dry-run --json`

Note: local `bun test` / `bun run test:tui` on my macOS+Bun 1.3.14 environment hits a Bun SIGTRAP after visible TUI tests start; the touched runtime/unit suites above pass and cover this change.
