### PR TITLE
fix(fro-bot): stop persisting credentials on mention runs

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -193,6 +193,8 @@ jobs:
               || ''
             }}
           token: ${{ secrets.FRO_BOT_PAT }}
+          persist-credentials: >-
+            ${{ !contains(fromJSON('["pull_request", "issue_comment", "issues"]'), github.event_name) }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
Summary
- Stop persisting credentials on mention-driven runs.

Verification
- actionlint
- diff-check

Tracking
- fro-bot/agent#1598
